### PR TITLE
feat(context): assemble pure function + SECTION_SCHEMA (PR-B of substrate refactor)

### DIFF
--- a/src/__tests__/ContextRegions.test.ts
+++ b/src/__tests__/ContextRegions.test.ts
@@ -217,3 +217,32 @@ describe('ContextRegions — snapshot / restore', () => {
     expect(clock).not.toHaveBeenCalled()
   })
 })
+
+describe('ContextRegions — _allRegions iteration', () => {
+  test('empty store iterates zero times', () => {
+    const store = new ContextRegions(() => 0)
+    expect([..._spread(store)]).toEqual([])
+  })
+
+  test('iterates all current regions (count + ids)', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('a', regionInput({ content: '1' }))
+    store.set('b', regionInput({ content: '2' }))
+    store.set('c', regionInput({ content: '3' }))
+    const ids = [..._spread(store)].map(r => r.id).sort()
+    expect(ids).toEqual(['a', 'b', 'c'])
+  })
+
+  test('does not include deleted regions', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('a', regionInput())
+    store.set('b', regionInput())
+    store.delete('a')
+    const ids = [..._spread(store)].map(r => r.id)
+    expect(ids).toEqual(['b'])
+  })
+})
+
+function _spread(store: ContextRegions): IterableIterator<import('../context/Region').Region> {
+  return store._allRegions()
+}

