### PR TITLE
fix(gateway): AnthropicAdapter extracts cache_read/creation_input_tokens

### DIFF
--- a/src/__tests__/AnthropicAdapter.test.ts
+++ b/src/__tests__/AnthropicAdapter.test.ts
@@ -1,9 +1,14 @@
 import { AnthropicAdapter } from '../gateway/AnthropicAdapter'
-import type { ModelRequest } from '../types/model'
+import type { ModelRequest, ModelResponse } from '../types/model'
 
 // buildParams is private. We exercise it via cast — no network call.
 function buildParamsOf(adapter: AnthropicAdapter, request: ModelRequest): Record<string, unknown> {
   return (adapter as unknown as { buildParams(r: ModelRequest): Record<string, unknown> }).buildParams(request)
+}
+
+// parseResponse is private. Same trick — feed it the raw shape Anthropic returns.
+function parseResponseOf(adapter: AnthropicAdapter, raw: unknown): ModelResponse {
+  return (adapter as unknown as { parseResponse(r: unknown): ModelResponse }).parseResponse(raw)
 }
 
 describe('AnthropicAdapter — cacheBreakpoint translation', () => {
@@ -55,5 +60,96 @@ describe('AnthropicAdapter — cacheBreakpoint translation', () => {
       { type: 'text', text: 'sys', cache_control: { type: 'ephemeral' } },
     ])
     expect(params['tools']).toHaveLength(1)
+  })
+})
+
+describe('AnthropicAdapter — response usage extraction', () => {
+  const adapter = new AnthropicAdapter({ apiKey: 'sk-test' })
+
+  // Base shape modeled on a real anthropic Message response.
+  const baseRaw = {
+    content: [{ type: 'text' as const, text: 'hi' }],
+    stop_reason: 'end_turn' as const,
+  }
+
+  test('extracts input + output tokens (no cache fields)', () => {
+    const resp = parseResponseOf(adapter, {
+      ...baseRaw,
+      usage: { input_tokens: 1000, output_tokens: 50 },
+    })
+    expect(resp.usage).toEqual({ inputTokens: 1000, outputTokens: 50 })
+  })
+
+  // Regression: AnthropicAdapter previously read only input/output tokens and
+  // dropped cache_read_input_tokens / cache_creation_input_tokens. As a result
+  // even when the request used cacheBreakpoint:'system-end' and Anthropic
+  // honored it, the trace's cacheStats showed up as undefined — the UI badge
+  // had no way to surface "cache substrate engaged". These two tests assert
+  // both numbers reach ModelUsage so the trace pipeline can build cacheStats.
+  test('extracts cache_read_input_tokens into cacheReadTokens', () => {
+    const resp = parseResponseOf(adapter, {
+      ...baseRaw,
+      usage: {
+        input_tokens:              1200,
+        output_tokens:             80,
+        cache_read_input_tokens:   800,
+      },
+    })
+    expect(resp.usage).toEqual({
+      inputTokens:      1200,
+      outputTokens:     80,
+      cacheReadTokens:  800,
+    })
+  })
+
+  test('extracts cache_creation_input_tokens into cacheCreationTokens', () => {
+    const resp = parseResponseOf(adapter, {
+      ...baseRaw,
+      usage: {
+        input_tokens:                  1500,
+        output_tokens:                 60,
+        cache_creation_input_tokens:   750,
+      },
+    })
+    expect(resp.usage).toEqual({
+      inputTokens:          1500,
+      outputTokens:         60,
+      cacheCreationTokens:  750,
+    })
+  })
+
+  test('extracts both cache fields when present in same response', () => {
+    const resp = parseResponseOf(adapter, {
+      ...baseRaw,
+      usage: {
+        input_tokens:                 2000,
+        output_tokens:                100,
+        cache_read_input_tokens:      1200,
+        cache_creation_input_tokens:  400,
+      },
+    })
+    expect(resp.usage).toEqual({
+      inputTokens:          2000,
+      outputTokens:         100,
+      cacheReadTokens:      1200,
+      cacheCreationTokens:  400,
+    })
+  })
+
+  test('treats null cache_*_input_tokens as absent', () => {
+    // Anthropic returns null (not 0) for these fields when the request had
+    // no cache_control marker. We should NOT report them as 0 — that would
+    // bias hit rate calculations and signal "cache subsystem engaged" when
+    // it wasn't. Absent === not engaged.
+    const resp = parseResponseOf(adapter, {
+      ...baseRaw,
+      usage: {
+        input_tokens:                  500,
+        output_tokens:                 30,
+        cache_read_input_tokens:       null,
+        cache_creation_input_tokens:   null,
+      },
+    })
+    expect(resp.usage).toEqual({ inputTokens: 500, outputTokens: 30 })
   })
 })

