### PR TITLE
feat(runtime): skill_request scope parameter — turn vs session lifetime (PR-C2)

### DIFF
--- a/examples/agent-docs-qa/README.md
+++ b/examples/agent-docs-qa/README.md
@@ -164,32 +164,35 @@ After `npx tsx server.ts`, open `http://localhost:7878` and verify:
 - **Custom corpus loading at runtime** — corpus path is hardcoded to
   `./corpus/`; replace files in that dir to change content.
 
-## Known substrate limitations (addressed in pending design)
+## Substrate notes
 
-This example is built on milkie's current `ContextLayer`, which has several
-architecturally-incomplete behaviors. The example honestly exposes them
-rather than papering over them:
+This example runs on the `ContextRegions` + `assemble` substrate (PR-C1)
+plus the skill lifetime model (PR-C2):
 
-- **No skill release path** — the agent can `skill_request` to load `verifier`,
-  but has no way to unload it. Once loaded, verifier stays in the system
-  prompt for the remainder of the conversation. Progressive disclosure is
-  one-way today.
-- **scratchpad and history are conflated** — the ReAct loop's
-  `assistant tool_use` / `tool` messages accumulate in the same `history`
-  array as cross-turn `(user, finalAssistant)` pairs. Across many turns the
-  intermediate tool-call noise crowds the LLM's context.
-- **Tool results have no upper bound** — `read_file` returns full chapter
-  bodies (10–20KB each) verbatim into history; nothing in the substrate
-  enforces a per-tool size policy.
+- **Skill lifetime** — `skill_request({ name, scope })` accepts `scope: 'turn' | 'session'`.
+  Default is `'turn'` (auto-released at turn end). This example's
+  `sanguo-researcher.md` agent explicitly passes `scope: 'session'` for `verifier`
+  because the agent's intended flow is "load this turn, use it next turn".
+  An agent that needed verifier only within the current turn would omit
+  `scope` (defaulting to `'turn'`) and let crystallization clean it up
+  automatically.
+- **scratchpad / history separation** — every assistant + tool message during
+  a turn becomes a `turn-local` scratchpad region. Cross-turn history holds
+  only `(user, finalAssistant)` pairs (built at turn-end crystallization).
+  No more ReAct-noise accumulation across turns.
 
-All three are addressed in:
-**`docs/superpowers/specs/2026-05-25-context-region-substrate-design.md`**
+Still pending in future PRs:
 
-After that substrate work lands (region abstraction + lifetime declaration +
-turn-end crystallization + `ToolResultStrategy`), this example's
-frontend + `agents/sanguo-researcher.agent.md` will be updated to demonstrate
-the full *load → use → auto-release at turn end* cycle and per-tool result
-shaping.
+- **Tool result strategy** (spec §4.4) — `read_file` still returns full chapter
+  bodies (10–20KB each) verbatim. The substrate has no per-tool size policy
+  yet; `ToolResultStrategy` (`shape` / `visibility` / `target` three axes) is
+  the planned fix. Tracked for a follow-up PR after Phase 5.
+- **Trace `region.added` / `region.removed` events** — the UI currently
+  detects skill loads by watching `tool.requested` (toolName === 'skill_request').
+  Once the substrate emits dedicated region lifecycle events (PR-D), the UI
+  can switch to those for a richer view.
+
+Full spec: **`docs/superpowers/specs/2026-05-25-context-region-substrate-design.md`**
 
 ## Related
 

--- a/examples/agent-docs-qa/agents/sanguo-researcher.md
+++ b/examples/agent-docs-qa/agents/sanguo-researcher.md
@@ -19,11 +19,15 @@ fsm:
 
         重要:当用户对你的回答表达怀疑("你确定吗" / "再确认下" /
         "verify" / "are you sure" / "真的吗" 等),调用
-        skill_request({ name: "verifier" }) 进入下一 epoch 的严格
-        验证模式,并在本轮回答里告知用户"已申请加载 verifier,下一轮
-        将严格 verify"。
+        skill_request({ name: "verifier", scope: "session" })
+        进入下一 epoch 的严格验证模式,并在本轮回答里告知用户
+        "已申请加载 verifier,下一轮将严格 verify"。
 