--- a/src/__tests__/assemble.test.ts
+++ b/src/__tests__/assemble.test.ts
@@ -1,0 +1,310 @@
+import { assemble } from '../context/assemble'
+import type { AssembleScope } from '../context/assemble'
+import { ContextRegions } from '../context/ContextRegions'
+import type { RegionInput } from '../context/Region'
+import type { Message } from '../types/common.js'
+import type { ToolSchema } from '../types/model.js'
+
+function defaultScope(overrides: Partial<AssembleScope> = {}): AssembleScope {
+  return {
+    currentState:  'default',
+    currentTurnId: 'turn-1',
+    currentEpoch:  0,
+    ...overrides,
+  }
+}
+
+function systemRegion(overrides: Partial<RegionInput> = {}): RegionInput {
+  return {
+    target:    'system',
+    section:   'header',
+    intraTurn: 'turn-persistent',
+    interTurn: 'session-persistent',
+    stability: 'immutable',
+    content:   'hello',
+    format:    (c) => String(c),
+    ...overrides,
+  }
+}
+
+function messageRegion(overrides: Partial<RegionInput> = {}): RegionInput {
+  return {
+    target:    'message',
+    section:   'current-turn',
+    intraTurn: 'turn-persistent',
+    interTurn: 'turn-local',
+    stability: 'volatile',
+    content:   { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] },
+    format:    (c) => c as Message,
+    ...overrides,
+  }
+}
+
+function toolRegion(overrides: Partial<RegionInput> = {}): RegionInput {
+  return {
+    target:    'tool',
+    section:   'default',
+    intraTurn: 'turn-persistent',
+    interTurn: 'session-persistent',
+    stability: 'session-stable',
+    content:   { name: 'echo', description: 'echo', inputSchema: {} } as ToolSchema,
+    format:    (c) => c as ToolSchema,
+    ...overrides,
+  }
+}
+
+describe('assemble — base cases', () => {
+  test('empty regions → empty assembled context', () => {
+    const store = new ContextRegions(() => 0)
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe('')
+    expect(out.messages).toEqual([])
+    expect(out.tools).toBeUndefined()
+  })
+
+  test('single system region → system block contains its formatted content', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('header', systemRegion({ content: 'You are an agent.' }))
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe('You are an agent.')
+    expect(out.messages).toEqual([])
+    expect(out.tools).toBeUndefined()
+  })
+
+  test('single message region → messages array contains formatted Message', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('u1', messageRegion())
+    const out = assemble(store, defaultScope())
+    expect(out.messages).toHaveLength(1)
+    expect(out.messages[0]!.role).toBe('user')
+  })
+
+  test('single tool region → tools array contains schema', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('t-echo', toolRegion())
+    const out = assemble(store, defaultScope())
+    expect(out.tools).toHaveLength(1)
+    expect(out.tools![0]!.name).toBe('echo')
+  })
+})
+
+describe('assemble — section ordering', () => {
+  test('sections render in SECTION_SCHEMA order regardless of insertion order', () => {
+    // Insert 'state' first, then 'header' — header must still come first.
+    let now = 100
+    const store = new ContextRegions(() => now++)
+    store.set('state-1', systemRegion({ section: 'state',  content: 'STATE-INSTR' }))
+    store.set('header',  systemRegion({ section: 'header', content: 'HEADER' }))
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe('HEADER\nSTATE-INSTR')
+  })
+
+  test('within section, regions sort by createdAt even when clock is non-monotonic', () => {
+    // Force createdAt order to differ from Map insertion order.
+    // Inserted A, B, C in that order; createdAt is 100, 50, 200.
+    // Map.values() yields A, B, C; sorted by createdAt yields B, A, C.
+    const values = [100, 50, 200]
+    let i = 0
+    const store = new ContextRegions(() => values[i++]!)
+    store.set('a', systemRegion({ section: 'session-skills', content: 'A' }))
+    store.set('b', systemRegion({ section: 'session-skills', content: 'B' }))
+    store.set('c', systemRegion({ section: 'session-skills', content: 'C' }))
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe('B\nA\nC')
+  })
+
+  test('within section, when both regions have ordinal, ordinal beats createdAt', () => {
+    let now = 0
+    const store = new ContextRegions(() => now++)
+    // createdAt order is X(0) then Y(1), but ordinals reverse them.
+    store.set('x', systemRegion({ section: 'session-skills', content: 'X', ordinal: 20 }))
+    store.set('y', systemRegion({ section: 'session-skills', content: 'Y', ordinal: 10 }))
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe('Y\nX')
+  })
+
+  test('within section, when only some have ordinal, fall back to createdAt for all (per spec §5)', () => {
+    let now = 0
+    const store = new ContextRegions(() => now++)
+    store.set('p', systemRegion({ section: 'session-skills', content: 'P', ordinal: 99 }))  // createdAt=0
+    store.set('q', systemRegion({ section: 'session-skills', content: 'Q' }))               // createdAt=1, no ordinal
+    const out = assemble(store, defaultScope())
+    // Per spec: bySectionLocalOrder only uses ordinal when BOTH have it.
+    // P (createdAt=0) wins regardless of its high ordinal.
+    expect(out.system).toBe('P\nQ')
+  })
+
+  test('messages render in SECTION_SCHEMA.message order: history → current-turn → scratchpad', () => {
+    let now = 100
+    const store = new ContextRegions(() => now++)
+    // Insert in reverse order; expected order follows schema.
+    store.set('scratch-1', messageRegion({
+      section: 'scratchpad',
+      content: { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'thinking' }] },
+    }))
+    store.set('current', messageRegion({
+      section: 'current-turn',
+      content: { role: 'user' as const, content: [{ type: 'text' as const, text: 'now' }] },
+    }))
+    store.set('hist-1', messageRegion({
+      section: 'history',
+      content: { role: 'user' as const, content: [{ type: 'text' as const, text: 'past' }] },
+    }))
+    const out = assemble(store, defaultScope())
+    expect(out.messages.map(m => (m.content[0] as { text: string }).text))
+      .toEqual(['past', 'now', 'thinking'])
+  })
+
+  test('format returning Message[] is flattened into messages array (history pair case)', () => {
+    const store = new ContextRegions(() => 0)
+    const pair = {
+      pair: [
+        { role: 'user' as const,      content: [{ type: 'text' as const, text: 'Q' }] },
+        { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'A' }] },
+      ],
+    }
+    store.set('hist-pair', {
+      target:    'message',
+      section:   'history',
+      intraTurn: 'turn-persistent',
+      interTurn: 'session-persistent',
+      stability: 'session-stable',
+      content:   pair,
+      format:    (c) => (c as typeof pair).pair as Message[],
+    })
+    const out = assemble(store, defaultScope())
+    expect(out.messages).toHaveLength(2)
+    expect(out.messages[0]!.role).toBe('user')
+    expect(out.messages[1]!.role).toBe('assistant')
+  })
+
+  test('multiple tool regions all included; sorted by createdAt', () => {
+    const values = [200, 100]
+    let i = 0
+    const store = new ContextRegions(() => values[i++]!)
+    store.set('t-b', toolRegion({
+      content: { name: 'b', description: 'b', inputSchema: {} } as ToolSchema,
+    }))
+    store.set('t-a', toolRegion({
+      content: { name: 'a', description: 'a', inputSchema: {} } as ToolSchema,
+    }))
+    const out = assemble(store, defaultScope())
+    expect(out.tools!.map(t => t.name)).toEqual(['a', 'b'])  // a has createdAt=100, comes first
+  })
+
+  test('full SECTION_SCHEMA traversal: all system sections render in their declared order', () => {
+    const store = new ContextRegions(() => 0)
+    // Reverse insertion order vs schema, plus one per section.
+    store.set('foot',  systemRegion({ section: 'footer',           content: 'FOOTER' }))
+    store.set('wm',    systemRegion({ section: 'wm',               content: 'WM' }))
+    store.set('toolss',systemRegion({ section: 'tools-state',      content: 'TOOLS-STATE' }))
+    store.set('state', systemRegion({ section: 'state',            content: 'STATE' }))
+    store.set('ssk',   systemRegion({ section: 'session-skills',   content: 'SESSION-SKILLS' }))
+    store.set('tools0',systemRegion({ section: 'tools-static',     content: 'TOOLS-STATIC' }))
+    store.set('psk',   systemRegion({ section: 'persistent-skills',content: 'PSK' }))
+    store.set('hdr',   systemRegion({ section: 'header',           content: 'HDR' }))
+    const out = assemble(store, defaultScope())
+    expect(out.system).toBe(
+      'HDR\nPSK\nTOOLS-STATIC\nSESSION-SKILLS\nSTATE\nTOOLS-STATE\nWM\nFOOTER'
+    )
+  })
+})
+
+describe('assemble — scope filtering (isActive)', () => {
+  test('state-scoped region included only when scope.currentState matches', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('s-a', systemRegion({
+      section:   'state',
+      content:   'A-INSTR',
+      intraTurn: { kind: 'state-scoped', state: 'state-A' },
+    }))
+    store.set('s-b', systemRegion({
+      section:   'state',
+      content:   'B-INSTR',
+      intraTurn: { kind: 'state-scoped', state: 'state-B' },
+    }))
+    const outA = assemble(store, defaultScope({ currentState: 'state-A' }))
+    expect(outA.system).toBe('A-INSTR')
+    const outB = assemble(store, defaultScope({ currentState: 'state-B' }))
+    expect(outB.system).toBe('B-INSTR')
+  })
+
+  test('TTL region excluded when currentEpoch > deadline', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('temp', systemRegion({
+      content:   'EPHEMERAL',
+      interTurn: { kind: 'ttl', deadline: 100 },
+    }))
+    const before = assemble(store, defaultScope({ currentEpoch: 50 }))
+    expect(before.system).toBe('EPHEMERAL')
+    const atDeadline = assemble(store, defaultScope({ currentEpoch: 100 }))
+    expect(atDeadline.system).toBe('EPHEMERAL')   // boundary: deadline inclusive
+    const after = assemble(store, defaultScope({ currentEpoch: 101 }))
+    expect(after.system).toBe('')                 // excluded
+  })
+
+  test('turn-persistent / session-persistent always included regardless of scope', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('a', systemRegion({
+      content:   'ALWAYS',
+      intraTurn: 'turn-persistent',
+      interTurn: 'session-persistent',
+    }))
+    const out = assemble(store, defaultScope({
+      currentState: 'whatever',
+      currentEpoch: Number.MAX_SAFE_INTEGER,
+    }))
+    expect(out.system).toBe('ALWAYS')
+  })
+
+  test('state-scoped and TTL are AND-ed (region excluded if either fails)', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('s', systemRegion({
+      content:   'SCOPED-TTL',
+      intraTurn: { kind: 'state-scoped', state: 'A' },
+      interTurn: { kind: 'ttl', deadline: 100 },
+    }))
+    // wrong state
+    expect(assemble(store, defaultScope({ currentState: 'B', currentEpoch: 0 })).system).toBe('')
+    // right state, past deadline
+    expect(assemble(store, defaultScope({ currentState: 'A', currentEpoch: 200 })).system).toBe('')
+    // right state, within deadline
+    expect(assemble(store, defaultScope({ currentState: 'A', currentEpoch: 50 })).system).toBe('SCOPED-TTL')
+  })
+})
+
+describe('assemble — purity invariant', () => {
+  test('same regions + scope → deep-equal AssembledContext on repeated calls', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('h', systemRegion({ content: 'H' }))
+    store.set('s', systemRegion({ section: 'session-skills', content: 'S' }))
+    store.set('m', messageRegion())
+    store.set('t', toolRegion())
+    const scope = defaultScope({ currentState: 'x', currentEpoch: 10 })
+    const a = assemble(store, scope)
+    const b = assemble(store, scope)
+    expect(b).toEqual(a)
+  })
+
+  test('assemble does not mutate the regions Map (epoch unchanged)', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('a', systemRegion())
+    store.set('b', messageRegion())
+    const epochBefore = store.getEpoch()
+    assemble(store, defaultScope())
+    assemble(store, defaultScope())
+    expect(store.getEpoch()).toBe(epochBefore)
+  })
+
+  test('assemble produces stable output across many invocations', () => {
+    const store = new ContextRegions(() => 100)
+    store.set('h',  systemRegion({ content: 'Base' }))
+    store.set('s1', systemRegion({ section: 'session-skills', content: 'S1' }))
+    store.set('s2', systemRegion({ section: 'session-skills', content: 'S2' }))
+    const scope = defaultScope()
+    const first = JSON.stringify(assemble(store, scope))
+    for (let i = 0; i < 10; i++) {
+      expect(JSON.stringify(assemble(store, scope))).toBe(first)
+    }
+  })
+})

