### PR TITLE
docs: two-tier memory pattern (arch note + roadmap entry)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -509,6 +509,26 @@ materializes, `ContextRegions` stays where it is — Agent Runtime would
 populate regions from values the external Context Layer delivers,
 instead of constructing them itself.
 
+**Two-tier memory pattern.** When the external Context Layer
+materializes, "memory" naturally splits into two tiers by how it
+surfaces to the LLM:
+
+- **Layer 1: in-context (WM-style).** Small, always-relevant state —
+  current intent, current plan, last decision. Rendered into every
+  LLM request via the `wm` region. Should be **session-stable** to
+  preserve prefix cache; mutations during a session cost cache hits.
+- **Layer 2: external (tool-mediated).** Large, occasionally-relevant
+  state — research findings, conversation summaries, user preferences,
+  long task state. Persisted out-of-band; LLM accesses via
+  `memory_read` / `memory_search` / `memory_write` tools. Tool results
+  enter scratchpad (turn-local), not the in-context WM region.
+
+Today only Layer 1 exists (`src/store/WorkingMemory.ts` + `wm` region).
+Layer 2 — `IMemoryStore` interface + memory tool surface — is
+roadmap.md "Memory tools (Layer 2)" and is one of the natural ways the
+external Context Layer's "memory lookup" responsibility could be
+prototyped before the full external infrastructure arrives.
+
 The substrate's full design spec lives at
 `docs/superpowers/specs/2026-05-25-context-region-substrate-design.md`.
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -257,11 +257,54 @@ turned into a parallel facade and violates invariant 12.
 
 ### External Context Layer / Data / Execution / Foundation (target)
 
-Today `src/context/ContextLayer.ts` is an internal class. The target
-architecture pushes it outside the milkie boundary; same with Data /
-Execution / Foundation. These migrations are intentionally not phased
-yet — they need a concrete consumer (e.g. KWeaver integration) to define
-the external interface shape. Until then the internal shim stays.
+Today there is no external Context Layer / Data / Execution / Foundation
+infrastructure. After PR-C1 the old `src/context/ContextLayer.ts` shim
+is gone — replaced by `ContextRegions` + `assemble` + lifecycle engine,
+which form an in-Agent **context management** discipline (not a Context
+Layer substitute; see ARCHITECTURE.md §Context Layer for the
+distinction). The target architecture still pushes Context Layer / Data
+/ Execution outside the milkie boundary as separate services; that
+migration is intentionally not phased yet — it needs a concrete
+consumer (e.g. KWeaver integration) to define the external interface
+shape.
+
+### Memory tools (Layer 2 external memory)
+
+**Goal.** Give agents a `memory_read` / `memory_write` / `memory_list`
+/ `memory_search` tool surface backed by an `IMemoryStore` interface
+(in-memory / SQLite / Redis implementations). Persists state out-of-band
+so it does not enter every LLM request; agent retrieves selectively.
+
+**Why a separate item.** The in-context WM (`src/store/WorkingMemory.ts`
++ `wm` region) is Layer 1 — small, always-rendered state. Layer 2 is
+the external memory tier described in ARCHITECTURE.md §Context Layer
+"Two-tier memory pattern". Today only Layer 1 exists; Layer 2 is the
+in-Agent precursor to what the future external Context Layer's
+"memory lookup" responsibility would deliver.
+
+**Estimated scope.** ~400 LOC + example. `IMemoryStore` interface,
+`InMemoryMemoryStore` + `SQLiteMemoryStore` implementations, 4 tools
+under `src/tools/memory.ts`, `ToolContext.memoryStore?` injection,
+unit tests, a heavy-WM example (e.g. todo agent) demonstrating
+cross-turn / cross-session persistence.
+
+**Trigger to actually do it.** Any of:
+- An agent on milkie needs stateful memory that exceeds the
+  in-context WM size budget (a few KB)
+- An agent needs cross-session persistence (state survives process
+  restart / different contextId)
+- A real workload appears that wants RAG-style memory_search and is
+  willing to bring an embedding backend
+- Two-tier memory becomes a recurring teaching point worth shipping
+
+Until one of those triggers, this stays deferred — making it real
+without a consumer would be speculative substrate.
+
+**Relationship to External Context Layer.** Doing memory tools first
+prototypes one slice of the future Context Layer's responsibility
+in-Agent. When the external interface arrives, `IMemoryStore` impl
+can point at the external memory service; agent / tool code stays
+the same.
 
 ---
 


### PR DESCRIPTION
## Summary

Captures the in-chat design discussion about two-tier memory architecture (WM-in-context as Layer 1 vs external memory tools as Layer 2). 2 files, +68 / -5.

## ARCHITECTURE.md

Adds a "Two-tier memory pattern" paragraph in §Context Layer Implementation note. Distinguishes:

- **Layer 1: in-context (WM-style)** — small, always-rendered state (current intent, plan, last decision); should be session-stable to preserve prefix cache
- **Layer 2: external (tool-mediated)** — large, occasionally-relevant state (research findings, conversation summaries, long task state); accessed via \`memory_read\` / \`memory_search\` / \`memory_write\` tools; results enter scratchpad (turn-local), not the in-context WM region

Today only Layer 1 exists. The note positions Layer 2 as an in-Agent prototype of what the future external Context Layer's "memory lookup" responsibility would deliver.

## roadmap.md

Two changes:

1. **Fix stale ref** — §External Context Layer section still referred to \`src/context/ContextLayer.ts\` as "an internal class". That file was deleted in PR-C1. Updated to reflect the post-PR-C1 reality.

2. **New §Memory tools (Layer 2)** — explicit deferred entry with:
   - Goal: 4 memory tools + \`IMemoryStore\` interface + heavy-WM example
   - Scope estimate: ~400 LOC + example
   - **Explicit trigger list** to avoid perpetual-TODO failure mode: any of (a) agent needs stateful memory exceeding in-context WM budget, (b) cross-session persistence, (c) RAG-style memory_search demand, (d) two-tier memory becomes recurring teaching point. Until one of those triggers, stays deferred.
   - Relationship to External Context Layer: doing memory tools first prototypes one slice in-Agent; when external interface arrives, \`IMemoryStore\` impl can point at external service.

## Why not implement now

Discussed in chat. agent-docs-qa shows the WM volatility problem doesn't yet bite (no agent writes WM). Implementing memory tools without a consumer is speculative substrate. Roadmap entry captures the design intent; arch note captures the contract; implementation waits for trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)