### PR TITLE
feat(tool): ToolResultStrategy Phase 1 (shape + onError) — large-result cache fix

### DIFF
--- a/docs/superpowers/plans/2026-05-26-pr-e-tool-result-strategy-phase-1.md
+++ b/docs/superpowers/plans/2026-05-26-pr-e-tool-result-strategy-phase-1.md
@@ -1,0 +1,802 @@
+# PR-E: ToolResultStrategy Phase 1 (shape + onError) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give tool authors a declarative way to **shape large tool outputs** before they enter the LLM context, addressing the empirical cache-burning we measured (agent-docs-qa Turn 3 Call 4: 75% → 17% hit rate when 1.7K → 8K input from a single `read_file` result).
+
+**Architecture:** Tools opt into a `resultStrategy: ToolResultStrategy` declaring how their raw output should be transformed (`shape`) before reaching the LLM, plus how errors are shaped separately (`onError`). Strategy is **applied at AgentRuntime** between tool execution and scratchpad-region insertion — keeps tool registry/execution untouched, trace records RAW output (replay correctness), shaped output goes into the LLM message stream. Shape is a pure function so replay reproduces same scratchpad bytes deterministically.
+
+**Tech Stack:** TypeScript, jest (`ts-jest`).
+
+**Spec:** `docs/superpowers/specs/2026-05-25-context-region-substrate-design.md` §4.4 (ToolResultStrategy three-axis design + safe default). PR-E Phase 1 ships **only the `shape` and `onError` axes**. `visibility` and `target` deferred to Phase 2 (need `context_fetch` system tool + tool_use/tool_result pairing handling for `'wm'`/`'discard'` targets).
+
+**Empirical baseline (before this PR):** measured on agent-docs-qa with 5-turn doubao conversation, 17 LLM calls, total input 63065 tokens, cached 22976 tokens — 36% overall hit rate. Single read_file results push input from 1.7K → 8K+ tokens, breaking prefix cache.
+
+---
+
+## Phase 1 scope vs spec §4.4
+
+| Spec §4.4 axis | Phase 1 | Phase 2+ |
+|---|---|---|
+| `shape: 'verbatim' \| truncate \| tail \| summarize \| extract \| transform` | ✅ ships `'verbatim'`, `truncate`, `tail`. Defers `summarize` (needs LLM), `extract` (needs jsonPath impl), `transform` (escape hatch — defer until concrete use case) | summarize / extract / transform |
+| `visibility: 'inline' \| 'stored-only' \| first-call-then-reference` | ✅ ships `'inline'` only (current behavior) | stored-only (needs `context_fetch` system tool) / first-call-then-reference (needs consumption tracking) |
+| `target: 'scratchpad' \| 'wm' \| 'discard'` | ✅ ships `'scratchpad'` only (current behavior) | wm / discard (need tool_use/tool_result pairing logic — Anthropic API rejects orphan tool_use) |
+| `onError: Shape` | ✅ shipped (default `'verbatim'`) | — |
+
+**Default:** keeps `'verbatim'` (backward compatible). PR body documents recommendation to opt-in to `truncate` for tools returning >2KB. **No existing tools forced to migrate.**
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/types/tool.ts` — add `Shape`, `ToolResultStrategy`, extend `ToolDefinition` with optional `resultStrategy`
+- `src/runtime/AgentRuntime.ts` — apply strategy to each tool result between `executeTools` and `appendScratchpadToolResults`
+- `src/trace/types.ts` — add optional `appliedStrategy` to `ToolRespondedPayload` (spec §8.3)
+- `src/trace/RecordingIOPort.ts` — record `appliedStrategy` on `tool.responded` event when AgentRuntime supplies it
+- `examples/agent-docs-qa/tools/corpus-tools.ts` — concretely demonstrate by adding `truncate(2000)` to `read_file`
+
+**Create:**
+- `src/runtime/toolResultStrategy.ts` — pure `applyShape(raw, shape, onError, error?)` helper + types
+- `src/__tests__/toolResultStrategy.test.ts` — unit tests for `applyShape`
+- `src/__tests__/AgentRuntime.toolResultStrategy.test.ts` — integration test demonstrating strategy applied end-to-end
+
+---
+
+## Task 1: Add ToolResultStrategy types
+
+**Files:**
+- Modify: `src/types/tool.ts`
+
+**Why:** Type contracts established before implementation. Additive — `resultStrategy` optional, existing tools unchanged.
+
+- [ ] **Step 1: Add `Shape` and `ToolResultStrategy` types after existing imports**
+
+In `src/types/tool.ts`, add at the end of the file:
+
+```typescript
+// ---- PR-E Phase 1: Tool result shaping ----
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §4.4
+//
+// Phase 1 ships shape + onError axes only. visibility / target stay implicit
+// ('inline' / 'scratchpad') — those need context_fetch tool + tool_use/result
+// pairing handling, deferred to Phase 2.
+
+export type Shape =
+  | 'verbatim'
+  | { kind: 'truncate'; maxChars: number; tailHint?: boolean }
+  | { kind: 'tail';     maxChars: number }
+
+export interface ToolResultStrategy {
+  shape:    Shape
+  /** Shape applied when the tool handler throws. Default 'verbatim' (full error info to agent). */
+  onError?: Shape
+}
+```
+
+- [ ] **Step 2: Add optional `resultStrategy` to `ToolDefinition`**
+
+Locate the `ToolDefinition` interface (around line 14-20). Update to:
+
+```typescript
+export interface ToolDefinition {
+  name:           string
+  description:    string
+  inputSchema:    JSONSchema
+  handler:        (input: unknown, ctx: ToolContext) => Promise<unknown>
+  parallelSafe?:  boolean
+  /** PR-E Phase 1: how raw tool output is shaped before entering LLM context. Default verbatim. */
+  resultStrategy?: ToolResultStrategy
+}
+```
+
+- [ ] **Step 3: TypeScript check + commit**
+
+```bash
+cd /Users/xupeng/dev/github/milkie
+npx tsc --noEmit -p .
+```
+Expected: zero errors.
+
+```bash
+git add src/types/tool.ts
+git commit -m "feat(tool): add ToolResultStrategy types — Shape + onError (PR-E step 1/7)"
+```
+
+---
+
+## Task 2: applyShape pure helper + unit tests
+
+**Files:**
+- Create: `src/runtime/toolResultStrategy.ts`
+- Create: `src/__tests__/toolResultStrategy.test.ts`
+
+**Why:** Shape is a pure function on serialized output. Test in isolation; AgentRuntime consumes via single entry point.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/__tests__/toolResultStrategy.test.ts`:
+
+```typescript
+import { applyShape, serializeOutput } from '../runtime/toolResultStrategy'
+import type { Shape } from '../types/tool'
+
+describe('serializeOutput', () => {
+  test('string passes through', () => {
+    expect(serializeOutput('hello')).toBe('hello')
+  })
+  test('null → "null"', () => {
+    expect(serializeOutput(null)).toBe('null')
+  })
+  test('undefined → ""', () => {
+    expect(serializeOutput(undefined)).toBe('')
+  })
+  test('object → JSON', () => {
+    expect(serializeOutput({ a: 1 })).toBe('{"a":1}')
+  })
+})
+
+describe('applyShape — verbatim', () => {
+  test('returns serialized output as-is', () => {
+    expect(applyShape({ a: 1 }, 'verbatim')).toBe('{"a":1}')
+  })
+
+  test('long content not truncated', () => {
+    const long = 'x'.repeat(10000)
+    expect(applyShape(long, 'verbatim')).toBe(long)
+  })
+})
+
+describe('applyShape — truncate', () => {
+  test('content shorter than maxChars passes through', () => {
+    expect(applyShape('short', { kind: 'truncate', maxChars: 100 })).toBe('short')
+  })
+
+  test('content longer than maxChars cut to maxChars', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100 })
+    expect(out.length).toBeLessThanOrEqual(150)   // 100 chars + truncation marker
+    expect(out.startsWith('xxxx')).toBe(true)
+  })
+
+  test('tailHint=true appends explanatory marker about truncated bytes', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100, tailHint: true })
+    expect(out).toMatch(/\[\.\.\.truncated.*900.*chars\.\.\.\]/)
+  })
+
+  test('tailHint=false (or omitted) appends bare ellipsis marker', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100 })
+    expect(out.endsWith('...')).toBe(true)
+  })
+
+  test('object serialized then truncated', () => {
+    const obj = { data: 'y'.repeat(1000) }
+    const out = applyShape(obj, { kind: 'truncate', maxChars: 50 })
+    expect(out.length).toBeLessThanOrEqual(100)
+    expect(out.startsWith('{"data":"yyy')).toBe(true)
+  })
+})
+
+describe('applyShape — tail', () => {
+  test('content shorter than maxChars passes through', () => {
+    expect(applyShape('short', { kind: 'tail', maxChars: 100 })).toBe('short')
+  })
+
+  test('content longer than maxChars cut to LAST maxChars', () => {
+    const content = 'A'.repeat(500) + 'B'.repeat(500)
+    const out = applyShape(content, { kind: 'tail', maxChars: 100 })
+    expect(out.endsWith('BBBB')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(150)
+  })
+
+  test('prepends ellipsis marker showing how many bytes dropped from head', () => {
+    const long = 'z'.repeat(1000)
+    const out = applyShape(long, { kind: 'tail', maxChars: 100 })
+    expect(out.startsWith('[...')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — expect FAIL (module missing)**
+
+```bash
+npx jest src/__tests__/toolResultStrategy.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+Create `src/runtime/toolResultStrategy.ts`:
+
+```typescript
+import type { Shape } from '../types/tool'
+
+/**
+ * Serialize raw tool output to a string for shaping + LLM consumption.
+ * Mirrors the existing AgentRuntime.executeTools serialization
+ * (JSON.stringify for objects, string passthrough, etc) so behavior
+ * is unchanged when shape='verbatim'.
+ */
+export function serializeOutput(raw: unknown): string {
+  if (raw === undefined) return ''
+  if (typeof raw === 'string') return raw
+  return JSON.stringify(raw)
+}
+
+/**
+ * Apply a Shape to raw tool output (handler result OR error message).
+ * Pure: same (raw, shape) → same string. Replay-safe.
+ */
+export function applyShape(raw: unknown, shape: Shape): string {
+  const serialized = serializeOutput(raw)
+
+  if (shape === 'verbatim') return serialized
+
+  if (shape.kind === 'truncate') {
+    if (serialized.length <= shape.maxChars) return serialized
+    const head = serialized.slice(0, shape.maxChars)
+    const droppedChars = serialized.length - shape.maxChars
+    if (shape.tailHint) {
+      return `${head}[...truncated ${droppedChars} chars...]`
+    }
+    return `${head}...`
+  }
+
+  if (shape.kind === 'tail') {
+    if (serialized.length <= shape.maxChars) return serialized
+    const tail = serialized.slice(-shape.maxChars)
+    const droppedChars = serialized.length - shape.maxChars
+    return `[...${droppedChars} chars dropped...]${tail}`
+  }
+
+  // Exhaustiveness check — typescript will error if a Shape variant is added without handling
+  const _exhaustive: never = shape
+  return serializeOutput(raw)
+}
+```
+
+- [ ] **Step 4: Run tests — expect GREEN**
+
+```bash
+npx jest src/__tests__/toolResultStrategy.test.ts
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/runtime/toolResultStrategy.ts src/__tests__/toolResultStrategy.test.ts
+git commit -m "feat(runtime): applyShape pure helper + unit tests (PR-E step 2/7)"
+```
+
+---
+
+## Task 3: AgentRuntime applies strategy when constructing tool_result MessageContent
+
+**Files:**
+- Modify: `src/runtime/AgentRuntime.ts`
+
+**Why:** Apply Shape AFTER tool execution + trace recording, BEFORE scratchpad-region insertion. This way trace records RAW output (replay correctness) and LLM sees shaped output.
+
+- [ ] **Step 1: Add imports**
+
+In `src/runtime/AgentRuntime.ts` add:
+
+```typescript
+import { applyShape, serializeOutput } from './toolResultStrategy.js'
+import type { ToolResultStrategy } from '../types/tool.js'
+```
+
+- [ ] **Step 2: Locate the tool_result MessageContent construction**
+
+Around line 583-590 the code looks like:
+
+```typescript
+if (response.toolCalls.length > 0) {
+  const results = await this.executeTools(response.toolCalls, state.tools)
+  await this.checkEvents()
+
+  // Append tool results to context
+  const toolResultContent: MessageContent[] = results.map(r => ({
+    type:        'tool_result' as const,
+    tool_use_id: r.toolCallId,
+    content:     r.error ?? JSON.stringify(r.output),
+    is_error:    r.isError,
+  }))
+  this.appendScratchpadToolResults(toolResultContent)
+  ...
+}
+```
+
+- [ ] **Step 3: Add a private helper to shape a single ToolResult**
+
+Add a private method on AgentRuntime (near other private helpers):
+
+```typescript
+/**
+ * Apply the tool's declared resultStrategy (if any) to a single ToolResult,
+ * returning the string content that should go into the tool_result message.
+ * Default strategy is 'verbatim' (backwards compatible — pre-PR-E behavior).
+ *
+ * The raw output is recorded as-is on the tool.responded event (in
+ * executeSingleTool / RecordingIOPort); this method only shapes what goes
+ * into the LLM's scratchpad message.
+ */
+private shapeToolResultForLlm(r: import('../types/tool.js').ToolResult): string {
+  if (r.isError) {
+    const strategy = this.toolStrategyFor(r.toolName)
+    return applyShape(r.error, strategy?.onError ?? 'verbatim')
+  }
+  const strategy = this.toolStrategyFor(r.toolName)
+  return applyShape(r.output, strategy?.shape ?? 'verbatim')
+}
+
+private toolStrategyFor(toolName: string): ToolResultStrategy | undefined {
+  return this.registry.get(toolName)?.resultStrategy
+}
+```
+
+- [ ] **Step 4: Replace the inline construction**
+
+Replace:
+```typescript
+const toolResultContent: MessageContent[] = results.map(r => ({
+  type:        'tool_result' as const,
+  tool_use_id: r.toolCallId,
+  content:     r.error ?? JSON.stringify(r.output),
+  is_error:    r.isError,
+}))
+```
+
+with:
+```typescript
+const toolResultContent: MessageContent[] = results.map(r => ({
+  type:        'tool_result' as const,
+  tool_use_id: r.toolCallId,
+  content:     this.shapeToolResultForLlm(r),
+  is_error:    r.isError,
+}))
+```
+
+- [ ] **Step 5: Verify the ToolRegistry has `.get(name)` returning ToolDefinition (or change the code)**
+
+Run:
+```bash
+grep -n "get\b" src/tools/ToolRegistry.ts | head -5
+```
+
+If `get` returns `ToolDefinition | undefined`, the `toolStrategyFor` helper works as written. If the signature differs, adapt the helper.
+
+- [ ] **Step 6: Verify**
+
+```bash
+npm run test:unit && npm run test:e2e:deterministic
+```
+Expected: 30 + 7 pass. No tools currently set resultStrategy → shape='verbatim' default → byte-identical to pre-PR-E behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/runtime/AgentRuntime.ts
+git commit -m "feat(runtime): apply tool resultStrategy when constructing tool_result message (PR-E step 3/7)"
+```
+
+---
+
+## Task 4: Trace appliedStrategy on tool.responded
+
+**Files:**
+- Modify: `src/trace/types.ts`
+- Modify: `src/runtime/AgentRuntime.ts` (emit appliedStrategy)
+
+**Why:** Spec §8.3 calls for `appliedStrategy` metadata on `tool.responded` so trace consumers (HTML report, downstream analysis) can see "this tool returned 12KB raw → stored 1KB after truncate(2000)".
+
+Phase 1 record minimal info: the shape kind + raw/stored byte counts. Defer richer detail (originalBytes, target=scratchpad, onErrorPath) to Phase 2.
+
+- [ ] **Step 1: Extend `ToolRespondedPayload`**
+
+In `src/trace/types.ts`, locate `ToolRespondedPayload`. Extend:
+
+```typescript
+export interface ToolRespondedPayload {
+  toolName: string
+  output?: unknown
+  error?: {
+    message:    string
+    retryable?: boolean
+    code?:      string
+    name?:      string
+  }
+  requestHash: string
+  /** PR-E: which shape was applied + how much was kept. Absent when strategy is 'verbatim' (no shaping happened). */
+  appliedStrategy?: {
+    shapeKind:     'verbatim' | 'truncate' | 'tail'
+    rawBytes:      number   // serialized output length BEFORE shape
+    storedBytes:   number   // length AFTER shape (what went into LLM)
+    onErrorPath:   boolean  // true if handler threw and onError shape was used
+  }
+}
+```
+
+- [ ] **Step 2: Emit appliedStrategy in AgentRuntime**
+
+The `tool.responded` event is appended by `RecordingIOPort.invokeTool` (in src/trace/RecordingIOPort.ts) — at that point we don't know which strategy will be applied (because shaping happens later in AgentRuntime).
+
+Two design options:
+- (a) Emit `appliedStrategy` from AgentRuntime as a SEPARATE event after shaping
+- (b) Post-process the tool.responded event before next write (complicates RecordingIOPort)
+- (c) Have AgentRuntime emit a `tool.shaped` span event on the llm.call span instead
+
+**Pick (c)** — cleanest. Don't mutate `tool.responded`. Add a `recordEvent` on the active span when shape is applied.
+
+In AgentRuntime, modify `shapeToolResultForLlm` to take an extra `recordTo: Span` arg, and after applying shape, emit:
+
+```typescript
+private shapeToolResultForLlm(r: ToolResult, llmSpan: Span): string {
+  const strategy = this.toolStrategyFor(r.toolName)
+  if (!strategy) return r.isError ? serializeOutput(r.error) : serializeOutput(r.output)
+
+  const shape = r.isError ? (strategy.onError ?? 'verbatim') : strategy.shape
+  const raw = r.isError ? r.error : r.output
+  const rawString = serializeOutput(raw)
+  const shaped = applyShape(raw, shape)
+
+  const shapeKind = shape === 'verbatim' ? 'verbatim' : shape.kind
+  if (shapeKind !== 'verbatim') {
+    this.recorder.recordEvent(llmSpan, 'tool.shaped', {
+      toolName:    r.toolName,
+      toolCallId:  r.toolCallId,
+      shapeKind,
+      rawBytes:    rawString.length,
+      storedBytes: shaped.length,
+      onErrorPath: r.isError,
+    })
+  }
+  return shaped
+}
+```
+
+Update the caller to pass `llmSpan`.
+
+Note: This deviates slightly from Step 1 (which extended `ToolRespondedPayload`). Drop the Step 1 change — we're using span events instead. Revert `ToolRespondedPayload` if you already extended it.
+
+**Revised Step 1 (apply this version):** skip extending `ToolRespondedPayload`. Just emit a new span event `tool.shaped` from AgentRuntime.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run test:unit && npm run test:e2e:deterministic
+```
+Expected: 30 + 7 pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/runtime/AgentRuntime.ts
+git commit -m "feat(trace): emit tool.shaped span event when resultStrategy non-verbatim (PR-E step 4/7)"
+```
+
+(If Step 1 of this task was already applied, also revert `src/trace/types.ts`:
+```bash
+git checkout src/trace/types.ts
+git add src/trace/types.ts
+```
+and amend.)
+
+---
+
+## Task 5: Integration test demonstrating strategy applied end-to-end
+
+**Files:**
+- Create: `src/__tests__/AgentRuntime.toolResultStrategy.test.ts`
+
+**Why:** Unit-tests of `applyShape` don't catch wiring bugs. This test runs a full AgentRuntime invoke with a stub gateway + a tool that returns a large string + has `resultStrategy: truncate(50)`, then asserts the next LLM call's last message has truncated content (not the raw 1000 chars).
+
+- [ ] **Step 1: Write the test**
+
+Create `src/__tests__/AgentRuntime.toolResultStrategy.test.ts`:
+
+```typescript
+import { AgentRuntime } from '../runtime/AgentRuntime'
+import type { AgentConfig } from '../types/agent'
+import type { ToolDefinition } from '../types/tool'
+import type { ModelRequest, ModelResponse } from '../types/model'
+import { MemoryStore } from '../store/MemoryStore'
+import { DefaultIOPort } from '../runtime/IOPort'
+import { NoopRecorder } from '../trajectory/NoopRecorder'
+
+class StubGateway {
+  constructor(private readonly responses: ModelResponse[]) {}
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const r = this.responses.shift()
+    if (!r) throw new Error('exhausted')
+    return r
+  }
+  async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+
+const bigReadTool: ToolDefinition = {
+  name:        'big_read',
+  description: 'returns a large string',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  parallelSafe: true,
+  handler: async () => 'X'.repeat(5000),
+  resultStrategy: { shape: { kind: 'truncate', maxChars: 50 } },
+}
+
+const agentConfig: AgentConfig = {
+  agentId:      'truncate-tester',
+  version:      '1.0.0',
+  systemPrompt: 'test',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 5 }] },
+  model: { provider: 'stub', model: 'stub', adapter: 'openai-compatible' as const },
+}
+
+describe('AgentRuntime — ToolResultStrategy applied end-to-end', () => {
+  test('tool with truncate(50) → tool_result content in next LLM request is truncated', async () => {
+    // Capture each ModelRequest the gateway sees
+    const requestsSeen: ModelRequest[] = []
+    const gateway = {
+      complete: async (req: ModelRequest): Promise<ModelResponse> => {
+        requestsSeen.push(req)
+        // Iteration 1: ask big_read; Iteration 2: produce text
+        if (requestsSeen.length === 1) {
+          return {
+            content:   [{ type: 'tool_use', id: 'tc1', name: 'big_read', input: {} }],
+            toolCalls: [{ id: 'tc1', name: 'big_read', input: {} }],
+            finishReason: 'tool_use',
+          }
+        }
+        return {
+          content:   [{ type: 'text', text: 'done' }],
+          toolCalls: [],
+          finishReason: 'end_turn',
+        }
+      },
+      stream: async function* (_req: ModelRequest): AsyncIterable<never> { yield* [] },
+    }
+
+    const runtime = new AgentRuntime({
+      config:     agentConfig,
+      goal:       'test',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder:   new NoopRecorder(),
+      ioPort:     new DefaultIOPort(gateway as never),
+      extraTools: [bigReadTool],
+    })
+
+    const result = await runtime.run('go')
+    expect(result.status).toBe('completed')
+
+    // Iteration 2's request must include tool_result with truncated content
+    expect(requestsSeen.length).toBe(2)
+    const messagesIter2 = requestsSeen[1]!.messages
+    const toolResultMsg = messagesIter2.find(m =>
+      m.role === 'tool' && m.content.some(c => c.type === 'tool_result')
+    )
+    expect(toolResultMsg).toBeDefined()
+    const tr = toolResultMsg!.content.find(c => c.type === 'tool_result') as { content: string }
+    expect(tr.content.length).toBeLessThan(100)              // truncated, not 5000
+    expect(tr.content.startsWith('XXXX')).toBe(true)         // starts with raw X's
+    expect(tr.content.endsWith('...')).toBe(true)            // truncation marker
+  })
+
+  test('tool without resultStrategy → tool_result content unchanged (verbatim default)', async () => {
+    const verbatimTool: ToolDefinition = {
+      name:        'big_read_verbatim',
+      description: 'returns a large string',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      parallelSafe: true,
+      handler: async () => 'Y'.repeat(5000),
+      // no resultStrategy
+    }
+
+    const requestsSeen: ModelRequest[] = []
+    const gateway = {
+      complete: async (req: ModelRequest): Promise<ModelResponse> => {
+        requestsSeen.push(req)
+        if (requestsSeen.length === 1) {
+          return {
+            content:   [{ type: 'tool_use', id: 'tc1', name: 'big_read_verbatim', input: {} }],
+            toolCalls: [{ id: 'tc1', name: 'big_read_verbatim', input: {} }],
+            finishReason: 'tool_use',
+          }
+        }
+        return {
+          content:   [{ type: 'text', text: 'done' }],
+          toolCalls: [],
+          finishReason: 'end_turn',
+        }
+      },
+      stream: async function* (_req: ModelRequest): AsyncIterable<never> { yield* [] },
+    }
+
+    const runtime = new AgentRuntime({
+      config:     agentConfig,
+      goal:       'test',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder:   new NoopRecorder(),
+      ioPort:     new DefaultIOPort(gateway as never),
+      extraTools: [verbatimTool],
+    })
+
+    await runtime.run('go')
+    expect(requestsSeen.length).toBe(2)
+    const messagesIter2 = requestsSeen[1]!.messages
+    const toolResultMsg = messagesIter2.find(m =>
+      m.role === 'tool' && m.content.some(c => c.type === 'tool_result')
+    )
+    const tr = toolResultMsg!.content.find(c => c.type === 'tool_result') as { content: string }
+    expect(tr.content.length).toBe(5000)   // full passthrough
+  })
+})
+```
+
+- [ ] **Step 2: Run + verify**
+
+```bash
+npx jest src/__tests__/AgentRuntime.toolResultStrategy.test.ts
+```
+Expected: both tests pass.
+
+If imports / types are off, adapt them based on what AgentRuntime actually exports/requires. Use existing test files (`src/__tests__/AgentRuntime.test.ts`) as patterns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/AgentRuntime.toolResultStrategy.test.ts
+git commit -m "test(runtime): e2e ToolResultStrategy applied via AgentRuntime → tool_result message (PR-E step 5/7)"
+```
+
+---
+
+## Task 6: Apply truncate(2000) to agent-docs-qa read_file
+
+**Files:**
+- Modify: `examples/agent-docs-qa/tools/corpus-tools.ts`
+
+**Why:** Concretely demonstrate the fix where empirical pain was measured. read_file returns 5K-15K char chapter bodies; truncate(2000) prevents single tool result from blowing cache.
+
+- [ ] **Step 1: Add `resultStrategy` to read_file definition**
+
+Locate the read_file ToolDefinition in `examples/agent-docs-qa/tools/corpus-tools.ts`. Add:
+
+```typescript
+{
+  name:        'read_file',
+  description: '...',
+  inputSchema: { ... },
+  parallelSafe: true,
+  handler: async (...) => { ... },
+  // PR-E: chapter bodies are 5K-15K chars; truncating to 2000 keeps tool_result
+  // from blowing prefix cache (measured: 75% → 17% hit rate without this).
+  // Agent should grep first to locate; read_file gives first 2000 chars of
+  // context. For deeper passages, agent can grep again with tighter pattern.
+  resultStrategy: { shape: { kind: 'truncate', maxChars: 2000, tailHint: true } },
+},
+```
+
+- [ ] **Step 2: Update agent-docs-qa README to mention this**
+
+In `examples/agent-docs-qa/README.md`, the "Known substrate" or "Substrate notes" section should mention that `read_file` is truncated to 2000 chars to demonstrate PR-E ToolResultStrategy. If no such section exists, add a brief one.
+
+- [ ] **Step 3: Run agent-docs-qa example tests**
+
+```bash
+npx jest examples/agent-docs-qa/__tests__/
+```
+Expected: 36/36 pass. The skill-loading e2e test does NOT depend on read_file output length (just on event flow), so truncating shouldn't break it. If a test asserts on specific read_file output content, update or override resultStrategy in the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/agent-docs-qa/tools/corpus-tools.ts examples/agent-docs-qa/README.md
+git commit -m "feat(examples): agent-docs-qa read_file uses truncate(2000) (PR-E step 6/7)"
+```
+
+---
+
+## Task 7: Full suite + commit + push + PR
+
+**Files:** none
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd /Users/xupeng/dev/github/milkie
+npm run test:unit && npm run test:e2e:deterministic && npx jest 2>&1 | tail -7
+```
+Expected: all green (43 suites approximately).
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/pr-e-tool-result-strategy-phase-1
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --title "feat(tool): ToolResultStrategy Phase 1 (shape + onError) — large-result cache fix" --body "$(cat <<'EOF'
+## Summary
+
+Empirically driven follow-up to PR-D. We measured agent-docs-qa with a 5-turn doubao conversation (17 LLM calls, 63K input tokens, 36% overall cache hit rate) and found the biggest single cache-killer is large \`read_file\` tool results: a single read pushes input from 1.7K → 8K+ tokens, blowing the prefix cache (75% → 17% hit rate on that LLM call).
+
+This PR ships **Phase 1 of \`ToolResultStrategy\`** (spec §4.4) — the \`shape\` and \`onError\` axes only. Tool authors can now declare \`resultStrategy: { shape: { kind: 'truncate', maxChars: N } }\` (or \`tail\`) to keep large outputs from blowing prefix cache.
+
+## What ships (Phase 1)
+
+| Axis | Phase 1 | Phase 2+ |
+|---|---|---|
+| \`shape\` | \`'verbatim'\` (default), \`{kind:'truncate', maxChars, tailHint?}\`, \`{kind:'tail', maxChars}\` | \`summarize\` (needs LLM), \`extract\` (jsonPath), \`transform\` (escape hatch) |
+| \`onError\` | shape applied when handler throws (default \`'verbatim'\` — full error to agent) | — |
+| \`visibility\` | not shipped (always \`'inline'\` = current behavior) | \`'stored-only'\` (needs \`context_fetch\` system tool), \`first-call-then-reference\` (needs consumption tracking) |
+| \`target\` | not shipped (always \`'scratchpad'\` = current behavior) | \`'wm'\` / \`'discard'\` (need tool_use/tool_result pairing — Anthropic API rejects orphan tool_use) |
+
+Default stays \`'verbatim'\` (backward compatible — no existing tool forced to migrate).
+
+## Architectural choice: shape happens in AgentRuntime, not tool registry
+
+- Tool handler returns raw output, unchanged
+- \`RecordingIOPort\` records raw output on \`tool.responded\` event (replay correctness)
+- AgentRuntime applies shape between tool execution and scratchpad-region insertion
+- Same raw + same shape → byte-identical scratchpad content → replay-safe
+
+## Trace observability
+
+When a non-verbatim shape is applied, AgentRuntime emits a \`tool.shaped\` span event on \`llm.call\` with shape kind + rawBytes + storedBytes + onErrorPath. HTML report renders these on the trace timeline (additive, no breaking change for existing renderers).
+
+## Empirical demonstration
+
+\`examples/agent-docs-qa/tools/corpus-tools.ts\` — \`read_file\` now uses \`truncate(2000, tailHint:true)\`. Re-running the 5-turn measurement (see method below) should show:
+
+- Per-call cache hit rate after a \`read_file\` no longer crashes to 17%
+- Overall hit rate moves up from 36% toward 50%+
+- Final answer quality unchanged because grep + truncated read gives enough context for citation; agent can grep tighter if needed
+
+## Test results
+
+- Full suite: 43/43 suites, 360+ tests pass + 15 skipped
+- New tests: unit tests for \`applyShape\` (verbatim / truncate / tail / object serialization / tailHint variants); integration test demonstrating end-to-end strategy application
+
+## Test plan
+
+- [x] \`npm run test:unit && npm run test:e2e:deterministic\`
+- [x] \`npx jest examples/agent-docs-qa/__tests__/\` — 36 pass
+- [ ] Reviewer reads the architectural choice in §3 and confirms shape-in-runtime not shape-in-registry is right
+- [ ] After merge: re-run the 5-turn cache measurement on agent-docs-qa, compare hit rate to 36% baseline
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Spec coverage self-check
+
+| Spec §4.4 element | Status |
+|---|---|
+| Shape: verbatim | ✅ Task 2 |
+| Shape: truncate | ✅ Task 2 |
+| Shape: tail | ✅ Task 2 |
+| Shape: summarize | Deferred (needs LLM call inside substrate — complex) |
+| Shape: extract | Deferred (needs jsonPath impl) |
+| Shape: transform | Deferred (escape hatch — no demand) |
+| onError | ✅ Task 2/3 |
+| Visibility | Deferred to Phase 2 (\`'inline'\` only) |
+| Target | Deferred to Phase 2 (\`'scratchpad'\` only) |
+| Safe default `truncate(4000) + inline + scratchpad` | **Not adopted in Phase 1** — kept \`'verbatim'\` default for backward compatibility. PR body documents migration path. |
+| Trace `appliedStrategy` observability | ✅ Task 4 (as \`tool.shaped\` span event) |
+
+## Type consistency check
+
+- \`Shape\` defined Task 1, used in Task 2 (\`applyShape\`), Task 3 (\`shapeToolResultForLlm\`), Task 5 (test fixture). Consistent.
+- \`ToolResultStrategy\` defined Task 1 with \`shape\`/\`onError\` fields. Used in Task 3 lookup. Consistent.
+
+## Placeholder scan
+
+None — every step shows concrete code or commands.

--- a/examples/agent-docs-qa/README.md
+++ b/examples/agent-docs-qa/README.md
@@ -181,12 +181,14 @@ plus the skill lifetime model (PR-C2):
   only `(user, finalAssistant)` pairs (built at turn-end crystallization).
   No more ReAct-noise accumulation across turns.
 
+- **Tool result strategy** (PR-E step 6) — `read_file` uses `truncate(2000, tailHint:true)`
+  to keep chapter bodies (typically 5–15KB) from bloating prefix cache. Measured empirical
+  impact: 75% → 17% cache hit rate drop on a 5-turn dialogue when untruncated read_file
+  landed. Trade-off: agent gets first 2K chars + "[...truncated N chars...]" marker;
+  for deeper passages, agent should grep with tighter pattern to locate text first.
+
 Still pending in future PRs:
 
-- **Tool result strategy** (spec §4.4) — `read_file` still returns full chapter
-  bodies (10–20KB each) verbatim. The substrate has no per-tool size policy
-  yet; `ToolResultStrategy` (`shape` / `visibility` / `target` three axes) is
-  the planned fix. Tracked for a follow-up PR after Phase 5.
 - **Trace `region.added` / `region.removed` events** — the UI currently
   detects skill loads by watching `tool.requested` (toolName === 'skill_request').
   Once the substrate emits dedicated region lifecycle events (PR-D), the UI

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -106,6 +106,11 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
         required: ['relPath'],
       },
       handler: t.read_file,
+      // PR-E: chapter bodies are 5K-15K chars; truncating to 2000 keeps tool_result
+      // from blowing prefix cache (measured: 75% → 17% hit rate without this).
+      // Agent should grep first to locate; read_file gives first 2000 chars of
+      // context. For deeper passages, agent can grep again with tighter pattern.
+      resultStrategy: { shape: { kind: 'truncate' as const, maxChars: 2000, tailHint: true } },
     },
     {
       name:        'grep',

--- a/src/__tests__/AgentRuntime.toolResultStrategy.test.ts
+++ b/src/__tests__/AgentRuntime.toolResultStrategy.test.ts
@@ -1,0 +1,155 @@
+import { AgentRuntime } from '../runtime/AgentRuntime'
+import { DefaultIOPort } from '../runtime/IOPort'
+import { MemoryStore } from '../store/MemoryStore'
+import { InMemoryRecorder } from '../trajectory/InMemoryRecorder'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { ToolDefinition } from '../types/tool'
+
+// ---- Fixtures ----
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    agentId:      'truncate-tester',
+    version:      '1.0.0',
+    systemPrompt: 'test',
+    fsm: {
+      states: [{ name: 'react', type: 'llm', max_iterations: 5 }],
+    },
+    model: {
+      provider: 'stub',
+      model:    'stub',
+      adapter:  'test',
+    },
+    ...overrides,
+  }
+}
+
+/**
+ * A gateway that captures every request it sees, returns a tool_call on the
+ * first invocation, and a text response on the second.
+ */
+function makeRequestCapturingGateway(toolName: string): {
+  gateway: IModelGateway
+  requestsSeen: ModelRequest[]
+} {
+  const requestsSeen: ModelRequest[] = []
+
+  const gateway: IModelGateway = {
+    async complete(req: ModelRequest): Promise<ModelResponse> {
+      requestsSeen.push(req)
+      if (requestsSeen.length === 1) {
+        return {
+          content:      [{ type: 'tool_use', id: 'tc1', name: toolName, input: {} }],
+          toolCalls:    [{ id: 'tc1', name: toolName, input: {} }],
+          finishReason: 'tool_use',
+        }
+      }
+      return {
+        content:      [{ type: 'text', text: 'done' }],
+        toolCalls:    [],
+        finishReason: 'end_turn',
+      }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<never> {
+      yield* []
+    },
+  }
+
+  return { gateway, requestsSeen }
+}
+
+// ---- Tests ----
+
+describe('AgentRuntime — ToolResultStrategy applied end-to-end', () => {
+  test('tool with truncate(50) → tool_result content in next LLM request is truncated', async () => {
+    const bigReadTool: ToolDefinition = {
+      name:        'big_read',
+      description: 'returns a large string',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      parallelSafe: true,
+      handler: async () => 'X'.repeat(5000),
+      resultStrategy: { shape: { kind: 'truncate', maxChars: 50 } },
+    }
+
+    const { gateway, requestsSeen } = makeRequestCapturingGateway('big_read')
+
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'test',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(gateway),
+      extraTools: [bigReadTool],
+    })
+
+    const result = await runtime.run('go')
+    expect(result.status).toBe('completed')
+
+    // Two LLM calls: iteration 1 (tool call) + iteration 2 (text response)
+    expect(requestsSeen.length).toBe(2)
+
+    const messagesIter2 = requestsSeen[1]!.messages
+    const toolResultMsg = messagesIter2.find(
+      m => m.role === 'tool' && m.content.some(c => c.type === 'tool_result'),
+    )
+    expect(toolResultMsg).toBeDefined()
+
+    const tr = toolResultMsg!.content.find(c => c.type === 'tool_result') as {
+      type: 'tool_result'
+      content: string
+    }
+    expect(tr).toBeDefined()
+
+    // Truncated content must be short — not the raw 5000 chars
+    expect(tr.content.length).toBeLessThan(100)
+
+    // Starts with the repeated character and ends with the truncation indicator
+    expect(tr.content.startsWith('XXXX')).toBe(true)
+    expect(tr.content.endsWith('...')).toBe(true)
+  })
+
+  test('tool without resultStrategy → tool_result content unchanged (verbatim default)', async () => {
+    const verbatimTool: ToolDefinition = {
+      name:        'big_read_verbatim',
+      description: 'returns a large string',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      parallelSafe: true,
+      handler: async () => 'Y'.repeat(5000),
+      // no resultStrategy — defaults to verbatim
+    }
+
+    const { gateway, requestsSeen } = makeRequestCapturingGateway('big_read_verbatim')
+
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'test',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(gateway),
+      extraTools: [verbatimTool],
+    })
+
+    const result = await runtime.run('go')
+    expect(result.status).toBe('completed')
+
+    expect(requestsSeen.length).toBe(2)
+
+    const messagesIter2 = requestsSeen[1]!.messages
+    const toolResultMsg = messagesIter2.find(
+      m => m.role === 'tool' && m.content.some(c => c.type === 'tool_result'),
+    )
+    expect(toolResultMsg).toBeDefined()
+
+    const tr = toolResultMsg!.content.find(c => c.type === 'tool_result') as {
+      type: 'tool_result'
+      content: string
+    }
+    expect(tr).toBeDefined()
+
+    // Verbatim: full 5000 chars must arrive unchanged
+    expect(tr.content.length).toBe(5000)
+  })
+})

--- a/src/__tests__/toolResultStrategy.test.ts
+++ b/src/__tests__/toolResultStrategy.test.ts
@@ -1,0 +1,79 @@
+import { applyShape, serializeOutput } from '../runtime/toolResultStrategy'
+import type { Shape } from '../types/tool'
+
+describe('serializeOutput', () => {
+  test('string passes through', () => {
+    expect(serializeOutput('hello')).toBe('hello')
+  })
+  test('null → "null"', () => {
+    expect(serializeOutput(null)).toBe('null')
+  })
+  test('undefined → ""', () => {
+    expect(serializeOutput(undefined)).toBe('')
+  })
+  test('object → JSON', () => {
+    expect(serializeOutput({ a: 1 })).toBe('{"a":1}')
+  })
+})
+
+describe('applyShape — verbatim', () => {
+  test('returns serialized output as-is', () => {
+    expect(applyShape({ a: 1 }, 'verbatim')).toBe('{"a":1}')
+  })
+
+  test('long content not truncated', () => {
+    const long = 'x'.repeat(10000)
+    expect(applyShape(long, 'verbatim')).toBe(long)
+  })
+})
+
+describe('applyShape — truncate', () => {
+  test('content shorter than maxChars passes through', () => {
+    expect(applyShape('short', { kind: 'truncate', maxChars: 100 })).toBe('short')
+  })
+
+  test('content longer than maxChars cut to maxChars', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100 })
+    expect(out.length).toBeLessThanOrEqual(150)   // 100 chars + truncation marker
+    expect(out.startsWith('xxxx')).toBe(true)
+  })
+
+  test('tailHint=true appends explanatory marker about truncated bytes', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100, tailHint: true })
+    expect(out).toMatch(/\[\.\.\.truncated.*900.*chars\.\.\.\]/)
+  })
+
+  test('tailHint=false (or omitted) appends bare ellipsis marker', () => {
+    const long = 'x'.repeat(1000)
+    const out = applyShape(long, { kind: 'truncate', maxChars: 100 })
+    expect(out.endsWith('...')).toBe(true)
+  })
+
+  test('object serialized then truncated', () => {
+    const obj = { data: 'y'.repeat(1000) }
+    const out = applyShape(obj, { kind: 'truncate', maxChars: 50 })
+    expect(out.length).toBeLessThanOrEqual(100)
+    expect(out.startsWith('{"data":"yyy')).toBe(true)
+  })
+})
+
+describe('applyShape — tail', () => {
+  test('content shorter than maxChars passes through', () => {
+    expect(applyShape('short', { kind: 'tail', maxChars: 100 })).toBe('short')
+  })
+
+  test('content longer than maxChars cut to LAST maxChars', () => {
+    const content = 'A'.repeat(500) + 'B'.repeat(500)
+    const out = applyShape(content, { kind: 'tail', maxChars: 100 })
+    expect(out.endsWith('BBBB')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(150)
+  })
+
+  test('prepends ellipsis marker showing how many bytes dropped from head', () => {
+    const long = 'z'.repeat(1000)
+    const out = applyShape(long, { kind: 'tail', maxChars: 100 })
+    expect(out.startsWith('[...')).toBe(true)
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -4,7 +4,7 @@ import { MaxIterationsError } from '../types/common.js'
 import type { IStateStore, AgentCheckpoint, ChildAgentRecord } from '../types/store.js'
 import type { ITrajectoryRecorder, Span } from '../types/trajectory.js'
 import type { ToolDefinition, ToolContext, ToolResult, ToolResultStrategy } from '../types/tool.js'
-import { applyShape } from './toolResultStrategy.js'
+import { applyShape, serializeOutput } from './toolResultStrategy.js'
 import type { MessageContent } from '../types/common.js'
 import { FSMEngine } from '../fsm/FSMEngine.js'
 import { ContextRegions } from '../context/ContextRegions.js'
@@ -299,12 +299,25 @@ export class AgentRuntime {
    * executeSingleTool / RecordingIOPort); this method only shapes what goes
    * into the LLM's scratchpad message.
    */
-  private shapeToolResultForLlm(r: ToolResult): string {
+  private shapeToolResultForLlm(r: ToolResult, llmSpan: Span): string {
     const strategy = this.toolStrategyFor(r.toolName)
-    if (r.isError) {
-      return applyShape(r.error, strategy?.onError ?? 'verbatim')
+    const shape = r.isError ? (strategy?.onError ?? 'verbatim') : (strategy?.shape ?? 'verbatim')
+    const raw = r.isError ? r.error : r.output
+    const rawString = serializeOutput(raw)
+    const shaped = applyShape(raw, shape)
+
+    // Only emit tool.shaped when a non-verbatim shape actually changed bytes.
+    if (shape !== 'verbatim' && shaped.length !== rawString.length) {
+      this.recorder.recordEvent(llmSpan, 'tool.shaped', {
+        toolName:    r.toolName,
+        toolCallId:  r.toolCallId,
+        shapeKind:   typeof shape === 'object' ? shape.kind : shape,
+        rawBytes:    rawString.length,
+        storedBytes: shaped.length,
+        onErrorPath: r.isError,
+      })
     }
-    return applyShape(r.output, strategy?.shape ?? 'verbatim')
+    return shaped
   }
 
   private emitRegionDelta(delta: import('../context/ContextRegions.js').RegionChangeDelta, reason: string): void {
@@ -602,11 +615,15 @@ export class AgentRuntime {
         const results = await this.executeTools(response.toolCalls, state.tools)
         await this.checkEvents()
 
-        // Append tool results to context
+        // Append tool results to context. shapeToolResultForLlm may emit
+        // tool.shaped events on llmSpan; InMemoryRecorder.recordEvent only
+        // pushes to span.events (doesn't check endTime), so emitting after
+        // endSpan is fine — keeps llmSpan close to LLM-call boundary so
+        // sub-agent spawning (inside executeTools) sees a closed parent span.
         const toolResultContent: MessageContent[] = results.map(r => ({
           type:        'tool_result' as const,
           tool_use_id: r.toolCallId,
-          content:     this.shapeToolResultForLlm(r),
+          content:     this.shapeToolResultForLlm(r, llmSpan),
           is_error:    r.isError,
         }))
         this.appendScratchpadToolResults(toolResultContent)

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -3,7 +3,8 @@ import type { AgentResult } from '../types/common.js'
 import { MaxIterationsError } from '../types/common.js'
 import type { IStateStore, AgentCheckpoint, ChildAgentRecord } from '../types/store.js'
 import type { ITrajectoryRecorder, Span } from '../types/trajectory.js'
-import type { ToolDefinition, ToolContext, ToolResult } from '../types/tool.js'
+import type { ToolDefinition, ToolContext, ToolResult, ToolResultStrategy } from '../types/tool.js'
+import { applyShape } from './toolResultStrategy.js'
 import type { MessageContent } from '../types/common.js'
 import { FSMEngine } from '../fsm/FSMEngine.js'
 import { ContextRegions } from '../context/ContextRegions.js'
@@ -283,6 +284,27 @@ export class AgentRuntime {
   private appendScratchpadToolResults(content: MessageContent[]): void {
     const id = `scratch:${this.ioPort.uuid()}`
     this.regions.set(id, makeScratchpadToolResultRegion(content))
+  }
+
+  private toolStrategyFor(toolName: string): ToolResultStrategy | undefined {
+    return this.registry.get(toolName)?.resultStrategy
+  }
+
+  /**
+   * Apply the tool's declared resultStrategy (if any) to a single ToolResult,
+   * returning the string content that should go into the tool_result message.
+   * Default strategy is 'verbatim' (backwards compatible — pre-PR-E behavior).
+   *
+   * The raw output is recorded as-is on the tool.responded event (in
+   * executeSingleTool / RecordingIOPort); this method only shapes what goes
+   * into the LLM's scratchpad message.
+   */
+  private shapeToolResultForLlm(r: ToolResult): string {
+    const strategy = this.toolStrategyFor(r.toolName)
+    if (r.isError) {
+      return applyShape(r.error, strategy?.onError ?? 'verbatim')
+    }
+    return applyShape(r.output, strategy?.shape ?? 'verbatim')
   }
 
   private emitRegionDelta(delta: import('../context/ContextRegions.js').RegionChangeDelta, reason: string): void {
@@ -584,7 +606,7 @@ export class AgentRuntime {
         const toolResultContent: MessageContent[] = results.map(r => ({
           type:        'tool_result' as const,
           tool_use_id: r.toolCallId,
-          content:     r.error ?? JSON.stringify(r.output),
+          content:     this.shapeToolResultForLlm(r),
           is_error:    r.isError,
         }))
         this.appendScratchpadToolResults(toolResultContent)

--- a/src/runtime/toolResultStrategy.ts
+++ b/src/runtime/toolResultStrategy.ts
@@ -1,0 +1,44 @@
+import type { Shape } from '../types/tool'
+
+/**
+ * Serialize raw tool output to a string for shaping + LLM consumption.
+ * Mirrors the existing AgentRuntime.executeTools serialization
+ * (JSON.stringify for objects, string passthrough, etc) so behavior
+ * is unchanged when shape='verbatim'.
+ */
+export function serializeOutput(raw: unknown): string {
+  if (raw === undefined) return ''
+  if (typeof raw === 'string') return raw
+  return JSON.stringify(raw)
+}
+
+/**
+ * Apply a Shape to raw tool output (handler result OR error message).
+ * Pure: same (raw, shape) → same string. Replay-safe.
+ */
+export function applyShape(raw: unknown, shape: Shape): string {
+  const serialized = serializeOutput(raw)
+
+  if (shape === 'verbatim') return serialized
+
+  if (shape.kind === 'truncate') {
+    if (serialized.length <= shape.maxChars) return serialized
+    const head = serialized.slice(0, shape.maxChars)
+    const droppedChars = serialized.length - shape.maxChars
+    if (shape.tailHint) {
+      return `${head}[...truncated ${droppedChars} chars...]`
+    }
+    return `${head}...`
+  }
+
+  if (shape.kind === 'tail') {
+    if (serialized.length <= shape.maxChars) return serialized
+    const tail = serialized.slice(-shape.maxChars)
+    const droppedChars = serialized.length - shape.maxChars
+    return `[...${droppedChars} chars dropped...]${tail}`
+  }
+
+  // Exhaustiveness check — TypeScript will error if a Shape variant is added without handling
+  const _exhaustive: never = shape
+  return serializeOutput(raw)
+}

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -12,11 +12,13 @@ export interface ToolContext {
 }
 
 export interface ToolDefinition {
-  name:          string
-  description:   string
-  inputSchema:   JSONSchema
-  handler:       (input: unknown, ctx: ToolContext) => Promise<unknown>
-  parallelSafe?: boolean
+  name:            string
+  description:     string
+  inputSchema:     JSONSchema
+  handler:         (input: unknown, ctx: ToolContext) => Promise<unknown>
+  parallelSafe?:   boolean
+  /** PR-E Phase 1: how raw tool output is shaped before entering LLM context. Default verbatim. */
+  resultStrategy?: ToolResultStrategy
 }
 
 export interface ToolCall {
@@ -32,4 +34,22 @@ export interface ToolResult {
   error?:     string
   isError:    boolean
   duration:   number
+}
+
+// ---- PR-E Phase 1: Tool result shaping ----
+// Spec: docs/superpowers/specs/2026-05-25-context-region-substrate-design.md §4.4
+//
+// Phase 1 ships shape + onError axes only. visibility / target stay implicit
+// ('inline' / 'scratchpad') — those need context_fetch tool + tool_use/result
+// pairing handling, deferred to Phase 2.
+
+export type Shape =
+  | 'verbatim'
+  | { kind: 'truncate'; maxChars: number; tailHint?: boolean }
+  | { kind: 'tail';     maxChars: number }
+
+export interface ToolResultStrategy {
+  shape:    Shape
+  /** Shape applied when the tool handler throws. Default 'verbatim' (full error info to agent). */
+  onError?: Shape
 }


### PR DESCRIPTION
## Summary

Empirically driven follow-up to PR-D. We measured agent-docs-qa with a 5-turn doubao conversation (17 LLM calls, 63K input tokens, 36% overall cache hit rate) and found the single biggest cache-killer was large \`read_file\` tool results: a single read pushes input from 1.7K → 8K+ tokens, dropping the per-call hit rate from 75% to 17%.

This PR ships **Phase 1 of \`ToolResultStrategy\`** (spec §4.4) — the \`shape\` and \`onError\` axes. Tool authors can now declare \`resultStrategy: { shape: { kind: 'truncate', maxChars: N } }\` (or \`tail\`) to keep large outputs from blowing prefix cache.

## What ships (Phase 1)

| Axis | Phase 1 | Phase 2+ |
|---|---|---|
| \`shape\` | \`'verbatim'\` (default), \`{kind:'truncate', maxChars, tailHint?}\`, \`{kind:'tail', maxChars}\` | \`summarize\` (needs LLM), \`extract\` (jsonPath), \`transform\` (escape hatch) |
| \`onError\` | shape applied when handler throws (default \`'verbatim'\` — full error to agent) | — |
| \`visibility\` | not shipped (always \`'inline'\` = current behavior) | \`'stored-only'\` (needs \`context_fetch\` system tool), \`first-call-then-reference\` (needs consumption tracking) |
| \`target\` | not shipped (always \`'scratchpad'\` = current behavior) | \`'wm'\` / \`'discard'\` (need tool_use/tool_result pairing handling — Anthropic API rejects orphan tool_use) |

Default stays \`'verbatim'\` (backward compatible — no existing tool forced to migrate).

## Architectural choice: shape happens in AgentRuntime, not tool registry

- Tool handler returns raw output, unchanged
- \`RecordingIOPort\` records raw output on \`tool.responded\` event (replay correctness)
- AgentRuntime applies shape between tool execution and scratchpad-region insertion
- Same raw + same shape → byte-identical scratchpad content → replay-safe

## Trace observability

When a non-verbatim shape actually changes byte count, AgentRuntime emits a \`tool.shaped\` span event on \`llm.call\` with \`shapeKind\` + \`rawBytes\` + \`storedBytes\` + \`onErrorPath\`. Useful for trace inspection — agent designers can see "this tool returned 12KB raw → stored 1KB after truncate(2000)".

## Empirical demonstration

\`examples/agent-docs-qa/tools/corpus-tools.ts\` — \`read_file\` now uses \`truncate(2000, tailHint:true)\`. Re-running the 5-turn measurement (method documented in chat history) should show:

- Per-call cache hit rate after a \`read_file\` no longer crashes to 17%
- Overall hit rate moves up from 36% baseline toward 50%+
- Final answer quality unchanged — grep + truncated read gives enough context for citation; agent can grep tighter if needed

agent-docs-qa README \"Substrate notes\" section updated to document the trade-off.

## Test results

- Full suite: **43/43 suites, 371 tests pass + 15 skipped**
- New tests:
  - \`src/__tests__/toolResultStrategy.test.ts\` — 14 unit tests for \`serializeOutput\` + \`applyShape\` (verbatim / truncate / tail / tailHint / object serialization / edge cases)
  - \`src/__tests__/AgentRuntime.toolResultStrategy.test.ts\` — 2 integration tests demonstrating end-to-end strategy application via stub gateway

## Notes from implementation

- Task 4 (\`tool.shaped\` span event) initially moved \`endSpan(llmSpan)\` AFTER tool result shaping out of misplaced caution; this broke s-007's sub-agent traceId assertions because keeping the parent span open during sub-agent spawn affected child trace context. Reverted — \`InMemoryRecorder.recordEvent\` only pushes to \`span.events\` (no endTime check), so emitting events on a closed span works fine.

## Test plan

- [x] \`npm run test:unit && npm run test:e2e:deterministic\`
- [x] \`npx jest examples/agent-docs-qa/__tests__/\` — 36/36 pass
- [x] Full \`npx jest\` — 43/43 suites, 371 tests pass
- [ ] Reviewer reads the architectural choice (shape-in-runtime not shape-in-registry)
- [ ] After merge: re-run the 5-turn cache measurement on agent-docs-qa, compare hit rate to the 36% baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)