--- a/src/gateway/AnthropicAdapter.ts
+++ b/src/gateway/AnthropicAdapter.ts
@@ -120,9 +120,25 @@ export class AnthropicAdapter implements IModelGateway {
       }
     }
 
+    // Anthropic reports cache_read_input_tokens / cache_creation_input_tokens
+    // alongside input_tokens whenever the request used cache_control markers
+    // (either via milkie's cacheBreakpoint plumbing or set externally). The
+    // raw API types in older @anthropic-ai/sdk versions don't always declare
+    // these fields, so read defensively through an unknown cast.
+    const rawUsage = raw.usage as {
+      input_tokens:                  number
+      output_tokens:                 number
+      cache_read_input_tokens?:      number | null
+      cache_creation_input_tokens?:  number | null
+    }
+    const cacheReadTokens     = rawUsage.cache_read_input_tokens     ?? undefined
+    const cacheCreationTokens = rawUsage.cache_creation_input_tokens ?? undefined
+
     const usage: ModelUsage = {
-      inputTokens:  raw.usage.input_tokens,
-      outputTokens: raw.usage.output_tokens,
+      inputTokens:  rawUsage.input_tokens,
+      outputTokens: rawUsage.output_tokens,
+      ...(cacheReadTokens     !== undefined ? { cacheReadTokens }     : {}),
+      ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
     }
 
     return { content, toolCalls, usage, finishReason: raw.stop_reason ?? undefined, raw }


### PR DESCRIPTION
## Summary

`AnthropicAdapter.parseResponse` was reading only `input_tokens` and `output_tokens` from `raw.usage`, dropping `cache_read_input_tokens` and `cache_creation_input_tokens`. As a result, even when a request used `cacheBreakpoint: 'system-end'` (which the adapter does correctly translate into a `cache_control: ephemeral` block on the system slot), the trace's `cacheStats` showed up as `undefined` and downstream consumers — HTML report, playground UI, observability dashboards — had no way to surface whether the cache substrate was actually engaging.

End-to-end: the cache pipeline was producing the right behavior on Anthropic but was end-to-end blind to itself.

Fix: read both fields defensively (older `@anthropic-ai/sdk` versions don't declare them in the typed `Message` shape) and populate the corresponding `ModelUsage.cacheReadTokens` / `cacheCreationTokens` optional fields. Treat `null` as absent so the trace doesn't falsely report "cache subsystem engaged with 0 tokens" for plain (no `cache_control`) requests — that would skew hit-rate calculations.

Adds 5 response-side `parseResponse` tests:
- baseline (no cache fields → only input/output reported)
- cache_read only (warm-up: prior call seeded cache, this call read it)
- cache_creation only (cold: this call seeded but read nothing)
- both present (typical after-marker-warm-up call)
- explicit nulls treated as absent (the cold/no-marker case)

These cover the round-trip the original tests missed. The original `AnthropicAdapter — cacheBreakpoint translation` describe block tested **only the request-side translation** (cacheBreakpoint → cache_control); response-side extraction had zero coverage, which is exactly why this bug shipped.

## Test plan

- [x] `npx jest src/__tests__/AnthropicAdapter.test.ts` — 9/9 pass (4 original + 5 new)
- [x] Full suite: `npx jest` — 43/43 suites, 382 tests pass + 15 skipped (no regressions)

## Discovery context

Found while building a cache-health badge on a playground UI. A `0/0/1.2k tok` cacheStats payload made it obvious that something upstream wasn't populating cache numbers even after the request had clearly used `cache_control`. JSONL inspection of real runs confirmed: doubao-via-volcengine (OpenAICompatibleAdapter) reported cacheReadTokens correctly via `prompt_tokens_details.cached_tokens`; Anthropic-routed runs would have shown all undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)