### PR TITLE
feat(context): Region + ContextRegions store (PR-A of substrate refactor)

### DIFF
--- a/src/__tests__/ContextRegions.test.ts
+++ b/src/__tests__/ContextRegions.test.ts
@@ -1,0 +1,219 @@
+import { ContextRegions } from '../context/ContextRegions'
+import type { RegionInput } from '../context/Region'
+
+// Tiny test fixture builder; tests fill in only the fields they care about.
+function regionInput(overrides: Partial<RegionInput> = {}): RegionInput {
+  return {
+    target:    'system',
+    section:   'header',
+    intraTurn: 'turn-persistent',
+    interTurn: 'session-persistent',
+    stability: 'immutable',
+    content:   'hello',
+    format:    (c) => String(c),
+    ...overrides,
+  }
+}
+
+describe('ContextRegions — set / get / delete primitives', () => {
+  test('get on empty store returns undefined', () => {
+    const store = new ContextRegions(() => 0)
+    expect(store.get('missing')).toBeUndefined()
+  })
+
+  test('set then get returns the region with id and createdAt filled', () => {
+    const store = new ContextRegions(() => 42)
+    store.set('header:base', regionInput({ content: 'base prompt' }))
+    const r = store.get('header:base')
+    expect(r).toBeDefined()
+    expect(r!.id).toBe('header:base')
+    expect(r!.createdAt).toBe(42)
+    expect(r!.content).toBe('base prompt')
+  })
+
+  test('delete returns true when region existed', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    expect(store.delete('x')).toBe(true)
+  })
+
+  test('delete returns false when region did not exist', () => {
+    const store = new ContextRegions(() => 0)
+    expect(store.delete('nonexistent')).toBe(false)
+  })
+
+  test('get after delete returns undefined', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    store.delete('x')
+    expect(store.get('x')).toBeUndefined()
+  })
+})
+
+describe('ContextRegions — upsert preserves createdAt + epoch tracking', () => {
+  test('set on existing id keeps the original createdAt (sort-stable upsert)', () => {
+    let now = 10
+    const store = new ContextRegions(() => now)
+    store.set('x', regionInput({ content: 'v1' }))
+    now = 999
+    store.set('x', regionInput({ content: 'v2' }))
+    const r = store.get('x')
+    expect(r!.createdAt).toBe(10)
+    expect(r!.content).toBe('v2')
+  })
+
+  test('epoch starts at 0', () => {
+    const store = new ContextRegions(() => 0)
+    expect(store.getEpoch()).toBe(0)
+  })
+
+  test('set increments epoch', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    expect(store.getEpoch()).toBe(1)
+    store.set('y', regionInput())
+    expect(store.getEpoch()).toBe(2)
+  })
+
+  test('upsert (set on existing id) also increments epoch', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    expect(store.getEpoch()).toBe(1)
+    store.set('x', regionInput({ content: 'v2' }))
+    expect(store.getEpoch()).toBe(2)
+  })
+
+  test('delete of existing region increments epoch', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    const before = store.getEpoch()
+    store.delete('x')
+    expect(store.getEpoch()).toBe(before + 1)
+  })
+
+  test('delete of non-existent region does NOT increment epoch', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('x', regionInput())
+    const before = store.getEpoch()
+    store.delete('nonexistent')
+    expect(store.getEpoch()).toBe(before)
+  })
+})
+
+describe('ContextRegions — clock injection', () => {
+  test('set calls clock exactly once per new region', () => {
+    const clock = jest.fn(() => 7)
+    const store = new ContextRegions(clock)
+    store.set('a', regionInput())
+    store.set('b', regionInput())
+    expect(clock).toHaveBeenCalledTimes(2)
+  })
+
+  test('upsert (set on existing id) does NOT call clock — createdAt preserved', () => {
+    const clock = jest.fn(() => 7)
+    const store = new ContextRegions(clock)
+    store.set('a', regionInput())
+    clock.mockClear()
+    store.set('a', regionInput({ content: 'updated' }))
+    expect(clock).not.toHaveBeenCalled()
+  })
+
+  test('get does not call clock', () => {
+    const clock = jest.fn(() => 7)
+    const store = new ContextRegions(clock)
+    store.set('a', regionInput())
+    clock.mockClear()
+    store.get('a')
+    store.get('missing')
+    expect(clock).not.toHaveBeenCalled()
+  })
+
+  test('delete does not call clock', () => {
+    const clock = jest.fn(() => 7)
+    const store = new ContextRegions(clock)
+    store.set('a', regionInput())
+    clock.mockClear()
+    store.delete('a')
+    store.delete('missing')
+    expect(clock).not.toHaveBeenCalled()
+  })
+
+  test('sequential clock values are stamped in order — sort-stable createdAt', () => {
+    const values = [100, 200, 300]
+    let i = 0
+    const store = new ContextRegions(() => values[i++]!)
+    store.set('a', regionInput())
+    store.set('b', regionInput())
+    store.set('c', regionInput())
+    expect(store.get('a')!.createdAt).toBe(100)
+    expect(store.get('b')!.createdAt).toBe(200)
+    expect(store.get('c')!.createdAt).toBe(300)
+  })
+})
+
+describe('ContextRegions — snapshot / restore', () => {
+  test('snapshot of empty store captures epoch=0 and no regions', () => {
+    const store = new ContextRegions(() => 0)
+    const snap = store.snapshot()
+    expect(snap.epoch).toBe(0)
+    expect(snap.regions).toEqual([])
+  })
+
+  test('snapshot captures current epoch and all regions', () => {
+    const store = new ContextRegions(() => 50)
+    store.set('a', regionInput({ content: 'one' }))
+    store.set('b', regionInput({ content: 'two' }))
+    const snap = store.snapshot()
+    expect(snap.epoch).toBe(2)
+    expect(snap.regions).toHaveLength(2)
+    const ids = snap.regions.map(r => r.id).sort()
+    expect(ids).toEqual(['a', 'b'])
+  })
+
+  test('restore on fresh store reproduces regions and epoch', () => {
+    const src = new ContextRegions(() => 11)
+    src.set('a', regionInput({ content: 'one' }))
+    src.set('b', regionInput({ content: 'two' }))
+    src.delete('a')
+    const snap = src.snapshot()
+
+    const dst = new ContextRegions(() => 999)   // different clock — should not be called
+    dst.restore(snap)
+    expect(dst.getEpoch()).toBe(snap.epoch)
+    expect(dst.get('a')).toBeUndefined()
+    expect(dst.get('b')!.content).toBe('two')
+    expect(dst.get('b')!.createdAt).toBe(11)    // original createdAt preserved
+  })
+
+  test('restore replaces any existing regions (not a merge)', () => {
+    const dst = new ContextRegions(() => 0)
+    dst.set('old', regionInput({ content: 'should-be-cleared' }))
+
+    const src = new ContextRegions(() => 5)
+    src.set('new', regionInput({ content: 'survives' }))
+    dst.restore(src.snapshot())
+
+    expect(dst.get('old')).toBeUndefined()
+    expect(dst.get('new')!.content).toBe('survives')
+  })
+
+  test('snapshot is decoupled from source store (later mutation does not leak)', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('a', regionInput())
+    const snap = store.snapshot()
+    store.set('b', regionInput())
+    expect(snap.regions).toHaveLength(1)
+    expect(snap.epoch).toBe(1)
+  })
+
+  test('restore does not invoke clock', () => {
+    const src = new ContextRegions(() => 5)
+    src.set('a', regionInput())
+    const snap = src.snapshot()
+
+    const clock = jest.fn(() => 999)
+    const dst = new ContextRegions(clock)
+    dst.restore(snap)
+    expect(clock).not.toHaveBeenCalled()
+  })
+})

