### PR TITLE
feat(adapter): OpenAICompatibleAdapter extracts cache hit tokens

### DIFF
--- a/src/__tests__/OpenAICompatibleAdapter.test.ts
+++ b/src/__tests__/OpenAICompatibleAdapter.test.ts
@@ -1,0 +1,59 @@
+import { OpenAICompatibleAdapter } from '../gateway/OpenAICompatibleAdapter'
+import type { ModelResponse } from '../types/model'
+
+// parseResponse is private; we exercise it via cast — no network call.
+function parseResponseOf(adapter: OpenAICompatibleAdapter, raw: unknown): ModelResponse {
+  return (adapter as unknown as { parseResponse(r: unknown): ModelResponse }).parseResponse(raw)
+}
+
+describe('OpenAICompatibleAdapter — cache stats extraction', () => {
+  const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test' })
+
+  test('no usage → no usage on ModelResponse', () => {
+    const raw = {
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+    }
+    const out = parseResponseOf(adapter, raw)
+    expect(out.usage).toBeUndefined()
+  })
+
+  test('usage without prompt_tokens_details → cacheReadTokens absent', () => {
+    const raw = {
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage:   { prompt_tokens: 100, completion_tokens: 50 },
+    }
+    const out = parseResponseOf(adapter, raw)
+    expect(out.usage).toEqual({ inputTokens: 100, outputTokens: 50 })
+    expect(out.usage?.cacheReadTokens).toBeUndefined()
+  })
+
+  test('usage with prompt_tokens_details.cached_tokens → cacheReadTokens populated', () => {
+    const raw = {
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage:   {
+        prompt_tokens:         100,
+        completion_tokens:     50,
+        prompt_tokens_details: { cached_tokens: 80 },
+      },
+    }
+    const out = parseResponseOf(adapter, raw)
+    expect(out.usage).toEqual({
+      inputTokens:     100,
+      outputTokens:    50,
+      cacheReadTokens: 80,
+    })
+  })
+
+  test('prompt_tokens_details.cached_tokens === 0 → still populated (legitimate zero, not absence)', () => {
+    const raw = {
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage:   {
+        prompt_tokens:         100,
+        completion_tokens:     50,
+        prompt_tokens_details: { cached_tokens: 0 },
+      },
+    }
+    const out = parseResponseOf(adapter, raw)
+    expect(out.usage?.cacheReadTokens).toBe(0)
+  })
+})

--- a/src/gateway/OpenAICompatibleAdapter.ts
+++ b/src/gateway/OpenAICompatibleAdapter.ts
@@ -132,8 +132,18 @@ export class OpenAICompatibleAdapter implements IModelGateway {
       toolCalls.push({ id: tc.id, name: tc.function.name, input })
     }
 
+    // PR-D follow-up: OpenAI's chat completions response includes
+    // prompt_tokens_details.cached_tokens when auto prefix caching hits
+    // (gpt-4o family, gpt-4o-mini, o1 family). No separate "creation
+    // tokens" counter — OpenAI's auto-cache writes are not surfaced.
+    const cachedTokens = (raw.usage as { prompt_tokens_details?: { cached_tokens?: number } } | undefined)
+      ?.prompt_tokens_details?.cached_tokens
     const usage: ModelUsage | undefined = raw.usage
-      ? { inputTokens: raw.usage.prompt_tokens, outputTokens: raw.usage.completion_tokens }
+      ? {
+          inputTokens:  raw.usage.prompt_tokens,
+          outputTokens: raw.usage.completion_tokens,
+          ...(cachedTokens !== undefined ? { cacheReadTokens: cachedTokens } : {}),
+        }
       : undefined
 
     return { content, toolCalls, usage, finishReason: choice.finish_reason ?? undefined, raw }


### PR DESCRIPTION
## Summary

PR-D shipped cache-stats plumbing through \`ModelUsage\` but only the Anthropic adapter populated it. OpenAI-compatible adapter (gpt-4o-mini, gpt-4o, o1, Volcengine doubao) ignored OpenAI's \`prompt_tokens_details.cached_tokens\` field — so trace \`cacheStats\` stayed empty for agent-docs-qa and any agent using OpenAI-compatible providers regardless of actual cache behavior.

Fix is small (~10 lines impl + 4 tests):
- Read \`raw.usage.prompt_tokens_details.cached_tokens\` via loose cast (SDK type doesn't yet declare this field for chat.completions)
- Populate \`ModelUsage.cacheReadTokens\` when present (preserves 0 vs undefined)
- \`cacheCreationTokens\` stays undefined — OpenAI doesn't surface auto-cache writes (Anthropic does because it uses explicit \`cache_control\`)

## Test plan

- [x] 4 new unit tests in \`src/__tests__/OpenAICompatibleAdapter.test.ts\` (no-usage / no-details / present / zero-value)
- [x] Full suite 41/41 suites, 355 tests pass
- [ ] After merge: empirical measurement on agent-docs-qa — chat 5+ turns, inspect \`.milkie/runs/*.jsonl\` for \`cacheStats\` values, validate / falsify the cache-miss推演 we discussed in chat

## Context

Blocks empirical answer to "is the volatile-system-vs-message-cache disorder actually expensive in agent-docs-qa-style workloads?". Without this, the trace is silent on cache behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)