-        verifier 是一次性的——同一会话内不要反复 request;如果用户
+        scope:"session" 让 verifier 在整个会话内持久 —— 默认 scope 是
+        "turn"(轮末自动释放),但本 agent 需要 verifier 在下一轮才能用上,
+        所以必须显式声明 session。
+
+        verifier 是一次性加载——同一会话内不要反复 request;如果用户
         再次怀疑、且 verifier 已加载,直接以严格模式重新验证即可。
       tools: [list_dir, read_file, grep, skill_request]
 model:

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -67,7 +67,7 @@ export class AgentRuntime {
 
   private eventQueue:    Array<{ type: string; payload: unknown }> = []
   private pendingEvents: Array<{ type: string; payload: unknown }> = []
-  private pendingSkillLoads: Array<{ name: string; instructions: string }> = []
+  private pendingSkillLoads: Array<{ name: string; instructions: string; scope: 'turn' | 'session' }> = []
   private childRecords: Map<string, ChildAgentRecord> = new Map()
   private rootSpan!:     Span
   private turnNumber:    number = 0
@@ -232,28 +232,31 @@ export class AgentRuntime {
       agentFactory:  this.factory,
       stateStore:    this.stateStore,
       emit:          emitFn,
-      requestSkill:  (name: string) => this.requestSkill(name),
+      requestSkill:  (name: string, scope?: 'turn' | 'session') => this.requestSkill(name, scope),
     }
   }
 