--- a/src/context/ContextRegions.ts
+++ b/src/context/ContextRegions.ts
@@ -1,0 +1,50 @@
+// Region store for the context substrate.
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §4.2
+
+import type { Region, RegionInput, RegionSnapshot } from './Region'
+
+export type Clock = () => number
+
+export class ContextRegions {
+  private readonly regions = new Map<string, Region>()
+  private epoch = 0
+
+  constructor(private readonly clock: Clock) {}
+
+  set(id: string, input: RegionInput): void {
+    const existing = this.regions.get(id)
+    const createdAt = existing?.createdAt ?? this.clock()
+    const region: Region = { id, createdAt, ...input }
+    this.regions.set(id, region)
+    this.epoch++
+  }
+
+  delete(id: string): boolean {
+    const existed = this.regions.delete(id)
+    if (existed) this.epoch++
+    return existed
+  }
+
+  get(id: string): Region | undefined {
+    return this.regions.get(id)
+  }
+
+  getEpoch(): number {
+    return this.epoch
+  }
+
+  snapshot(): RegionSnapshot {
+    return {
+      epoch:   this.epoch,
+      regions: [...this.regions.values()],
+    }
+  }
+
+  restore(snap: RegionSnapshot): void {
+    this.regions.clear()
+    for (const r of snap.regions) {
+      this.regions.set(r.id, r)
+    }
+    this.epoch = snap.epoch
+  }
+}