--- a/src/context/ContextRegions.ts
+++ b/src/context/ContextRegions.ts
@@ -33,6 +33,13 @@ export class ContextRegions {
     return this.epoch
   }
 
+  // Public iterator for the assemble layer. Leading underscore signals
+  // "internal to substrate — not for general consumers". Iteration order
+  // is unspecified: assemble must do its own sorting.
+  _allRegions(): IterableIterator<Region> {
+    return this.regions.values()
+  }
+
   snapshot(): RegionSnapshot {
     return {
       epoch:   this.epoch,

--- a/src/context/assemble.ts
+++ b/src/context/assemble.ts
@@ -1,0 +1,89 @@
+// Pure assembly function: regions Map → assembled ModelRequest parts.
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §5
+//
+// Called once per LLM request boundary by AgentRuntime (PR-C). No mutation,
+// no IOPort access — deterministic by construction: same regions + same scope
+// → byte-identical output.
+
+import type { Region } from './Region'
+import type { ContextRegions } from './ContextRegions'
+import { SECTION_SCHEMA } from './sectionSchema'
+import type { Message } from '../types/common.js'
+import type { ToolSchema } from '../types/model.js'
+
+export interface AssembleScope {
+  currentState:  string
+  currentTurnId: string
+  currentEpoch:  number
+  subAgentId?:   string
+}
+
+// The assembled parts that come from regions. The caller (AgentRuntime)
+// composes a full ModelRequest by adding model / toolChoice / metadata
+// from agent config — those concerns don't belong in regions.
+export interface AssembledContext {
+  system:   string
+  messages: Message[]
+  tools?:   ToolSchema[]
+}
+
+export function assemble(regions: ContextRegions, scope: AssembleScope): AssembledContext {
+  const active = [...regions._allRegions()].filter(r => isActive(r, scope))
+
+  const systemRegions  = active.filter(r => r.target === 'system')
+  const messageRegions = active.filter(r => r.target === 'message')
+  const toolRegions    = active.filter(r => r.target === 'tool')
+
+  const systemBlocks: string[] = []
+  for (const sec of SECTION_SCHEMA.system) {
+    for (const r of systemRegions.filter(x => x.section === sec).sort(bySectionLocalOrder)) {
+      systemBlocks.push(r.format(r.content) as string)
+    }
+  }
+
+  const messages: Message[] = []
+  for (const sec of SECTION_SCHEMA.message) {
+    for (const r of messageRegions.filter(x => x.section === sec).sort(bySectionLocalOrder)) {
+      const out = r.format(r.content)
+      if (Array.isArray(out)) messages.push(...(out as Message[]))
+      else messages.push(out as Message)
+    }
+  }
+
+  const tools: ToolSchema[] = []
+  for (const r of toolRegions.slice().sort(bySectionLocalOrder)) {
+    tools.push(r.format(r.content) as ToolSchema)
+  }
+
+  return {
+    system:   systemBlocks.join('\n'),
+    messages,
+    ...(tools.length > 0 ? { tools } : {}),
+  }
+}
+
+// Per spec §5: only compare ordinal when BOTH regions declared one; otherwise
+// fall back to createdAt. Partial ordinal usage is intentionally meaningless
+// — agents either commit to ordinals for a section or rely on createdAt.
+function bySectionLocalOrder(a: Region, b: Region): number {
+  if (a.ordinal != null && b.ordinal != null) return a.ordinal - b.ordinal
+  return a.createdAt - b.createdAt
+}
+
+// Per spec §5: assemble filters regions that are not active in the current
+// scope. Belt-and-suspenders alongside the boundary engines (PR-C) which
+// proactively delete such regions — assemble still hides them defensively so
+// a missed engine pass cannot leak stale content into the LLM request.
+//
+// Other lifecycle states (one-shot, tool-buffer, turn-local, summarize,
+// promote-to-wm) are engine-driven mutations, not runtime filters, so they
+// are not checked here.
+function isActive(region: Region, scope: AssembleScope): boolean {
+  if (typeof region.intraTurn === 'object' && region.intraTurn.kind === 'state-scoped') {
+    if (region.intraTurn.state !== scope.currentState) return false
+  }
+  if (typeof region.interTurn === 'object' && region.interTurn.kind === 'ttl') {
+    if (scope.currentEpoch > region.interTurn.deadline) return false
+  }
+  return true
+}

--- a/src/context/sectionSchema.ts
+++ b/src/context/sectionSchema.ts
@@ -1,0 +1,37 @@
+// Section ordering schema for assemble.
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §5 + §6
+//
+// Sections are ordered by stability (most stable first) so that prefix cache
+// hits the longest stable prefix. Cache breakpoint candidates are marked.
+
+import type { RegionTarget, MessageSection, SystemSection, ToolSection } from './Region'
+
+export const SECTION_SCHEMA: {
+  readonly system:  ReadonlyArray<SystemSection>
+  readonly message: ReadonlyArray<MessageSection>
+  readonly tool:    ReadonlyArray<ToolSection>
+} = {
+  system: [
+    'header',
+    'persistent-skills',
+    'tools-static',
+    // ─── cache breakpoint candidate: stable cut ───
+    'session-skills',
+    // ─── cache breakpoint candidate: session cut ───
+    'state',
+    'tools-state',
+    'wm',
+    // ─── cache breakpoint candidate: turn cut ───
+    'footer',
+  ],
+  message: [
+    'history',
+    'current-turn',
+    'scratchpad',
+  ],
+  tool: ['default'],
+}
+
+export function sectionsFor(target: RegionTarget): ReadonlyArray<string> {
+  return SECTION_SCHEMA[target]
+}


### PR DESCRIPTION
## Summary

Second of **4 PRs** landing the Context Region Substrate spec (`docs/superpowers/specs/2026-05-25-context-region-substrate-design.md`). Builds on **PR-A** (Region + ContextRegions store, merged in #6).

This PR is **greenfield modulo a small addition** to `ContextRegions._allRegions` (the iterator PR-A explicitly deferred as "consumer-only API"). `ContextLayer` remains the production path; **PR-C** will wire `AgentRuntime` to `assemble`.

## What's in

**`src/context/sectionSchema.ts`** (spec §5 + §6):
- `SECTION_SCHEMA` constant — sections ordered by stability so prefix cache hits the longest stable prefix
- Comments mark the three cache-cut candidates (`stable-cut`, `session-cut`, `turn-cut`) that PR-D will translate to Anthropic-style `cache_control`

**`src/context/assemble.ts`** (spec §5):
- `AssembleScope` — `{ currentState, currentTurnId, currentEpoch, subAgentId? }`
- `AssembledContext` — `{ system, messages, tools? }`. Deliberately **does not include `model`** — that, plus `toolChoice` / `metadata`, are agent-config concerns AgentRuntime adds when composing the final `ModelRequest`
- `assemble(regions, scope)` pure function:
  - filters by `isActive` (state-scoped + TTL — belt-and-suspenders alongside boundary engines in PR-C)
  - groups by target (`system` / `message` / `tool`)
  - within each target, iterates sections per `SECTION_SCHEMA`
  - within section, sorts by `bySectionLocalOrder` (ordinal-when-both / else `createdAt`)
  - flattens `Message[]` from `format` (history pair case)
  - omits `tools` field when empty
- `isActive` only handles state-scoped + TTL; other lifecycle states (`one-shot`, `tool-buffer`, `turn-local`, `summarize-on-overflow`, `promote-to-wm`) are engine-driven mutations, not runtime filters

**`src/context/ContextRegions.ts`** — `_allRegions()` iterator added (3 lines)

## Test coverage

| Suite | Tests added | Description |
|---|---|---|
| `assemble.test.ts` | 4 | Base cases (empty / system / message / tool single-region) |
| | 5 | Section ordering (across SECTION_SCHEMA + within-section createdAt / ordinal-when-both / ordinal-fallback / full traversal) |
| | 3 | Message + tool targets (cross-section message order / Message[] flatten / tool sort) |
| | 4 | Scope filtering (state-scoped / TTL / always-included / AND combination) |
| | 3 | Purity invariant (deep-equal / no-mutation / stable across 10 invocations) |
| `ContextRegions.test.ts` | 3 | `_allRegions` iterator (empty / multi / post-delete) |
| **Total added** | **22** | (PR-B brings repo to 47 ContextRegions+assemble tests) |

Existing suites untouched: 30 unit + 7 deterministic e2e all green.

## What's NOT in (intentional — landing in later PRs)

- AgentRuntime wiring / scratchpad split / boundary engines (intra-turn + inter-turn / crystallization) / replay fixture re-record — **PR-C**
- Trace event types (`region.added` / `region.removed` / `context.boundary.applied`) — **PR-D**
- Adapter `cache_control` translation and `usage.cache_read_tokens` exposure — **PR-D**
- `ContextLayer.ts` deletion — PR-C once migration completes

## Design choices worth flagging

- **AssembledContext omits `model`**: spec §5 showed `{ model: /* from agent config */, ... }` but that contradicts the function's pure-by-regions signature. Pushing `model` out to the AgentRuntime composer keeps assemble's contract clean (regions don't know which model they'll be sent to).
- **`bySectionLocalOrder` partial-ordinal semantics per spec §5**: if only one region has `ordinal`, both fall back to `createdAt`. Tested explicitly. May want to revisit if this proves surprising in practice — would change to "missing ordinal = +Infinity" — but for now mirror the spec.
- **`isActive` boundary inclusivity for TTL**: `currentEpoch === deadline` is included; `currentEpoch > deadline` excluded. Matches spec wording "deadline passed".

## TDD discipline

| Task | RED-first? | Notes |
|---|---|---|
| `_allRegions` (3 tests) | Yes | Method missing → compile error |
| Base cases (4 tests) | Yes | Module missing → compile error |
| Section ordering (5 tests) | Partial | 1 of 5 truly RED (ordinal); 4 were invariant lock-ins that happened to pass due to Map insertion order. Added a non-monotonic clock test to **force** a true RED for the createdAt sort, then implemented |
| Message/tool targets (3 tests) | No | All passed immediately on the schema-loop implementation from Task #10. Invariant lock-in |
| Scope filtering (4 tests) | Yes | 3 of 4 truly RED (no `isActive` yet) — implemented to GREEN |
| Purity (3 tests) | No | assemble was designed pure from start; tests document invariants |

Honest read: ~60% strict TDD, ~40% invariant lock-in. Implementation is correct; future regressions are guarded. Reviewer can push back if pure TDD discipline is required throughout.

## Spec sections covered

- §5 assemble function — fully implemented (signature adjusted as noted above)
- §6 cache-aware section schema — `SECTION_SCHEMA` constant matches spec ordering exactly; cache-cut comments mark PR-D targets
- §11 invariants — items 1 (purity), 4 (sort stability), 5 (state-scoped filter), 7 (TTL filter) directly tested in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)