-  private requestSkill(name: string): { requested: string; status: string; version?: string } {
+  private requestSkill(name: string, scope: 'turn' | 'session' = 'turn'): { requested: string; status: string; version?: string; scope?: 'turn' | 'session' } {
     const normalized = name.trim().replace(/\s+skill$/i, '')
     const version = this.config.skills?.[normalized]
     const instructions = this.config.skillInstructions?.[normalized]
     if (!version || !instructions) {
       return { requested: name, status: 'unavailable' }
     }
-    this.pendingSkillLoads.push({ name: normalized, instructions })
-    return { requested: normalized, status: 'pending_next_epoch', version }
+    this.pendingSkillLoads.push({ name: normalized, instructions, scope })
+    return { requested: normalized, status: 'pending_next_epoch', version, scope }
   }
 
   private applyPendingSkills(): void {
-    for (const { name, instructions } of this.pendingSkillLoads) {
+    for (const { name, instructions, scope } of this.pendingSkillLoads) {
       const id = `skill:${name}`
       // Already loaded? Skip (preserves createdAt; idempotent like Map.set upsert).
+      // Note: this means re-requesting with a different scope is a no-op — the
+      // first request wins. Acceptable trade-off; agents that need to "upgrade"
+      // a turn-scoped skill to session would have to release first (not currently
+      // possible — release intentionally absent per spec §4.3 rationale).
       if (this.regions.get(id)) continue
-      // PR-C2 will plumb scope through requestSkill; PR-C1 defaults to session.
-      this.regions.set(id, makeSkillRegion(name, instructions, 'session'))
+      this.regions.set(id, makeSkillRegion(name, instructions, scope))
     }
     this.pendingSkillLoads = []
   }

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -15,15 +15,22 @@ export const systemTools: ToolDefinition[] = [
 
   {
     name:        'skill_request',
-    description: 'Request a skill to be loaded in the next context epoch.',
+    description: "Request a skill to be loaded in the next context epoch. Choose scope=turn for one-shot usage (auto-released at turn end) or scope=session for cross-turn persistence. Default: turn.",
     inputSchema: {
       type:       'object',
-      properties: { name: { type: 'string', description: 'Skill name to load' } },
+      properties: {
+        name:  { type: 'string', description: 'Skill name to load' },
+        scope: {
+          type: 'string',
+          enum: ['turn', 'session'],
+          description: "Lifetime: 'turn' = available only for the current conversational turn (auto-released at turn end); 'session' = persists across turns. Default: 'turn'.",
+        },
+      },
       required:   ['name'],
     },
     handler: async (input: unknown, ctx) => {
-      const { name } = input as { name: string }
-      return ctx.requestSkill?.(name) ?? { requested: name, status: 'unavailable' }
+      const { name, scope } = input as { name: string; scope?: 'turn' | 'session' }
+      return ctx.requestSkill?.(name, scope) ?? { requested: name, status: 'unavailable' }
     },
   },
 ]

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -8,7 +8,7 @@ export interface ToolContext {
   agentFactory:  AgentFactory
   stateStore:    IStateStore
   emit:          (event: string, payload?: unknown) => void
-  requestSkill?: (name: string) => { requested: string; status: string; version?: string }
+  requestSkill?: (name: string, scope?: 'turn' | 'session') => { requested: string; status: string; version?: string; scope?: 'turn' | 'session' }
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
## Summary

Fourth piece of the Context Region Substrate. Branches off **PR-C1** (#8 — please review/merge that first). Implements **spec §4.3 — Skill lifetime model**.

The skill_request system tool now accepts an optional \`scope\` parameter:
- \`scope: 'turn'\` (**default**) — skill is released automatically by turn-end crystallization
- \`scope: 'session'\` — skill persists across turns; included in checkpoint

There is intentionally **no \`skill_release\` tool**. Agents declare lifetime at request time; the substrate's boundary engine takes care of cleanup. See spec §4.3 for the "why" — short version: LLM resource-management is unreliable (forget release, premature release, thrashing), and 'turn' as the default eliminates resource leaks while still letting agents opt into 'session' for the rare cross-turn case.

## Changes

| File | Change |
|---|---|
| \`src/types/tool.ts\` | \`ToolContext.requestSkill\` signature extended with optional \`scope\` param + return value |
| \`src/tools/system.ts\` | \`skill_request\` tool: inputSchema adds optional \`scope\` enum; description updated; handler passes scope through |
| \`src/runtime/AgentRuntime.ts\` | \`pendingSkillLoads\` field type carries scope; \`requestSkill\` defaults to \`'turn'\`; \`applyPendingSkills\` calls \`makeSkillRegion(name, instructions, scope)\` |
| \`examples/agent-docs-qa/agents/sanguo-researcher.md\` | Agent prompt now uses \`scope: "session"\` for verifier (its flow loads in turn N, uses in turn N+1) |
| \`examples/agent-docs-qa/README.md\` | "Substrate notes" section rewritten — removed resolved limitations, kept genuinely pending ones (\`ToolResultStrategy\`, trace region.* events) |

## Default = 'turn' rationale

Per spec §4.3 default scope is \`'turn'\` because:
- Most skill use cases are within-turn (the agent loads a skill to handle the current question)
- Auto-release eliminates the "forgot to release → resource leak" failure mode
- Cross-turn persistence is the rare case that should be explicitly declared, not silently default

The agent-docs-qa example happens to need cross-turn persistence (verifier loaded in turn N, used in turn N+1), so it's been updated to explicitly request \`scope: 'session'\`. Other agents that just need within-turn usage can omit the parameter and benefit from auto-cleanup.

## What about already-loaded skills?

\`applyPendingSkills\` is idempotent: re-requesting the same skill with a different scope is a no-op (first request wins). Acceptable for Phase 1; if "scope upgrade" becomes a real need we can add it later.

## Compatibility

- **Tests**: zero new failures. 39/39 suites, 335 tests pass (15 skipped live-LLM cases).
- **Existing agents**: any agent that doesn't pass \`scope\` now gets \`'turn'\` instead of \`'session'\`. Agents that rely on cross-turn skill persistence (like sanguo-researcher) need to explicitly opt into \`scope: 'session'\`. None of the test suites do — confirmed empirically.

## Spec coverage delta vs PR-C1

| Spec section | Before PR-C2 | After PR-C2 |
|---|---|---|
| §4.3 skill lifetime model | Partial (path implemented; default = 'session' for backwards compat) | ✓ (\`scope\` parameter plumbed end-to-end; default = 'turn' per spec) |

Still deferred:
- §4.4 \`ToolResultStrategy\` — separate PR after Phase 5
- §7.2 \`runIntraTurnEngine\` — when other lifecycle states (tool-buffer, one-shot) get real usage
- PR-D — trace events + cache health + adapter cache_control

🤖 Generated with [Claude Code](https://claude.com/claude-code)