### PR TITLE
feat(trace): event-sourced region context reconstruction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,6 +183,27 @@ payload describing which Regions were included, dropped, or compressed.
 *Not:* the request itself. The boundary is the *policy* that produces the
 request; the request lives in the subsequent `llm.requested` payload.
 
+### Event-sourced runtime state
+
+Runtime state used for observability, diagnosis, replay, fork, and lineage is
+reconstructed from the append-only event log plus content-addressed object
+stores. Snapshots may exist as checkpoints, resume artifacts, or acceleration
+indexes, but they are derived artifacts, not canonical truth.
+
+For context Regions specifically, `region.added` / `region.removed` Events
+describe lifecycle changes, while content hashes point to immutable Region
+content objects. A "context at Event X" view is produced by folding those
+Events up to X. Persisting complete `ContextRegions` snapshots at every
+moment is not the model; if a snapshot is used to speed up a query, it must be
+rebuildable from the event log plus the content-addressed store.
+
+*Example:* a trace inspector reconstructs the active Region map before an
+`llm.requested` Event by folding prior Region lifecycle Events and fetching
+their content by hash.
+*Not:* checkpoint restore. Checkpoints are runtime recovery artifacts; they
+may contain Region snapshots, but they are not the audit source for explaining
+historical context.
+
 ### IOPort
 
 The single chokepoint through which the runtime crosses into nondeterminism
@@ -218,6 +239,7 @@ subsystems (Agent Runtime, Agent Trace, Evolution) sit below them.
 | **IOPort** vs **Event** | IOPort is the nondet boundary. Events are its recorded outputs. |
 | **Region** vs **`region.added` Event** | The Region is context state. The Event is the record that the state changed. |
 | **Context boundary** vs **LLM request** | The boundary is the policy that selects/orders Regions. The request is its serialized output. |
+| **Snapshot** vs **Event-sourced view** | A snapshot is a checkpoint or acceleration artifact. The view is derived from Events plus content-addressed objects and remains reconstructable without the snapshot. |
 
 ---
 
@@ -355,6 +377,11 @@ production artifact.
   capturing clock reads, UUIDs, random values, tool outputs, and other
   external I/O results, so replay can reuse recorded values rather than
   re-sampling the world.
+- **Region content store** — a content-addressed object store for Region
+  content and, where needed, rendered Region output. Region lifecycle Events
+  carry hashes into this store; context-at-time and why-this-call queries fold
+  the event log and dereference those hashes rather than reading live runtime
+  state or relying on per-moment full snapshots.
 - **Replay / Fork / Diff** — replay folds the event log back into runtime
   state; fork branches a run at any event, sharing the prefix from cache (no
   new model calls for the shared history); diff compares two runs structurally.

--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -3,6 +3,8 @@ import { DefaultIOPort } from '../runtime/IOPort'
 import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
 import { InMemoryRecorder } from '../trajectory/InMemoryRecorder'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { MemoryTraceObjectStore } from '../trace/TraceObjectStore'
 import type { AgentConfig } from '../types/agent'
 import type { AgentCheckpoint } from '../types/store'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
@@ -316,6 +318,57 @@ describe('AgentRuntime', () => {
       expect(result.output).toBe('resumed')
       expect(result.agentRunId).toBe('run-original')
       expect(result.contextId).toBe('ctx-original')
+    })
+
+    it('records resume crystallization region removals after loading a checkpoint', async () => {
+      const stateStore = new MemoryStore()
+      const eventStore = new MemoryEventStore()
+      const checkpoint: AgentCheckpoint = {
+        checkpointId: 'cp-1',
+        sequence:     1,
+        goal:         'resume goal',
+        currentTurn:  'previous turn',
+        fsm:          { currentState: 'paused', resumeState: 'react', stateData: null },
+        context: {
+          workingMemory: { data: {}, log: [] },
+          regions: {
+            epoch: 1,
+            regions: [{
+              id:        'current-turn',
+              target:    'message',
+              section:   'current-turn',
+              createdAt: 1,
+              intraTurn: 'turn-persistent',
+              interTurn: 'turn-local',
+              stability: 'volatile',
+              content:   'previous turn',
+            } as never],
+          },
+        },
+        pendingEvents: [],
+        children:      [],
+        meta: {
+          agentId:    'test-agent',
+          agentRunId: 'run-original',
+          timestamp:  Date.now(),
+          traceId:    'trace-original',
+          contextId:  'ctx-original',
+        },
+      }
+      await stateStore.set('checkpoint-key', checkpoint)
+
+      const milkie = new Milkie({
+        stateStore,
+        eventStore,
+        traceObjectStore: new MemoryTraceObjectStore(),
+        gateway: new SequentialGateway([textResponse('resumed')]),
+      })
+      milkie.registerAgent(makeConfig())
+
+      const result = await milkie.resume('checkpoint-key', 'test-agent', 'resume goal', 'continue')
+      const events = await eventStore.readByRunId(result.agentRunId)
+
+      expect(events.some(e => e.type === 'region.removed' && (e.payload as { id?: string }).id === 'current-turn')).toBe(true)
     })
 
     it('propagates parent interrupt to running sub-agents and records child checkpoints', async () => {

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -4,6 +4,8 @@ import path from 'path'
 
 import { MemoryEventStore } from '../trace/MemoryEventStore'
 import { JsonlEventStore } from '../trace/JsonlEventStore'
+import { FileTraceObjectStore, MemoryTraceObjectStore } from '../trace/TraceObjectStore'
+import { contextBefore, getRegionAt } from '../trace/RegionContextView'
 import { RecordingIOPort } from '../trace/RecordingIOPort'
 import { DefaultIOPort } from '../runtime/IOPort'
 import { Milkie } from '../runtime/Milkie'
@@ -15,6 +17,7 @@ import type {
   ToolRequestedPayload,
   ToolRespondedPayload,
   FsmTransitionPayload,
+  RegionAddedPayload,
 } from '../trace/types'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
@@ -137,6 +140,61 @@ describe('JsonlEventStore', () => {
     await store.append(makeEvent())
     const stat = await fs.stat(nested)
     expect(stat.isDirectory()).toBe(true)
+  })
+})
+
+// ---- TraceObjectStore / region context reconstruction ----
+
+describe('TraceObjectStore', () => {
+  it('deduplicates identical canonical bytes and reads them by content hash', async () => {
+    const store = new MemoryTraceObjectStore()
+
+    const h1 = await store.putCanonical('{"a":1}')
+    const h2 = await store.putCanonical('{"a":1}')
+
+    expect(h1).toBe(h2)
+    expect(await store.getCanonical(h1)).toBe('{"a":1}')
+  })
+
+  it('FileTraceObjectStore round-trips canonical bytes across instances', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'milkie-objects-'))
+    try {
+      const writer = new FileTraceObjectStore(dir)
+      const hash = await writer.putCanonical('{"name":"research"}')
+
+      const reader = new FileTraceObjectStore(dir)
+      expect(await reader.getCanonical(hash)).toBe('{"name":"research"}')
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reconstructs context regions from region lifecycle events plus object store', async () => {
+    const objects = new MemoryTraceObjectStore()
+    const h1 = await objects.putCanonical('"v1"')
+    const h2 = await objects.putCanonical('"v2"')
+
+    const events: Event[] = [
+      makeEvent({
+        id: 'e1',
+        type: 'region.added',
+        payload: { id: 'skill:research', target: 'system', section: 'session-skills', stability: 'turn-stable', reason: 'test', contentHash: h1 },
+      }),
+      makeEvent({
+        id: 'e2',
+        type: 'region.added',
+        payload: { id: 'skill:research', target: 'system', section: 'session-skills', stability: 'turn-stable', reason: 'test', contentHash: h2 },
+      }),
+      makeEvent({
+        id: 'e3',
+        type: 'region.removed',
+        payload: { id: 'skill:research', reason: 'test' },
+      }),
+    ]
+
+    expect((await getRegionAt(events, 'e1', 'skill:research', objects))?.content).toBe('"v1"')
+    expect((await getRegionAt(events, 'e2', 'skill:research', objects))?.content).toBe('"v2"')
+    expect(await getRegionAt(events, 'e3', 'skill:research', objects)).toBeUndefined()
   })
 })
 