--- a/src/context/Region.ts
+++ b/src/context/Region.ts
@@ -1,0 +1,82 @@
+// Region type definitions for the context substrate.
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §4.1
+
+export type RegionTarget = 'system' | 'message' | 'tool'
+
+export type SystemSection =
+  | 'header'
+  | 'persistent-skills'
+  | 'tools-static'
+  | 'session-skills'
+  | 'state'
+  | 'tools-state'
+  | 'wm'
+  | 'footer'
+
+export type MessageSection =
+  | 'history'
+  | 'current-turn'
+  | 'scratchpad'
+
+export type ToolSection = 'default'
+
+export type RegionSection = SystemSection | MessageSection | ToolSection
+
+export type IntraTurnScope =
+  | 'turn-persistent'
+  | { kind: 'state-scoped'; state: string }
+  | { kind: 'tool-buffer'; remainingCalls: number }
+  | 'one-shot'
+
+export type InterTurnScope =
+  | 'session-persistent'
+  | 'turn-local'
+  | { kind: 'ttl'; deadline: number }
+  | 'summarize-on-overflow'
+  | 'promote-to-wm'
+
+export type RegionStability =
+  | 'immutable'
+  | 'session-stable'
+  | 'turn-stable'
+  | 'volatile'
+
+// Format functions return one of three shapes depending on target:
+//   target='system' → string (rendered into system prompt block)
+//   target='message' → Message or Message[] (folded into messages array)
+//   target='tool'   → ToolSchema (folded into tools array)
+// Concrete Message / ToolSchema types live elsewhere; Region itself stays
+// substrate-level and does not import them — the format function's caller
+// (assemble in PR-B) is responsible for typing the output correctly.
+export type RegionFormatOutput = string | object | ReadonlyArray<object>
+
+export interface Region {
+  readonly id:         string
+  readonly target:     RegionTarget
+  readonly section:    RegionSection
+
+  readonly ordinal?:   number
+  readonly createdAt:  number
+
+  readonly intraTurn:  IntraTurnScope
+  readonly interTurn:  InterTurnScope
+
+  readonly stability:       RegionStability
+  readonly cacheBreakpoint?: boolean
+
+  readonly content: unknown
+  readonly format:  (content: unknown) => RegionFormatOutput
+}
+
+// Input shape for ContextRegions.set — id and createdAt are filled by the
+// store (id from the caller's argument, createdAt from the injected clock).
+export type RegionInput = Omit<Region, 'id' | 'createdAt'>
+
+// Snapshot for checkpoint / restore. Format functions are not serializable;
+// the consumer (checkpoint loader) re-attaches them by region id or section.
+// PR-A keeps the snapshot opaque; PR-C will refine when restore semantics
+// concretize.
+export interface RegionSnapshot {
+  readonly epoch:   number
+  readonly regions: ReadonlyArray<Region>
+}


### PR DESCRIPTION
## Summary

First of **4 PRs** landing the Context Region Substrate spec
(`docs/superpowers/specs/2026-05-25-context-region-substrate-design.md`).

This PR is **pure greenfield** — three new files, zero consumers, no existing code touched. `ContextLayer` remains the production path until PR-C wires `AgentRuntime` to the new store. Low risk by construction.

## What's in

**`src/context/Region.ts`** (spec §4.1):
- `RegionTarget` / `SystemSection` / `MessageSection` / `ToolSection` union types
- `IntraTurnScope` / `InterTurnScope` discriminated unions (incl. `'promote-to-wm'`)
- `RegionStability` classification (`'immutable'` / `'session-stable'` / `'turn-stable'` / `'volatile'`)
- `Region` + `RegionInput` + `RegionSnapshot` interfaces

**`src/context/ContextRegions.ts`** (spec §4.2):
- `Map<id, Region>` store with three CRUD primitives — `set` / `delete` / `get`
- Constructor-injected `clock` (Phase-4 determinism friendly — IOPort.now feeds it)
- `set` is **upsert**; preserves the original `createdAt` on second set with the same id (no sort drift)
- `epoch` counter increments on every structural mutation (set on any id; successful delete)
- `snapshot()` returns a decoupled `RegionSnapshot` for checkpointing
- `restore(snap)` replaces (not merges); does **not** invoke the clock

**`src/__tests__/ContextRegions.test.ts`** — 22 tests, 4 describe blocks:
- CRUD primitives (5)
- Upsert + epoch tracking (6)
- Clock-injection contract (5)
- Snapshot / restore round-trip (6)

## What's NOT in (intentional — landing in later PRs)

- `assemble` pure function — **PR-B**
- AgentRuntime wiring / scratchpad split / boundary engines / replay fixture re-record — **PR-C**
- Trace event types (`region.added` / `region.removed` / `context.boundary.applied`) — **PR-D**
- Cache health (`usage.cache_read_tokens`) and adapter `cache_control` — **PR-D**
- `ContextLayer.ts` deletion — happens in PR-C once the migration completes

## TDD discipline

Followed Red-Green-Refactor for set/get/delete (Task #2), upsert + epoch (Task #3), and snapshot/restore (Task #5) — each test class verified RED first, then minimal implementation to GREEN. Clock-injection tests (Task #4) document invariants already satisfied by the simpler primitives' implementation; they passed immediately. Acknowledged as invariant lock-in rather than pure RED-first TDD.

## Test plan

- [x] 22 new tests in `src/__tests__/ContextRegions.test.ts` all pass
- [x] `npm run test:unit` — 30/30 untouched and green
- [x] `npm run test:e2e:deterministic` — 7/7 untouched and green
- [ ] Reviewer confirms PR-B can build on this surface without revisiting

## Spec sections covered

- §4.1 Region type — fully implemented
- §4.2 ContextRegions class — fully implemented (modulo internal helper `_allRegions` deferred to PR-B which is the only consumer)
- §11 invariants — items 2, 4, 10 directly tested; items 1, 3, 5–9 deferred to consumers (assemble, boundary engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)