### PR TITLE
chore: ignore tsc-leaked .js files under src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 # Build output
 dist/
 *.tsbuildinfo
+# tsc occasionally leaves .js next to .ts sources when invoked with non-default outDir
+src/**/*.js
 
 # Test artifacts
 test-output/


### PR DESCRIPTION
## Summary

- When tsc is invoked with non-default outDir, `.js` output lands next to `.ts` sources instead of in `dist/`. Those files show up as untracked noise in `git status` across every branch.
- This repo never commits `.js` to `src/` (verified: `git ls-files '*.js'` returns empty).
- Add `src/**/*.js` to `.gitignore` so accidental tsc leakage at source paths is suppressed. `dist/` remains the canonical build-output location and is unaffected.

## Test plan

- [ ] `git ls-files '*.js'` still returns empty (no tracked files affected)
- [ ] `git status` on a branch with leaked `src/**/*.js` files now lists only intentional changes
- [ ] `dist/` still ignored as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)