@@ -348,6 +406,31 @@ describe('RecordingIOPort — Phase 3 additions', () => {
     expect(startedEvt).toBeDefined()
     expect(kinds[kinds.length - 1]).toBe('agent.run.completed')
     expect((startedEvt!.payload as { agentId: string }).agentId).toBe('a1')
+  })
+
+  it('region.added events carry content hashes and can reconstruct context before an LLM request', async () => {
+    const eventStore = new MemoryEventStore()
+    const traceObjectStore = new MemoryTraceObjectStore()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway:    new StubGateway([textResponse('hello')]),
+      eventStore,
+      traceObjectStore,
+    })
+    milkie.registerAgent(minimalAgentConfig('a1'))
+
+    const result = await milkie.invoke({ agentId: 'a1', goal: 'g', input: 'i' })
+
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const headerAdded = events.find(e => e.type === 'region.added' && (e.payload as RegionAddedPayload).id === 'header')!
+    const headerPayload = headerAdded.payload as RegionAddedPayload
+    expect(headerPayload.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(await traceObjectStore.getCanonical(headerPayload.contentHash)).toBe('"system"')
+
+    const firstLlm = events.find(e => e.type === 'llm.requested')!
+    const context = await contextBefore(events, firstLlm.id, traceObjectStore)
+    expect(context.get('header')?.content).toBe('"system"')
+    expect(context.get('current-turn')?.content).toContain('Goal: g')
   })
 })
 

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -22,6 +22,15 @@ import type {
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
 
+class FailingEventStore extends MemoryEventStore {
+  async append(event: Event): Promise<void> {
+    if (event.type === 'region.added' || event.type === 'region.removed' || event.type === 'context.boundary.applied') {
+      throw new Error('disk full')
+    }
+    await super.append(event)
+  }
+}
+
 function minimalAgentConfig(agentId: string): AgentConfig {
   return {
     agentId,
@@ -195,6 +204,19 @@ describe('TraceObjectStore', () => {
     expect((await getRegionAt(events, 'e1', 'skill:research', objects))?.content).toBe('"v1"')
     expect((await getRegionAt(events, 'e2', 'skill:research', objects))?.content).toBe('"v2"')
     expect(await getRegionAt(events, 'e3', 'skill:research', objects)).toBeUndefined()
+  })
+
+  it('gracefully hydrates legacy region.added events without contentHash', async () => {
+    const objects = new MemoryTraceObjectStore()
+    const events: Event[] = [
+      makeEvent({
+        id: 'legacy',
+        type: 'region.added',
+        payload: { id: 'header', target: 'system', section: 'header', stability: 'immutable', reason: 'legacy' },
+      }),
+    ]
+
+    expect((await getRegionAt(events, 'legacy', 'header', objects))?.content).toBeUndefined()
   })
 })
 
@@ -425,12 +447,43 @@ describe('RecordingIOPort — Phase 3 additions', () => {
     const headerAdded = events.find(e => e.type === 'region.added' && (e.payload as RegionAddedPayload).id === 'header')!
     const headerPayload = headerAdded.payload as RegionAddedPayload
     expect(headerPayload.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/)
-    expect(await traceObjectStore.getCanonical(headerPayload.contentHash)).toBe('"system"')
+    expect(await traceObjectStore.getCanonical(headerPayload.contentHash!)).toBe('"system"')
 
     const firstLlm = events.find(e => e.type === 'llm.requested')!
     const context = await contextBefore(events, firstLlm.id, traceObjectStore)
     expect(context.get('header')?.content).toBe('"system"')
     expect(context.get('current-turn')?.content).toContain('Goal: g')
+  })
+
+  it('does not expose content hashes when no traceObjectStore is configured', async () => {
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway:    new StubGateway([textResponse('hello')]),
+      eventStore,
+    })
+    milkie.registerAgent(minimalAgentConfig('a1'))
+
+    const result = await milkie.invoke({ agentId: 'a1', goal: 'g', input: 'i' })
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const added = events.find(e => e.type === 'region.added')!
+
+    expect((added.payload as RegionAddedPayload).contentHash).toBeUndefined()
+  })
+
+  it('trace write failures do not change the agent result', async () => {
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway:    new StubGateway([textResponse('hello')]),
+      eventStore: new FailingEventStore(),
+      traceObjectStore: new MemoryTraceObjectStore(),
+    })
+    milkie.registerAgent(minimalAgentConfig('a1'))
+
+    const result = await milkie.invoke({ agentId: 'a1', goal: 'g', input: 'i' })
+
+    expect(result.status).toBe('completed')
+    expect(result.output).toBe('hello')
   })
 })
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { Milkie } from '../runtime/Milkie.js'
 import { JsonlEventStore } from '../trace/JsonlEventStore.js'
