### PR TITLE
feat(trace): emit skill lifecycle events

### DIFF
--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -15,6 +15,7 @@ import type {
   ToolRequestedPayload,
   ToolRespondedPayload,
   FsmTransitionPayload,
+  SkillLifecyclePayload,
 } from '../trace/types'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
@@ -62,6 +63,12 @@ const textResponse = (text: string): ModelResponse => ({
   content:      [{ type: 'text', text }],
   toolCalls:    [],
   finishReason: 'end_turn',
+})
+
+const toolCallResponse = (id: string, name: string, input: unknown): ModelResponse => ({
+  content:      [{ type: 'tool_use', id, name, input }],
+  toolCalls:    [{ id, name, input }],
+  finishReason: 'tool_use',
 })
 
 const sampleRequest: ModelRequest = {
@@ -348,6 +355,48 @@ describe('RecordingIOPort — Phase 3 additions', () => {
     expect(startedEvt).toBeDefined()
     expect(kinds[kinds.length - 1]).toBe('agent.run.completed')
     expect((startedEvt!.payload as { agentId: string }).agentId).toBe('a1')
+  })
+
+  it('records skill.loaded and skill.unloaded lifecycle events with version provenance', async () => {
+    const store = new MemoryEventStore()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('skill-1', 'skill_request', { name: 'research' }),
+        textResponse('done with research'),
+      ]),
+      eventStore: store,
+    })
+    milkie.registerAgent({
+      ...minimalAgentConfig('test-agent'),
+      fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 3 }] },
+      skills: { research: '1.0.0' },
+      skillInstructions: { research: 'Research skill instructions' },
+    })
+
+    const result = await milkie.invoke({ agentId: 'test-agent', goal: 'g', input: 'i' })
+
+    const events = await store.readByRunId(result.agentRunId)
+    const loaded = events.find(e => e.type === 'skill.loaded')!
+    const unloaded = events.find(e => e.type === 'skill.unloaded')!
+    expect(loaded).toBeDefined()
+    expect(unloaded).toBeDefined()
+    const loadedIndex = events.findIndex(e => e.type === 'skill.loaded')
+    const requestedWithSkillIndex = events.findIndex(e =>
+      e.type === 'llm.requested'
+      && ((e.payload as LlmRequestedPayload).request.system ?? '').includes('Research skill instructions')
+    )
+    expect(requestedWithSkillIndex).toBeGreaterThan(-1)
+    expect(loadedIndex).toBeLessThan(requestedWithSkillIndex)
+
+    const loadedPayload = loaded.payload as SkillLifecyclePayload
+    expect(loadedPayload).toMatchObject({
+      skillId: 'skill:research',
+      version: '1.0.0',
+      source:  'agent-config.skillInstructions',
+    })
+    expect(loadedPayload.sha).toMatch(/^[a-f0-9]{64}$/)
+    expect(unloaded.payload).toEqual(loaded.payload)
   })
 })
 

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
+import { createHash } from 'crypto'
 import type { AgentConfig, FSMState } from '../types/agent.js'
 import type { AgentResult } from '../types/common.js'
 import { MaxIterationsError } from '../types/common.js'
@@ -31,6 +32,7 @@ import type { IIOPort } from './IOPort.js'
 import { cognitiveTools } from '../tools/cognitive.js'
 import { systemTools } from '../tools/system.js'
 import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