+import { FileTraceObjectStore } from '../trace/TraceObjectStore.js'
 import { SQLiteStore } from '../store/SQLiteStore.js'
 import type { AgentCheckpoint } from '../types/store.js'
 
@@ -30,7 +31,8 @@ async function buildCliMilkie(): Promise<{ milkie: Milkie, milkieDir: string, st
   const stateStore = new SQLiteStore({ path: path.join(milkieDir, 'state.sqlite') })
   await stateStore.init()
   const eventStore = new JsonlEventStore(path.join(milkieDir, 'runs'))
-  const milkie = new Milkie({ stateStore, eventStore })
+  const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
+  const milkie = new Milkie({ stateStore, eventStore, traceObjectStore })
   await milkie.loadManifest(path.join(milkieDir, 'agents.json'))
   return { milkie, milkieDir, stateStore }
 }
@@ -199,7 +201,8 @@ export async function main(argv: string[]): Promise<MainResult> {
         throw new Error('no .milkie/ directory found upward from cwd')
       }
       const eventStore = new JsonlEventStore(path.join(milkieDir, 'runs'))
-      const milkie = new Milkie({ eventStore })
+      const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
+      const milkie = new Milkie({ eventStore, traceObjectStore })
       await milkie.loadManifest(path.join(milkieDir, 'agents.json'))
       const result = await milkie.replay(runId)
       stdout.push(JSON.stringify({

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,14 @@ export { AnthropicAdapter }         from './gateway/AnthropicAdapter.js'
 export { OpenAICompatibleAdapter }  from './gateway/OpenAICompatibleAdapter.js'
 export { createGateway }            from './gateway/GatewayFactory.js'
 
+// Trace stores / views
+export { MemoryEventStore } from './trace/MemoryEventStore.js'
+export { JsonlEventStore } from './trace/JsonlEventStore.js'
+export { MemoryTraceObjectStore, FileTraceObjectStore } from './trace/TraceObjectStore.js'
+export { contextAt, contextBefore, getRegionAt, getRegionBefore } from './trace/RegionContextView.js'
+export type { ITraceObjectStore } from './trace/TraceObjectStore.js'
+export type { RegionContentRef, ContextFoldMode } from './trace/RegionContextView.js'
+
 // Built-in tools
 export { cognitiveTools } from './tools/cognitive.js'
 export { systemTools } from './tools/system.js'

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -87,6 +87,7 @@ export class AgentRuntime {
   private pendingTraceWrites: Promise<unknown>[] = []
   private traceWriteChain: Promise<unknown> = Promise.resolve()
   private initialRegionsEmitted = false
+  private needsResumeCrystallization = false
   private childRecords: Map<string, ChildAgentRecord> = new Map()
   private rootSpan!:     Span
   private turnNumber:    number = 0
@@ -150,23 +151,25 @@ export class AgentRuntime {
       // burn an ioPort.uuid()/now() that replay's skip-write branch wouldn't
       // match. Date.now() / uuidv4() direct keep record/replay paths symmetric.
       if (this.eventStore) {
-        void this.eventStore.append({
-          id:        uuidv4(),
-          runId:     this.agentRunId,
-          type:      'fsm.transition',
-          actor:     this.config.agentId,
-          timestamp: Date.now(),
-          payload: {
-            from,
-            to,
-            trigger: {
-              // emitEvent / framework emit sites stamp domain explicitly; the
-              // only path that leaves it unset is direct construction in tests.
-              domain:  event.domain ?? 'business',
-              name:    event.name,
-              ...(event.payload !== undefined ? { payload: event.payload } : {}),
+        this.enqueueTraceWrite(async () => {
+          await this.eventStore!.append({
+            id:        uuidv4(),
+            runId:     this.agentRunId,
+            type:      'fsm.transition',
+            actor:     this.config.agentId,
+            timestamp: Date.now(),
+            payload: {
+              from,
+              to,
+              trigger: {
+                // emitEvent / framework emit sites stamp domain explicitly; the
+                // only path that leaves it unset is direct construction in tests.
+                domain:  event.domain ?? 'business',
+                name:    event.name,
+                ...(event.payload !== undefined ? { payload: event.payload } : {}),
+              },
             },
-          },
+          })
         })
       }
     })
@@ -406,16 +409,27 @@ export class AgentRuntime {
   }
 
   private buildRegionAddedPayload(region: Region, reason: string): import('../trace/types.js').RegionAddedPayload {
-    const contentHash = this.hashCanonical(region.content)
-    const rendered = this.renderRegion(region)
+    let contentHash: string | undefined
+    let renderedHash: string | undefined
+    try {
+      if (this.traceObjectStore) {
+        contentHash = this.hashCanonical(region.content)
+        const rendered = this.renderRegion(region)
+        if (rendered !== undefined) renderedHash = this.hashCanonical(rendered)
+      }
+    } catch {
+      // Region lifecycle events are observability records. Unsupported content
+      // shapes should degrade the hash fields, not make ContextRegions.set()
+      // fail and change agent behavior.
+    }
     return {
       id:        region.id,
       target:    region.target,
       section:   region.section,
       stability: region.stability,
       reason,
-      contentHash,
-      ...(rendered !== undefined ? { renderedHash: this.hashCanonical(rendered) } : {}),
+      ...(contentHash ? { contentHash } : {}),
+      ...(renderedHash ? { renderedHash } : {}),
     }
   }
 
@@ -429,10 +443,15 @@ export class AgentRuntime {
 
   private async persistRegionContent(region: Region): Promise<void> {
     if (!this.traceObjectStore) return
-    await this.traceObjectStore.putCanonical(canonicalize(region.content))
-    const rendered = this.renderRegion(region)
-    if (rendered !== undefined) {
-      await this.traceObjectStore.putCanonical(canonicalize(rendered))
+    try {
+      await this.traceObjectStore.putCanonical(canonicalize(region.content))
+      const rendered = this.renderRegion(region)
+      if (rendered !== undefined) {
+        await this.traceObjectStore.putCanonical(canonicalize(rendered))
+      }
+    } catch {
+      // Keep trace object storage best-effort. The event remains useful with
+      // metadata only if canonicalization/storage rejects a region shape.
     }
   }
 
@@ -448,6 +467,16 @@ export class AgentRuntime {
     const settled = await Promise.allSettled(writes)
     const rejected = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
     if (rejected) throw rejected.reason
+  }
+
+  private async tryFlushTraceWrites(): Promise<void> {
+    try {
+      await this.flushTraceWrites()
+    } catch {
+      // Trace persistence is best-effort and must not change the business
+      // outcome of a run. Durable deployments should surface store failures at
+      // the store/hosting layer.
+    }
   }
 
   private emitBoundaryApplied(summary: import('../context/lifecycleEngine.js').CrystallizationSummary): void {
@@ -565,6 +594,7 @@ export class AgentRuntime {
       this.fsm.emitEvent('interrupt')
       this.fsm.processPendingEvent()
       const checkpoint = await this.saveCheckpoint(resumeState)
+      await this.tryFlushTraceWrites()
       // Save to context:latest so Milkie.resume can find it
       await this.checkpoints.saveForContext(this.contextId, this.turnNumber, checkpoint)
       await this.stateStore.set(`context:${this.contextId}:checkpoint:latest`, checkpoint)
@@ -610,12 +640,11 @@ export class AgentRuntime {
       this.fsm.transitionTo(checkpoint.fsm.resumeState, { name: 'RESUME', domain: 'lifecycle' })
     }
     // Interrupt checkpoints did NOT crystallize (interrupt path saves mid-turn),
-    // so scratchpad + current-turn survive in the snapshot. Crystallize now so
-    // the resumed turn starts clean: prior partial work becomes a history pair,
-    // scratchpad clears, and the caller's new current-turn (set by run/continueTurn
-    // before executeFSM) is the only message after history.
-    // Wait-for-user checkpoints crystallized at save time, so this is a no-op for them.
-    this.crystallizeTurn()
+    // so scratchpad + current-turn survive in the snapshot. Defer
+    // crystallization until run() has a rootSpan, otherwise region.added /
+    // region.removed events would be silently dropped and event-sourced context
+    // reconstruction would miss the resume boundary.
+    this.needsResumeCrystallization = true
   }
 
   async run(input: string): Promise<AgentResult> {
@@ -625,6 +654,10 @@ export class AgentRuntime {
       contextId: this.contextId,
     })
     this.emitInitialRegionAdds()
+    if (this.needsResumeCrystallization) {
+      this.crystallizeTurn()
+      this.needsResumeCrystallization = false
+    }
 
     const turnInput = `Goal: ${this.goal}\n\n${input}`
     this.setCurrentTurn(turnInput)
@@ -660,7 +693,7 @@ export class AgentRuntime {
         status:     'error',
       }
     } finally {
-      await this.flushTraceWrites()
+      await this.tryFlushTraceWrites()
       await this.recorder.flush()
     }
   }
@@ -689,6 +722,7 @@ export class AgentRuntime {
             // invoke sees an empty history).
             this.crystallizeTurn()
             const checkpoint = await this.saveCheckpoint()
+            await this.tryFlushTraceWrites()
             await this.checkpoints.saveForContext(this.contextId, this.turnNumber, checkpoint)
             await this.stateStore.set(`context:${this.contextId}:checkpoint:latest`, checkpoint)
           }
@@ -733,7 +767,7 @@ export class AgentRuntime {
         ...(assembled.tools ? { tools: assembled.tools } : {}),
         ...(assembled.cacheBreakpoint ? { cacheBreakpoint: assembled.cacheBreakpoint } : {}),
       }
-      await this.flushTraceWrites()
+      await this.tryFlushTraceWrites()
 
       const llmSpan = this.recorder.startSpan('llm.call', {
         provider:     this.config.model.provider,

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -31,6 +31,9 @@ import type { IIOPort } from './IOPort.js'
 import { cognitiveTools } from '../tools/cognitive.js'
 import { systemTools } from '../tools/system.js'
 import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
+import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
+import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
+import type { Region } from '../context/Region.js'
 
 export interface AgentRuntimeOptions {
   config:            AgentConfig
@@ -50,6 +53,7 @@ export interface AgentRuntimeOptions {
    * region events get re-written on top of the existing run JSONL.
    */
   eventStore?:       import('../trace/EventStore.js').IEventStore
+  traceObjectStore?: ITraceObjectStore
   extraTools?:       ToolDefinition[]
   subAgentConfigs?:  Map<string, AgentConfig>  // agentId → config, for spawning
   childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
@@ -65,6 +69,7 @@ export class AgentRuntime {
   private readonly recorder:         ITrajectoryRecorder
   private readonly ioPort:           IIOPort
   private readonly eventStore?:      import('../trace/EventStore.js').IEventStore
+  private readonly traceObjectStore?: ITraceObjectStore
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly extraTools:      ToolDefinition[]
@@ -79,6 +84,9 @@ export class AgentRuntime {
   private eventQueue:    Array<{ type: string; payload: unknown }> = []
   private pendingEvents: Array<{ type: string; payload: unknown }> = []
   private pendingSkillLoads: Array<{ name: string; instructions: string; scope: 'turn' | 'session' }> = []
+  private pendingTraceWrites: Promise<unknown>[] = []
+  private traceWriteChain: Promise<unknown> = Promise.resolve()
+  private initialRegionsEmitted = false
   private childRecords: Map<string, ChildAgentRecord> = new Map()
   private rootSpan!:     Span
   private turnNumber:    number = 0
@@ -94,6 +102,7 @@ export class AgentRuntime {
     this.stateStore      = opts.stateStore
     this.recorder        = opts.recorder
     this.eventStore      = opts.eventStore
+    this.traceObjectStore = opts.traceObjectStore
     this.subAgentConfigs = opts.subAgentConfigs
     this.childRecorderFactory = opts.childRecorderFactory
     this.extraTools      = opts.extraTools ?? []
@@ -360,13 +369,18 @@ export class AgentRuntime {
 
   private emitRegionDelta(delta: import('../context/ContextRegions.js').RegionChangeDelta, reason: string): void {
     if (!this.rootSpan) return   // pre-run mutations not yet attributable to a root span
-    this.recorder.recordEvent(this.rootSpan, delta.kind === 'added' ? 'region.added' : 'region.removed', {
-      id:        delta.id,
-      section:   delta.section,
-      target:    delta.target,
-      stability: delta.stability,
-      reason,
-    })
+    const region = delta.kind === 'added' ? this.regions.get(delta.id) : undefined
+    const addedPayload = region ? this.buildRegionAddedPayload(region, reason) : undefined
+    const recorderPayload = delta.kind === 'added'
+      ? { ...(addedPayload ?? {
+        id:        delta.id,
+        section:   delta.section,
+        target:    delta.target,
+        stability: delta.stability,
+        reason,
+      }) }
+      : { id: delta.id, reason }
+    this.recorder.recordEvent(this.rootSpan, delta.kind === 'added' ? 'region.added' : 'region.removed', recorderPayload)
     // Also write to the event log so trace HTML / web UI / inspect can see
     // these. Recorder-only (span events) doesn't reach the live event stream.
     if (this.eventStore) {
@@ -375,17 +389,65 @@ export class AgentRuntime {
       // burn an ioPort.uuid()/now() in record mode that replay's skip-write
       // branch wouldn't match. Date.now() / uuid() direct keep record and
       // replay paths symmetric on IOPort consumption.
-      void this.eventStore.append({
-        id:        uuidv4(),
-        runId:     this.agentRunId,
-        type:      delta.kind === 'added' ? 'region.added' : 'region.removed',
-        actor:     this.config.agentId,
-        timestamp: Date.now(),
-        payload:   delta.kind === 'added'
-          ? { id: delta.id, target: delta.target ?? 'system', section: delta.section ?? 'unknown', stability: delta.stability ?? 'volatile', reason }
-          : { id: delta.id, reason },
+      this.enqueueTraceWrite(async () => {
+        if (addedPayload) await this.persistRegionContent(region!)
+        await this.eventStore!.append({
+          id:        uuidv4(),
+          runId:     this.agentRunId,
+          type:      delta.kind === 'added' ? 'region.added' : 'region.removed',
+          actor:     this.config.agentId,
+          timestamp: Date.now(),
+          payload:   delta.kind === 'added'
+            ? (addedPayload ?? { id: delta.id, target: delta.target ?? 'system', section: delta.section ?? 'unknown', stability: delta.stability ?? 'volatile', reason })
+            : { id: delta.id, reason },
+        })
       })
     }
+  }
+
+  private buildRegionAddedPayload(region: Region, reason: string): import('../trace/types.js').RegionAddedPayload {
+    const contentHash = this.hashCanonical(region.content)
+    const rendered = this.renderRegion(region)
+    return {
+      id:        region.id,
+      target:    region.target,
+      section:   region.section,
+      stability: region.stability,
+      reason,
+      contentHash,
+      ...(rendered !== undefined ? { renderedHash: this.hashCanonical(rendered) } : {}),
+    }
+  }
+
+  private renderRegion(region: Region): unknown {
+    return region.format(region.content)
+  }
+
+  private hashCanonical(value: unknown): string {
+    return contentAddressForCanonicalBytes(canonicalize(value))
+  }
+
+  private async persistRegionContent(region: Region): Promise<void> {
+    if (!this.traceObjectStore) return
+    await this.traceObjectStore.putCanonical(canonicalize(region.content))
+    const rendered = this.renderRegion(region)
+    if (rendered !== undefined) {
+      await this.traceObjectStore.putCanonical(canonicalize(rendered))
+    }
+  }
+
+  private enqueueTraceWrite(write: () => Promise<void>): void {
+    const next = this.traceWriteChain.then(write)
+    this.traceWriteChain = next.catch(() => undefined)
+    this.pendingTraceWrites.push(next)
+  }
+
+  private async flushTraceWrites(): Promise<void> {
+    const writes = this.pendingTraceWrites
+    this.pendingTraceWrites = []
+    const settled = await Promise.allSettled(writes)
+    const rejected = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+    if (rejected) throw rejected.reason
   }
 
   private emitBoundaryApplied(summary: import('../context/lifecycleEngine.js').CrystallizationSummary): void {
@@ -406,23 +468,39 @@ export class AgentRuntime {
       // burn an ioPort.uuid()/now() in record mode that replay's skip-write
       // branch wouldn't match. Date.now() / uuid() direct keep record and
       // replay paths symmetric on IOPort consumption.
-      void this.eventStore.append({
-        id:        uuidv4(),
-        runId:     this.agentRunId,
-        type:      'context.boundary.applied',
-        actor:     this.config.agentId,
-        timestamp: Date.now(),
-        payload: {
-          boundary: 'turn-end',
-          epoch:    this.regions.getEpoch(),
-          crystallization: {
-            kept:         summary.kept.length,
-            dropped:      summary.dropped.length,
-            promoted:     summary.promoted.length,
-            archivedPair: summary.archivedPair,
+      this.enqueueTraceWrite(async () => {
+        await this.eventStore!.append({
+          id:        uuidv4(),
+          runId:     this.agentRunId,
+          type:      'context.boundary.applied',
+          actor:     this.config.agentId,
+          timestamp: Date.now(),
+          payload: {
+            boundary: 'turn-end',
+            epoch:    this.regions.getEpoch(),
+            crystallization: {
+              kept:         summary.kept.length,
+              dropped:      summary.dropped.length,
+              promoted:     summary.promoted.length,
+              archivedPair: summary.archivedPair,
+            },
           },
-        },
+        })
       })
+    }
+  }
+
+  private emitInitialRegionAdds(): void {
+    if (this.initialRegionsEmitted) return
+    this.initialRegionsEmitted = true
+    for (const region of this.regions._allRegions()) {
+      this.emitRegionDelta({
+        kind:      'added',
+        id:        region.id,
+        section:   region.section,
+        target:    region.target,
+        stability: region.stability,
+      }, 'runtime-initialized')
     }
   }
 
@@ -546,6 +624,7 @@ export class AgentRuntime {
       goal:      this.goal,
       contextId: this.contextId,
     })
+    this.emitInitialRegionAdds()
 
     const turnInput = `Goal: ${this.goal}\n\n${input}`
     this.setCurrentTurn(turnInput)
@@ -581,6 +660,7 @@ export class AgentRuntime {
         status:     'error',
       }
     } finally {
+      await this.flushTraceWrites()
       await this.recorder.flush()
     }
   }
@@ -653,6 +733,7 @@ export class AgentRuntime {
         ...(assembled.tools ? { tools: assembled.tools } : {}),
         ...(assembled.cacheBreakpoint ? { cacheBreakpoint: assembled.cacheBreakpoint } : {}),
       }
+      await this.flushTraceWrites()
 
       const llmSpan = this.recorder.startSpan('llm.call', {
         provider:     this.config.model.provider,

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -16,7 +16,7 @@ import { AgentRuntime } from './AgentRuntime.js'
 import { DefaultIOPort, type IIOPort } from './IOPort.js'
 import type { IEventStore } from '../trace/EventStore.js'
 import { RecordingIOPort } from '../trace/RecordingIOPort.js'
-import { MemoryTraceObjectStore, type ITraceObjectStore } from '../trace/TraceObjectStore.js'
+import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { CacheIndex } from '../trace/CacheIndex.js'
 import { ReplayingIOPort } from '../trace/ReplayingIOPort.js'
 import { ReplayError } from '../trace/ReplayError.js'
@@ -57,7 +57,7 @@ export class Milkie {
     this.extraTools      = opts.tools            ?? []
     this.trajectoryStore = opts.trajectoryStore  ?? null
     this.eventStore      = opts.eventStore       ?? null
-    this.traceObjectStore = opts.traceObjectStore ?? (opts.eventStore ? new MemoryTraceObjectStore() : null)
+    this.traceObjectStore = opts.traceObjectStore ?? null
   }
 
   private wrapIOPort(gateway: IModelGateway, runId: string): IIOPort {

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -16,6 +16,7 @@ import { AgentRuntime } from './AgentRuntime.js'
 import { DefaultIOPort, type IIOPort } from './IOPort.js'
 import type { IEventStore } from '../trace/EventStore.js'
 import { RecordingIOPort } from '../trace/RecordingIOPort.js'
+import { MemoryTraceObjectStore, type ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { CacheIndex } from '../trace/CacheIndex.js'
 import { ReplayingIOPort } from '../trace/ReplayingIOPort.js'
 import { ReplayError } from '../trace/ReplayError.js'
@@ -37,6 +38,7 @@ export interface MilkieOptions {
    * only observability surface (Phase 2 behavior).
    */
   eventStore?:      IEventStore
+  traceObjectStore?: ITraceObjectStore
 }
 
 export class Milkie {
@@ -45,6 +47,7 @@ export class Milkie {
   private readonly extraTools:      ToolDefinition[]
   private readonly trajectoryStore: TrajectoryStore | null
   private readonly eventStore:      IEventStore | null
+  private readonly traceObjectStore: ITraceObjectStore | null
 
   private readonly agents:   Map<string, AgentConfig> = new Map()
 
@@ -54,6 +57,7 @@ export class Milkie {
     this.extraTools      = opts.tools            ?? []
     this.trajectoryStore = opts.trajectoryStore  ?? null
     this.eventStore      = opts.eventStore       ?? null
+    this.traceObjectStore = opts.traceObjectStore ?? (opts.eventStore ? new MemoryTraceObjectStore() : null)
   }
 
   private wrapIOPort(gateway: IModelGateway, runId: string): IIOPort {
@@ -202,6 +206,7 @@ export class Milkie {
       recorder,
       ioPort,
       eventStore:      this.eventStore ?? undefined,
+      traceObjectStore: this.traceObjectStore ?? undefined,
       extraTools:      this.extraTools,
       subAgentConfigs: this.agents,
       childRecorderFactory,
@@ -278,6 +283,7 @@ export class Milkie {
       recorder,
       ioPort:          this.wrapIOPort(gateway, agentRunId),
       eventStore:      this.eventStore ?? undefined,
+      traceObjectStore: this.traceObjectStore ?? undefined,
       extraTools:      this.extraTools,
       subAgentConfigs: this.agents,
       childRecorderFactory,

--- a/src/trace/RegionContextView.ts
+++ b/src/trace/RegionContextView.ts
@@ -7,7 +7,7 @@ export interface RegionContentRef {
   section:      string
   stability:    RegionAddedPayload['stability']
   reason:       string
-  contentHash:  string
+  contentHash?: string
   renderedHash?: string
   content?:     string
   rendered?:    string
@@ -32,7 +32,7 @@ export function foldRegionContext(events: Event[]): Map<string, RegionContentRef
         section:      payload.section,
         stability:    payload.stability,
         reason:       payload.reason,
-        contentHash:  payload.contentHash,
+        ...(payload.contentHash ? { contentHash: payload.contentHash } : {}),
         ...(payload.renderedHash ? { renderedHash: payload.renderedHash } : {}),
       })
     } else if (event.type === 'region.removed') {
@@ -56,7 +56,7 @@ export async function hydrateRegionContext(
     const rendered = ref.renderedHash ? await objectStore.getCanonical(ref.renderedHash) : undefined
     hydrated.set(id, {
       ...ref,
-      content:  await objectStore.getCanonical(ref.contentHash),
+      ...(ref.contentHash ? { content: await objectStore.getCanonical(ref.contentHash) } : {}),
       ...(rendered !== undefined ? { rendered } : {}),
     })
   }

--- a/src/trace/RegionContextView.ts
+++ b/src/trace/RegionContextView.ts
@@ -1,0 +1,98 @@
+import type { Event, RegionAddedPayload, RegionRemovedPayload } from './types.js'
+import type { ITraceObjectStore } from './TraceObjectStore.js'
+
+export interface RegionContentRef {
+  id:           string
+  target:       RegionAddedPayload['target']
+  section:      string
+  stability:    RegionAddedPayload['stability']
+  reason:       string
+  contentHash:  string
+  renderedHash?: string
+  content?:     string
+  rendered?:    string
+}
+
+export type ContextFoldMode = 'at' | 'before'
+
+function eventsThrough(events: Event[], eventId: string, mode: ContextFoldMode): Event[] {
+  const index = events.findIndex(e => e.id === eventId)
+  if (index < 0) throw new Error(`Event not found: ${eventId}`)
+  return events.slice(0, mode === 'at' ? index + 1 : index)
+}
+
+export function foldRegionContext(events: Event[]): Map<string, RegionContentRef> {
+  const active = new Map<string, RegionContentRef>()
+  for (const event of events) {
+    if (event.type === 'region.added') {
+      const payload = event.payload as RegionAddedPayload
+      active.set(payload.id, {
+        id:           payload.id,
+        target:       payload.target,
+        section:      payload.section,
+        stability:    payload.stability,
+        reason:       payload.reason,
+        contentHash:  payload.contentHash,
+        ...(payload.renderedHash ? { renderedHash: payload.renderedHash } : {}),
+      })
+    } else if (event.type === 'region.removed') {
+      const payload = event.payload as RegionRemovedPayload
+      active.delete(payload.id)
+    }
+  }
+  return active
+}
+
+export function contextRefsAt(events: Event[], eventId: string, mode: ContextFoldMode = 'at'): Map<string, RegionContentRef> {
+  return foldRegionContext(eventsThrough(events, eventId, mode))
+}
+
+export async function hydrateRegionContext(
+  refs: Map<string, RegionContentRef>,
+  objectStore: ITraceObjectStore,
+): Promise<Map<string, RegionContentRef>> {
+  const hydrated = new Map<string, RegionContentRef>()
+  for (const [id, ref] of refs) {
+    const rendered = ref.renderedHash ? await objectStore.getCanonical(ref.renderedHash) : undefined
+    hydrated.set(id, {
+      ...ref,
+      content:  await objectStore.getCanonical(ref.contentHash),
+      ...(rendered !== undefined ? { rendered } : {}),
+    })
+  }
+  return hydrated
+}
+
+export async function contextAt(
+  events: Event[],
+  eventId: string,
+  objectStore: ITraceObjectStore,
+): Promise<Map<string, RegionContentRef>> {
+  return hydrateRegionContext(contextRefsAt(events, eventId, 'at'), objectStore)
+}
+
+export async function contextBefore(
+  events: Event[],
+  eventId: string,
+  objectStore: ITraceObjectStore,
+): Promise<Map<string, RegionContentRef>> {
+  return hydrateRegionContext(contextRefsAt(events, eventId, 'before'), objectStore)
+}
+
+export async function getRegionAt(
+  events: Event[],
+  eventId: string,
+  regionId: string,
+  objectStore: ITraceObjectStore,
+): Promise<RegionContentRef | undefined> {
+  return (await contextAt(events, eventId, objectStore)).get(regionId)
+}
+
+export async function getRegionBefore(
+  events: Event[],
+  eventId: string,
+  regionId: string,
+  objectStore: ITraceObjectStore,
+): Promise<RegionContentRef | undefined> {
+  return (await contextBefore(events, eventId, objectStore)).get(regionId)
+}

--- a/src/trace/TraceObjectStore.ts
+++ b/src/trace/TraceObjectStore.ts
@@ -1,0 +1,103 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { contentAddressForCanonicalBytes } from './hash.js'
+
+export interface ITraceObjectStore {
+  putCanonical(bytes: string): Promise<string>
+  getCanonical(hash: string): Promise<string | undefined>
+  has(hash: string): Promise<boolean>
+}
+
+function assertSupportedHash(hash: string): string {
+  const prefix = 'sha256:'
+  if (!hash.startsWith(prefix)) {
+    throw new Error(`Unsupported trace object hash: ${hash}`)
+  }
+  const hex = hash.slice(prefix.length)
+  if (!/^[a-f0-9]{64}$/.test(hex)) {
+    throw new Error(`Invalid sha256 trace object hash: ${hash}`)
+  }
+  return hex
+}
+
+function assertHashMatches(hash: string, bytes: string): void {
+  const actual = contentAddressForCanonicalBytes(bytes)
+  if (actual !== hash) {
+    throw new Error(`Trace object hash mismatch: expected ${hash}, got ${actual}`)
+  }
+}
+
+export class MemoryTraceObjectStore implements ITraceObjectStore {
+  private readonly objects = new Map<string, string>()
+
+  async putCanonical(bytes: string): Promise<string> {
+    const hash = contentAddressForCanonicalBytes(bytes)
+    const existing = this.objects.get(hash)
+    if (existing !== undefined && existing !== bytes) {
+      throw new Error(`Trace object hash collision or corruption for ${hash}`)
+    }
+    this.objects.set(hash, bytes)
+    return hash
+  }
+
+  async getCanonical(hash: string): Promise<string | undefined> {
+    assertSupportedHash(hash)
+    const bytes = this.objects.get(hash)
+    if (bytes !== undefined) assertHashMatches(hash, bytes)
+    return bytes
+  }
+
+  async has(hash: string): Promise<boolean> {
+    assertSupportedHash(hash)
+    return this.objects.has(hash)
+  }
+}
+
+export class FileTraceObjectStore implements ITraceObjectStore {
+  constructor(private readonly baseDir: string) {}
+
+  private fileFor(hash: string): string {
+    const hex = assertSupportedHash(hash)
+    return path.join(this.baseDir, 'sha256', hex.slice(0, 2), hex.slice(2))
+  }
+
+  async putCanonical(bytes: string): Promise<string> {
+    const hash = contentAddressForCanonicalBytes(bytes)
+    const file = this.fileFor(hash)
+    try {
+      const existing = await fs.readFile(file, 'utf-8')
+      if (existing !== bytes) {
+        throw new Error(`Trace object hash collision or corruption for ${hash}`)
+      }
+      return hash
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    }
+
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, bytes, { encoding: 'utf-8', flag: 'wx' }).catch(async (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EEXIST') throw err
+      const existing = await fs.readFile(file, 'utf-8')
+      if (existing !== bytes) {
+        throw new Error(`Trace object hash collision or corruption for ${hash}`)
+      }
+    })
+    return hash
+  }
+
+  async getCanonical(hash: string): Promise<string | undefined> {
+    const file = this.fileFor(hash)
+    try {
+      const bytes = await fs.readFile(file, 'utf-8')
+      assertHashMatches(hash, bytes)
+      return bytes
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw err
+    }
+  }
+
+  async has(hash: string): Promise<boolean> {
+    return (await this.getCanonical(hash)) !== undefined
+  }
+}

--- a/src/trace/TraceObjectStore.ts
+++ b/src/trace/TraceObjectStore.ts
@@ -64,24 +64,22 @@ export class FileTraceObjectStore implements ITraceObjectStore {
   async putCanonical(bytes: string): Promise<string> {
     const hash = contentAddressForCanonicalBytes(bytes)
     const file = this.fileFor(hash)
-    try {
-      const existing = await fs.readFile(file, 'utf-8')
-      if (existing !== bytes) {
-        throw new Error(`Trace object hash collision or corruption for ${hash}`)
-      }
-      return hash
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-    }
+    if (await this.has(hash)) return hash
 
     await fs.mkdir(path.dirname(file), { recursive: true })
-    await fs.writeFile(file, bytes, { encoding: 'utf-8', flag: 'wx' }).catch(async (err: NodeJS.ErrnoException) => {
-      if (err.code !== 'EEXIST') throw err
+    const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+    try {
+      await fs.writeFile(tmp, bytes, { encoding: 'utf-8', flag: 'wx' })
+      await fs.link(tmp, file)
+      await fs.rm(tmp, { force: true })
+    } catch (err) {
+      await fs.rm(tmp, { force: true }).catch(() => undefined)
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
       const existing = await fs.readFile(file, 'utf-8')
       if (existing !== bytes) {
         throw new Error(`Trace object hash collision or corruption for ${hash}`)
       }
-    })
+    }
     return hash
   }
 

--- a/src/trace/hash.ts
+++ b/src/trace/hash.ts
@@ -30,8 +30,16 @@ function normalize(value: unknown): unknown {
   return value
 }
 
-function sha256Hex(s: string): string {
+export function sha256Hex(s: string): string {
   return createHash('sha256').update(s).digest('hex')
+}
+
+export function contentAddressForCanonicalBytes(bytes: string): string {
+  return `sha256:${sha256Hex(bytes)}`
+}
+
+export function hashCanonical(value: unknown): string {
+  return contentAddressForCanonicalBytes(canonicalize(value))
 }
 
 export function hashModelRequest(req: ModelRequest): string {

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -112,6 +112,10 @@ export interface RegionAddedPayload {
   stability: 'immutable' | 'session-stable' | 'turn-stable' | 'volatile'
   /** Why this region appeared (e.g. 'agent-set', 'turn-archived', 'promoted-to-wm'). */
   reason:    string
+  /** Content-addressed canonical Region.content bytes. */
+  contentHash: string
+  /** Content-addressed canonical format(content) bytes, when renderable. */
+  renderedHash?: string
 }
 
 export interface RegionRemovedPayload {

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -112,8 +112,8 @@ export interface RegionAddedPayload {
   stability: 'immutable' | 'session-stable' | 'turn-stable' | 'volatile'
   /** Why this region appeared (e.g. 'agent-set', 'turn-archived', 'promoted-to-wm'). */
   reason:    string
-  /** Content-addressed canonical Region.content bytes. */
-  contentHash: string
+  /** Content-addressed canonical Region.content bytes. Missing on legacy events or unsupported content shapes. */
+  contentHash?: string
   /** Content-addressed canonical format(content) bytes, when renderable. */
   renderedHash?: string
 }


### PR DESCRIPTION
## Summary

把 Region 内容做成内容寻址(content-addressed)的不可变对象,让 Agent Trace 能从 append-only event log 重建任意时刻的 working context。

- 新增 `TraceObjectStore`(`MemoryTraceObjectStore` / `FileTraceObjectStore`,sha256 内容寻址,自动去重)
- 新增 `RegionContextView`:折叠 `region.added` / `region.removed` 事件 + 解引用 content hash,重建 "context at / before event X"
- `region.added` payload 增加可选 `contentHash` / `renderedHash`,指向 object store 里的不可变内容
- `RegionAddedPayload.contentHash` 为可选,兼容历史 event log 与不可序列化的 content shape
- CLI 默认把 content store 落在 `.milkie/objects/`(与 `runs/` 事件日志分离)
- ARCHITECTURE.md 增补 "Event-sourced runtime state" 小节

## 已修复的 review 发现

第二轮 review(`4bb011b`)修掉了首轮的 4 个高危项,均配回归测试:

1. **trace 写入失败不再改变 agent 结果** — 新增 `tryFlushTraceWrites`,observability I/O 失败(ENOSPC 等)best-effort 吞掉,不再把成功的 run 翻成 error,也不再在 finally 里掩盖原始错误
2. **resume 不再丢失 region 生命周期事件** — checkpoint 恢复后的 crystallization 延迟到 `run()` 内(rootSpan 已建)执行,`region.removed` 正确入日志
3. **向后兼容** — `contentHash` 全链路可选,旧 JSONL event log 不再触发 hydrate 崩溃
4. **持久化语义** — 移除 "有 eventStore 就默认内存 object store" 的脚枪;无 object store 时干脆不产出 contentHash

另外:`canonicalize` 抛异常被 try/catch 降级为只存元数据;`fsm.transition` 改走写入链;`FileTraceObjectStore` 用 temp 文件 + 原子 `fs.link` 修掉并发写 TOCTOU 竞态。

## 后续(本 PR 不做)

- 远程 / 对象存储后端(S3/GCS/MinIO):`ITraceObjectStore` 接口已 pluggable,K8s 多副本场景加一个实现注入即可,CAS 不可变性保证抽象不泄漏
- 遗留低优先项:`emitRegionDelta` 死 fallback 清理、content/rendered 双重 canonicalize 合一

## Test plan

- [x] `npm run build`(tsc)通过
- [x] 完整 jest 套件:43 suites / 394 passed,含 4 个新增回归测试
- [ ] 真实 CLI 端到端跑一次 record → replay/inspect,确认 `.milkie/objects/` 内容可被 context view 重建

🤖 Generated with [Claude Code](https://claude.com/claude-code)