+import type { SkillLifecyclePayload } from '../trace/types.js'
 
 export interface AgentRuntimeOptions {
   config:            AgentConfig
@@ -53,6 +55,13 @@ export interface AgentRuntimeOptions {
   extraTools?:       ToolDefinition[]
   subAgentConfigs?:  Map<string, AgentConfig>  // agentId → config, for spawning
   childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
+}
+
+type SkillLoadRequest = {
+  name:         string
+  instructions: string
+  scope:        'turn' | 'session'
+  lifecycle:    SkillLifecyclePayload
 }
 
 export class AgentRuntime {
@@ -78,7 +87,8 @@ export class AgentRuntime {
 
   private eventQueue:    Array<{ type: string; payload: unknown }> = []
   private pendingEvents: Array<{ type: string; payload: unknown }> = []
-  private pendingSkillLoads: Array<{ name: string; instructions: string; scope: 'turn' | 'session' }> = []
+  private pendingSkillLoads: Array<SkillLoadRequest> = []
+  private loadedSkills: Map<string, SkillLifecyclePayload> = new Map()
   private childRecords: Map<string, ChildAgentRecord> = new Map()
   private rootSpan!:     Span
   private turnNumber:    number = 0
@@ -285,22 +295,49 @@ export class AgentRuntime {
     if (!version || !instructions) {
       return { requested: name, status: 'unavailable' }
     }
-    this.pendingSkillLoads.push({ name: normalized, instructions, scope })
+    this.pendingSkillLoads.push({
+      name: normalized,
+      instructions,
+      scope,
+      lifecycle: this.buildSkillLifecyclePayload(normalized, version, instructions),
+    })
     return { requested: normalized, status: 'pending_next_epoch', version, scope }
   }
 
   private applyPendingSkills(): void {
-    for (const { name, instructions, scope } of this.pendingSkillLoads) {
+    for (const { name, instructions, scope, lifecycle } of this.pendingSkillLoads) {
       const id = `skill:${name}`
-      // Already loaded? Skip (preserves createdAt; idempotent like Map.set upsert).
-      // Note: this means re-requesting with a different scope is a no-op — the
-      // first request wins. Acceptable trade-off; agents that need to "upgrade"
-      // a turn-scoped skill to session would have to release first (not currently
-      // possible — release intentionally absent per spec §4.3 rationale).
-      if (this.regions.get(id)) continue
+      const existing = this.regions.get(id)
+      const previous = this.loadedSkills.get(id) ?? this.lifecycleFromExistingSkill(id, existing)
+      // Same version already loaded: preserve createdAt and keep repeated
+      // skill_request idempotent.
+      if (existing && previous?.version === lifecycle.version) continue
+      if (existing && previous) {
+        this.emitSkillLifecycle('skill.unloaded', previous)
+      }
+      this.loadedSkills.set(id, lifecycle)
       this.regions.set(id, makeSkillRegion(name, instructions, scope))
+      this.emitSkillLifecycle('skill.loaded', lifecycle)
     }
     this.pendingSkillLoads = []
+  }
+
+  private buildSkillLifecyclePayload(name: string, version: string, instructions: string): SkillLifecyclePayload {
+    return {
+      skillId: `skill:${name}`,
+      version,
+      source:  'agent-config.skillInstructions',
+      sha:     createHash('sha256').update(instructions).digest('hex'),
+    }
+  }
+
+  private lifecycleFromExistingSkill(id: string, existing: ReturnType<ContextRegions['get']>): SkillLifecyclePayload | undefined {
+    if (!existing || !id.startsWith('skill:')) return undefined
+    const name = id.slice('skill:'.length)
+    const version = this.config.skills?.[name]
+    const instructions = (existing.content as { instructions?: unknown }).instructions
+    if (!version || typeof instructions !== 'string') return undefined
+    return this.buildSkillLifecyclePayload(name, version, instructions)
   }
 
   private setCurrentTurn(input: string): void {
@@ -384,6 +421,29 @@ export class AgentRuntime {
         payload:   delta.kind === 'added'
           ? { id: delta.id, target: delta.target ?? 'system', section: delta.section ?? 'unknown', stability: delta.stability ?? 'volatile', reason }
           : { id: delta.id, reason },
+      })
+    }
+
+    if (delta.kind === 'removed' && delta.id.startsWith('skill:')) {
+      const lifecycle = this.loadedSkills.get(delta.id)
+      if (lifecycle) {
+        this.emitSkillLifecycle('skill.unloaded', lifecycle)
+        this.loadedSkills.delete(delta.id)
+      }
+    }
+  }
+
+  private emitSkillLifecycle(type: 'skill.loaded' | 'skill.unloaded', payload: SkillLifecyclePayload): void {
+    if (!this.rootSpan) return
+    this.recorder.recordEvent(this.rootSpan, type, { ...payload })
+    if (this.eventStore) {
+      void this.eventStore.append({
+        id:        uuidv4(),
+        runId:     this.agentRunId,
+        type,
+        actor:     this.config.agentId,
+        timestamp: Date.now(),
+        payload,
       })
     }
   }
@@ -525,6 +585,13 @@ export class AgentRuntime {
     this.turnNumber = checkpoint.sequence
     // Re-attach format functions dropped by JSON serialization.
     this.regions.restore(rehydrateSnapshot(checkpoint.context.regions))
+    this.loadedSkills = new Map()
+    for (const r of this.regions._allRegions()) {
+      if (r.id.startsWith('skill:')) {
+        const lifecycle = this.lifecycleFromExistingSkill(r.id, r)
+        if (lifecycle) this.loadedSkills.set(r.id, lifecycle)
+      }
+    }
     const restoredMemory = WorkingMemory.fromJSON(checkpoint.context.workingMemory)
     Object.assign(this.memory, restoredMemory)
     this.fsm.restore(checkpoint.fsm)

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -19,6 +19,8 @@ export type EventKind =
   | 'region.removed'
   | 'context.boundary.applied'
   | 'fsm.transition'
+  | 'skill.loaded'
+  | 'skill.unloaded'
 
 export interface Event<P = unknown> {
   id: string
@@ -134,6 +136,15 @@ export interface ContextBoundaryAppliedPayload {
   }
 }
 
+// ---- Skill lifecycle payloads (#22) ----
+
+export interface SkillLifecyclePayload {
+  skillId: string
+  version: string
+  source:  string
+  sha?:    string
+}
+
 // ---- FSM payloads (#21) ----
 
 /**
@@ -174,6 +185,8 @@ export type RegionAddedEvent        = Event<RegionAddedPayload>        & { type:
 export type RegionRemovedEvent      = Event<RegionRemovedPayload>      & { type: 'region.removed' }
 export type ContextBoundaryAppliedEvent = Event<ContextBoundaryAppliedPayload> & { type: 'context.boundary.applied' }
 export type FsmTransitionEvent     = Event<FsmTransitionPayload>     & { type: 'fsm.transition' }
+export type SkillLoadedEvent       = Event<SkillLifecyclePayload>    & { type: 'skill.loaded' }
+export type SkillUnloadedEvent     = Event<SkillLifecyclePayload>    & { type: 'skill.unloaded' }
 
 export type AnyEvent =
   | LlmRequestedEvent
@@ -188,3 +201,5 @@ export type AnyEvent =
   | RegionRemovedEvent
   | ContextBoundaryAppliedEvent
   | FsmTransitionEvent
+  | SkillLoadedEvent
+  | SkillUnloadedEvent


### PR DESCRIPTION
## Summary
- Add skill.loaded and skill.unloaded trace event kinds and payload typing
- Emit skill lifecycle events from AgentRuntime skill load/unload paths
- Cover lifecycle event ordering and provenance in trace tests

## Validation
- npm run build -- --pretty false
- npx jest src/__tests__/Trace.test.ts tests/e2e/deterministic.test.ts --runInBand
- npm run test:unit
- npm run test:e2e:deterministic

Closes #22