### PR TITLE
feat(trace): sub-agent first-class runId + independent replay (#47)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-sub-agent-first-class-replay.md
+++ b/docs/superpowers/plans/2026-05-29-sub-agent-first-class-replay.md
@@ -1,0 +1,554 @@
+# sub-agent 一类公民化（模型 I）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让子 agent 把自己的 I/O 录进独立的 `<childRunId>.jsonl`、emit 自己的 `agent.run.started/completed`，并让含 sub-agent 的 run 能正确 replay —— 不引入递归 replay（模型 I）。
+
+**Architecture:** Milkie 注入一个 record-only 的子 port 工厂；spawn 时给子铸一个绑 `childRunId`、用子自己 model gateway 的 `RecordingIOPort`，子 I/O 与生命周期事件落子的流。父 replay **不重跑子**（子 tool 由父 cache 吐 output）；为此把父侧子边界 id 改为信息性 uuid，使父 cache 不含任何"只有重跑子才会消费"的条目。子可经 `Milkie.replay(childRunId)` 独立重放。
+
+**Tech Stack:** TypeScript (ESM, `.js` import 后缀)、vitest。事件存储 `IEventStore`（Memory/Jsonl），IOPort 装饰链（`DefaultIOPort` → `RecordingIOPort`/`ReplayingIOPort`）。
+
+**设计依据：** `docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md`
+
+---
+
+## File Structure
+
+- `src/types/store.ts` — `ChildAgentRecord` 加 `runId`。
+- `src/runtime/AgentFactory.ts` — `AgentSpawnOptions` 加 `eventStore` + `makeChildPort`（向下传递子构造所需）。
+- `src/runtime/Milkie.ts` — 构造 `makeChildPort` 工厂并注入顶层 runtime（`invoke` / `resume`）。
+- `src/runtime/AgentRuntime.ts` — 主体：`makeChildPort` option/field/构造；`spawnFn` 注入向下传递；`makeSubAgentTool.handler` 改写（独立 childRunId、子 port、生命周期、信息性父侧 id）。
+- `src/__tests__/Trace.test.ts` — record 侧断言（子流分离、生命周期、父流干净、gateway）。
+- `src/__tests__/Replay.test.ts` — 父 replay 转绿 + 子独立 replay。
+
+每个 Task 自带测试，先红后绿，独立提交。
+
+---
+
+## Task 1: 子获得独立 runId，I/O 落 `<childRunId>.jsonl`
+
+**Files:**
+- Modify: `src/runtime/AgentFactory.ts:8-19`（`AgentSpawnOptions`）
+- Modify: `src/runtime/AgentRuntime.ts:40-62`（options）、`75-118`（field+ctor）、`135-142`（spawnFn）、`210-247`（handler）
+- Modify: `src/runtime/Milkie.ts:197-213`（invoke 注入）
+- Test: `src/__tests__/Trace.test.ts`
+
+- [ ] **Step 1: 写失败测试** — 在 `Trace.test.ts` 的 `describe('agent.spawned / agent.returned events', ...)` 内追加：
+
+```ts
+it('records child LLM I/O under an independent childRunId, not the parent run', async () => {
+  const eventStore = new MemoryEventStore()
+  const milkie = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway: new StubGateway([
+      toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+      textResponse('worker done'),   // worker 的 LLM 回复
+      textResponse('all done'),      // supervisor 收尾
+    ]),
+    eventStore,
+  })
+  milkie.registerAgent(supervisorConfig())
+  milkie.registerAgent(workerConfig())
+
+  const result = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+  const parentEvents = await eventStore.readByRunId(result.agentRunId)
+
+  const spawned = parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload
+  // childRunId 现在是真正独立的 runId，且 != 父 runId
+  expect(spawned.childRunId).not.toBe(result.agentRunId)
+
+  // 父流里没有 worker 的 llm 事件（它们去了子流）
+  const parentLlm = parentEvents.filter(e => e.type === 'llm.requested')
+  // supervisor 自己有 2 次 LLM（spawn 决策 + 收尾），worker 的不在父流
+  const childEvents = await eventStore.readByRunId(spawned.childRunId)
+  const childLlm = childEvents.filter(e => e.type === 'llm.requested')
+  expect(childLlm.length).toBeGreaterThan(0)        // 子流有 worker 的 llm
+  expect(parentLlm.length).toBe(2)                  // 父流只有 supervisor 自己的
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "independent childRunId"`
+Expected: FAIL（今天子复用父 runId/port，`spawned.childRunId` 是 contextId 且子 llm 落在父流，`childLlm.length` 为 0 或 `parentLlm` 偏多）
+
+- [ ] **Step 3a: `AgentSpawnOptions` 加字段** — `src/runtime/AgentFactory.ts`，在 interface 内 `extraTools?` 后追加：
+
+```ts
+  eventStore?:   import('../trace/EventStore.js').IEventStore
+  makeChildPort?: import('./AgentRuntime.js').MakeChildPort
+```
+
+- [ ] **Step 3b: 在 `AgentRuntime.ts` 定义并导出 `MakeChildPort` 类型** — 紧邻 `AgentRuntimeOptions`（约 `:39` 之后）：
+
+```ts
+import type { AgentRunStartedPayload, AgentRunCompletedPayload } from '../trace/types.js'
+
+export type MakeChildPort = (
+  childRunId:  string,
+  childConfig: AgentConfig,
+  start:       AgentRunStartedPayload,
+) => Promise<{ port: IIOPort; finish: (c: AgentRunCompletedPayload) => Promise<void> }>
+```
+
+（若文件已 `import type { SkillLifecyclePayload } from '../trace/types.js'`，把上面两个类型并入同一 import。）
+
+- [ ] **Step 3c: options + field + 构造 + spawnFn 向下传递** — `AgentRuntime.ts`：
+
+`AgentRuntimeOptions` 内 `childRecorderFactory?` 后加：
+```ts
+  makeChildPort?: MakeChildPort
+```
+field 区（`childRecorderFactory` 私有字段后）加：
+```ts
+  private readonly makeChildPort?: MakeChildPort
+```
+构造函数体（`this.childRecorderFactory = opts.childRecorderFactory` 附近）加：
+```ts
+    this.makeChildPort = opts.makeChildPort
+```
+spawnFn（`:135-142`）改为把 `eventStore` / `makeChildPort` 也传给子，使孙子也能分流：
+```ts
+    this.factory = new AgentFactory(async (spawnOpts: AgentSpawnOptions) => {
+      const child = new AgentRuntime({
+        ...spawnOpts,
+        parentId:             this.agentRunId,
+        childRecorderFactory: this.childRecorderFactory,
+        eventStore:           this.eventStore,
+        makeChildPort:        this.makeChildPort,
+      })
+      return child.run(spawnOpts.input)
+    })
+```
+
+- [ ] **Step 3d: 改写 `makeSubAgentTool.handler`** — `AgentRuntime.ts:210-280`。关键改动：父侧子边界 id 用 `uuidv4()`（信息性，绕 cache）；新增独立 `childRunId`；铸子 port + 生命周期；spawn 用子 port + 独立 runId；`agent.spawned/returned` 用 `childRunId`。替换 handler 体内自 `const childTraceId` 起到 spawn 调用：
+
+```ts
+      handler: async (rawInput: unknown, ctx: ToolContext) => {
+        const { goal, input: subInput } = rawInput as { goal: string; input: string }
+        const subConfig = this.subAgentConfigs?.get(agentId)
+        if (!subConfig) {
+          throw new Error(`Sub-agent config not found: ${agentId}. Pass subAgentConfigs to AgentRuntime.`)
+        }
+
+        // 父侧子边界 id 信息性化（绕 cache）：模型 I 下父 replay 不进 handler，
+        // 这些不可是父 cache 条目，否则 tail under-consume。
+        const childTraceId   = uuidv4()
+        const childContextId = uuidv4()
+        const taskId         = uuidv4()
+        const childRunId     = uuidv4()   // 子的独立 run 身份
+
+        const childRecorder = this.childRecorderFactory?.(subConfig, childContextId, childTraceId) ?? this.recorder
+        const spawnSpan = this.recorder.startSpan('agent.spawn', {
+          childAgentId: agentId, taskId, turn: this.turnNumber, childTraceId, childContextId, childRunId,
+        })
+        await this.recordChild({ taskId, agentId, runId: childRunId, contextId: childContextId, status: 'running' })
+        this.emitAgentSpawned(childRunId, agentId, goal)
+
+        // 铸子 port（record-only；replay 不注入 makeChildPort → 回退父 ioPort，且 replay 不进此分支）
+        let childPort: IIOPort = this.ioPort
+        let finish: ((c: AgentRunCompletedPayload) => Promise<void>) | null = null
+        if (this.makeChildPort) {
+          const built = await this.makeChildPort(childRunId, subConfig, {
+            agentId, goal, input: subInput, contextId: childContextId, parentId: this.agentRunId,
+          })
+          childPort = built.port
+          finish    = built.finish
+        }
+
+        try {
+          const result = await ctx.agentFactory.spawn({
+            config:     subConfig,
+            goal,
+            input:      subInput,
+            contextId:  childContextId,
+            agentRunId: childRunId,        // 独立 runId
+            stateStore: this.stateStore,
+            recorder:   childRecorder,
+            ioPort:     childPort,         // 子自己的 port
+            extraTools: this.extraTools,
+            eventStore: this.eventStore,   // 子的 fsm/region 也落子流
+            makeChildPort: this.makeChildPort,
+          })
+          await finish?.({ status: result.status, lastTextOutput: result.output })
+
+          const childCheckpoint = result.status === 'interrupted'
+            ? await this.stateStore.get(`context:${childContextId}:checkpoint:latest`) as AgentCheckpoint | undefined
+            : undefined
+          await this.recordChild({
+            taskId, agentId, runId: childRunId, contextId: childContextId,
+            checkpointId: childCheckpoint?.checkpointId,
+            status: result.status === 'interrupted' ? 'interrupted' : result.status === 'completed' ? 'success' : 'error',
+          })
+          this.recorder.recordEvent(spawnSpan, 'agent.spawn.complete', { resultStatus: result.status })
+          this.emitAgentReturned(childRunId, result.status)
+          spawnSpan.attributes['resultStatus']   = result.status
+          spawnSpan.attributes['childTraceId']   = childTraceId
+          spawnSpan.attributes['childContextId'] = childContextId
+          if (childCheckpoint?.checkpointId) spawnSpan.attributes['checkpointId'] = childCheckpoint.checkpointId
+          this.recorder.endSpan(spawnSpan, 'ok')
+          return result.output
+        } catch (err) {
+          await finish?.({ status: 'error', error: err instanceof Error ? err.message : String(err) })
+          await this.recordChild({ taskId, agentId, runId: childRunId, contextId: childContextId, status: 'error' })
+          this.emitAgentReturned(childRunId, 'error')
+          spawnSpan.attributes['resultStatus'] = 'error'
+          this.recorder.endSpan(spawnSpan, 'error')
+          throw err
+        }
+      },
+```
+
+确保文件顶部已 import `AgentRunCompletedPayload`（Step 3b 已加）。
+
+- [ ] **Step 3e: `ChildAgentRecord` 加 `runId`** — `src/types/store.ts:48-54`：
+
+```ts
+export interface ChildAgentRecord {
+  taskId:        string
+  agentId:       string
+  runId?:        string
+  contextId?:    string
+  checkpointId?: string
+  status:        'running' | 'success' | 'error' | 'interrupted'
+}
+```
+
+- [ ] **Step 3f: Milkie 构造并注入 `makeChildPort`** — `src/runtime/Milkie.ts`。在 `invoke`（`:197` 附近，构造 runtime 前）加：
+
+```ts
+    const makeChildPort = this.eventStore
+      ? (async (childRunId, childConfig, start) => {
+          const gw   = this.gatewayOverride ?? createGateway(childConfig.model)
+          const port = new RecordingIOPort(new DefaultIOPort(gw), this.eventStore!, childRunId)
+          await port.attach(start)
+          return { port, finish: (c) => port.detach(c) }
+        }) satisfies import('./AgentRuntime.js').MakeChildPort
+      : undefined
+```
+并在 `new AgentRuntime({...})` 的 opts 里加 `makeChildPort,`。`resume`（`:276`）同样加 `makeChildPort`（可抽一个私有 `buildMakeChildPort()` 复用，避免重复）。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "independent childRunId"`
+Expected: PASS
+
+- [ ] **Step 5: 跑既有 #24 spawn 测试确认未回归**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "agent.spawned"`
+Expected: PASS（`spawned.childRunId === returned.childRunId` 仍成立，值变为真 childRunId）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/store.ts src/runtime/AgentFactory.ts src/runtime/AgentRuntime.ts src/runtime/Milkie.ts src/__tests__/Trace.test.ts
+git commit -m "feat(trace): sub-agent records I/O under independent childRunId (#47)"
+```
+
+---
+
+## Task 2: 子 emit `agent.run.started{parentId}` / `agent.run.completed{status}`
+
+子的生命周期事件已由 Task 1 的 `makeChildPort`（`attach`/`finish→detach`）写入子流。本 Task 加断言锁定契约。
+
+**Files:**
+- Test: `src/__tests__/Trace.test.ts`
+
+- [ ] **Step 1: 写测试**
+
+```ts
+it('child run emits agent.run.started{parentId} and agent.run.completed in its own stream', async () => {
+  const eventStore = new MemoryEventStore()
+  const milkie = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway: new StubGateway([
+      toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+      textResponse('worker done'),
+      textResponse('all done'),
+    ]),
+    eventStore,
+  })
+  milkie.registerAgent(supervisorConfig())
+  milkie.registerAgent(workerConfig())
+
+  const result = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+  const parentEvents = await eventStore.readByRunId(result.agentRunId)
+  const spawned = parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload
+
+  const childEvents = await eventStore.readByRunId(spawned.childRunId)
+  const started = childEvents.find(e => e.type === 'agent.run.started')!
+  const completed = childEvents.find(e => e.type === 'agent.run.completed')!
+  expect(childEvents[0]!.type).toBe('agent.run.started')         // 子流第一帧
+  expect((started.payload as AgentRunStartedPayload).parentId).toBe(result.agentRunId)
+  expect((started.payload as AgentRunStartedPayload).agentId).toBe('worker')
+  expect((completed.payload as AgentRunCompletedPayload).status).toBe('completed')
+  expect(started.runId).toBe(spawned.childRunId)
+})
+```
+
+（在 `Trace.test.ts` 顶部 import 补 `AgentRunStartedPayload, AgentRunCompletedPayload`。）
+
+- [ ] **Step 2: 跑测试**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "agent.run.started{parentId}"`
+Expected: PASS（Task 1 已实现行为；若失败说明 attach 顺序/parentId 未填，回到 Task 1 Step 3f 检查）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/Trace.test.ts
+git commit -m "test(trace): assert child emits run.started{parentId}/completed (#47)"
+```
+
+---
+
+## Task 3: 含 sub-agent 的父 run 能正确 replay（核心验收，今天是坏的）
+
+**Files:**
+- Test: `src/__tests__/Replay.test.ts`
+
+- [ ] **Step 1: 写失败测试** — 仿 `Replay.test.ts` 既有 record→replay 双 Milkie 模式：
+
+```ts
+it('replays a run containing a sub-agent with no divergence', async () => {
+  const eventStore = new MemoryEventStore()
+  const record = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway: new StubGateway([
+      toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+      textResponse('worker done'),
+      textResponse('all done'),
+    ]),
+    eventStore,
+  })
+  record.registerAgent(supervisorConfig())
+  record.registerAgent(workerConfig())
+  const orig = await record.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+
+  const replay = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway: new StubGateway([]),   // replay 不应触达 gateway
+    eventStore,
+  })
+  replay.registerAgent(supervisorConfig())
+  replay.registerAgent(workerConfig())
+
+  const replayed = await replay.replay(orig.agentRunId)
+  expect(replayed.status).toBe('completed')
+  expect(replayed.output).toBe(orig.output)   // 'all done'
+})
+```
+
+（`supervisorConfig`/`workerConfig`/`StubGateway`/`toolCallResponse`/`textResponse` 若 `Replay.test.ts` 没有，从 `Trace.test.ts` 复制这几个 helper 到本文件顶部。）
+
+- [ ] **Step 2: 跑测试确认失败（前提：未做 §1d 之前）**
+
+Run: `npx vitest run src/__tests__/Replay.test.ts -t "containing a sub-agent"`
+注意：若 Task 1 已落地（父侧 id 已信息性化、子 I/O 已分流），此测试**可能直接 PASS** —— 这正是模型 I 的红利（replay 侧零改动）。若 PASS，记录"今天坏、Task1 后转绿"的事实于 commit message，跳到 Step 4。若仍 FAIL（divergence），按 Step 3 排查。
+
+- [ ] **Step 3: 排查（仅当 Step 2 FAIL）**
+
+divergence 必为 over/under-consume 之一：
+- **under-consume**：父 cache 仍含"只有重跑子才消费"的条目 → 检查是否还有父侧子边界值走了 `this.ioPort.uuid()`/`this.ioPort.now()`（应全为 `uuidv4()`/recorder）。`batchId`（`AgentRuntime.ts:1009`）保持 ioPort.uuid 是对的（handler 外、record/replay 对称消费）。
+- **over-consume**：子 tool 的 `tool.responded` 未被父 cache 命中 → 检查 `hashToolCall(agentId, {goal,input})` 在 record/replay 是否一致（input 形状一致即可）。
+
+修正后回到 Step 2。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run src/__tests__/Replay.test.ts -t "containing a sub-agent"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/__tests__/Replay.test.ts
+git commit -m "test(trace): parent run with sub-agent replays without divergence (#47)"
+```
+
+---
+
+## Task 4: 子 run 可经 `Milkie.replay(childRunId)` 独立重放
+
+**Files:**
+- Test: `src/__tests__/Replay.test.ts`
+
+- [ ] **Step 1: 写测试**
+
+```ts
+it('replays a child run standalone by its childRunId', async () => {
+  const eventStore = new MemoryEventStore()
+  const record = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway: new StubGateway([
+      toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+      textResponse('worker done'),
+      textResponse('all done'),
+    ]),
+    eventStore,
+  })
+  record.registerAgent(supervisorConfig())
+  record.registerAgent(workerConfig())
+  const orig = await record.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+  const parentEvents = await eventStore.readByRunId(orig.agentRunId)
+  const childRunId = (parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload).childRunId
+
+  const replay = new Milkie({ stateStore: new MemoryStore(), gateway: new StubGateway([]), eventStore })
+  replay.registerAgent(supervisorConfig())
+  replay.registerAgent(workerConfig())
+
+  const child = await replay.replay(childRunId)
+  expect(child.status).toBe('completed')
+  expect(child.output).toBe('worker done')
+})
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `npx vitest run src/__tests__/Replay.test.ts -t "child run standalone"`
+Expected: PASS（子流自带 `agent.run.started`(goal/input/contextId/parentId) + llm I/O → `extractRunSnapshot` + `CacheIndex` 即可独立重放）。若 FAIL 报 "missing lifecycle event"，确认 Task 1 的子 `attach/detach` 已写入子流。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/Replay.test.ts
+git commit -m "test(trace): child run is independently replayable by childRunId (#47)"
+```
+
+---
+
+## Task 5: `ChildAgentRecord.runId` 持久化进父 checkpoint
+
+**Files:**
+- Test: `src/__tests__/AgentRuntime.test.ts`
+
+- [ ] **Step 1: 写测试** — 仿既有 supervisor 中断测试（`AgentRuntime.test.ts:375` 一带），断言父 checkpoint 的 `children[].runId` 等于 `agent.spawned.childRunId`。复用其 harness（interrupt → 读 `context:<ctx>:checkpoint:latest`）：
+
+```ts
+it('persists child runId in the parent checkpoint children records', async () => {
+  // ...沿用 :375 测试的 supervisor+worker+eventStore+interrupt 搭建...
+  // interrupt 后：
+  const parentCp = await stateStore.get(`context:ctx-supervisor:checkpoint:latest`) as AgentCheckpoint
+  expect(parentCp.children.length).toBeGreaterThan(0)
+  for (const c of parentCp.children) {
+    expect(typeof c.runId).toBe('string')
+    expect(c.runId!.length).toBeGreaterThan(0)
+  }
+})
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `npx vitest run src/__tests__/AgentRuntime.test.ts -t "persists child runId"`
+Expected: PASS（Task 1 Step 3d 的 `recordChild({ runId: childRunId, ... })` + checkpoint 已存 `children`，`AgentRuntime.ts:717`）。若 FAIL，确认 `recordChild` 各调用点都带 `runId`。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/AgentRuntime.test.ts
+git commit -m "test(trace): persist child runId in parent checkpoint (#47)"
+```
+
+---
+
+## Task 6: 子用自己 model 的 gateway（修连带 bug）
+
+**Files:**
+- Test: `src/__tests__/Trace.test.ts`
+
+- [ ] **Step 1: 写测试** — 不设 `gateway` override；让子 config 的 adapter 非法，spawn 时 `createGateway(childConfig.model)` 会抛、且错误信息含子的 adapter 名 → 证明子 port 用的是 **childConfig.model**（而非父 gateway）：
+
+```ts
+it('builds the child port from the child config gateway (not the parent)', async () => {
+  const eventStore = new MemoryEventStore()
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore })   // 无 gateway override
+
+  const parent = supervisorConfig()
+  parent.model = { provider: 'anthropic', model: 'm', adapter: 'anthropic' } // 父：可构造、无网络调用
+  const child = workerConfig()
+  child.model = { provider: 'x', model: 'm', adapter: 'no-such-adapter' }     // 子：非法 adapter
+  milkie.registerAgent(parent)
+  milkie.registerAgent(child)
+
+  const result = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+  const events = await eventStore.readByRunId(result.agentRunId)
+  const toolResp = events.find(e => e.type === 'tool.responded' &&
+    (e.payload as ToolRespondedPayload).toolName === 'worker')!.payload as ToolRespondedPayload
+  expect(toolResp.error?.message ?? '').toContain('no-such-adapter')
+})
+```
+
+注意：父 LLM 需先返回一个调用 worker 的 tool_use。无 override 时父 `anthropic` gateway 会真的发起调用 → 测试不可控。**因此本测试改用 record 路径不可行**；替代为**直接单测 `makeChildPort` 行为**：
+
+```ts
+it('child port factory resolves gateway from child config', async () => {
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
+  const make = (milkie as any)['buildMakeChildPort']?.() ?? null
+  expect(make).not.toBeNull()
+  const bogus = { ...workerConfig(), model: { provider: 'x', model: 'm', adapter: 'no-such-adapter' } }
+  await expect(make('child-run-1', bogus, {
+    agentId: 'worker', goal: 'g', input: 'i', contextId: 'c', parentId: 'p',
+  })).rejects.toThrow(/no-such-adapter/)
+})
+```
+
+为此把 Task 1 Step 3f 的工厂抽成 `private buildMakeChildPort(): MakeChildPort | undefined`（invoke/resume 复用），测试经 `as any` 取到它。**采用此单测版本，删除上面那个不可控的 record 版本。**
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "child config"`
+Expected: FAIL（若 `buildMakeChildPort` 尚未抽出 → undefined；或工厂误用了 override/父 gateway）
+
+- [ ] **Step 3: 实现** — 在 `Milkie.ts` 把工厂抽成方法：
+
+```ts
+private buildMakeChildPort(): import('./AgentRuntime.js').MakeChildPort | undefined {
+  if (!this.eventStore) return undefined
+  const eventStore = this.eventStore
+  const override   = this.gatewayOverride
+  return async (childRunId, childConfig, start) => {
+    const gw   = override ?? createGateway(childConfig.model)
+    const port = new RecordingIOPort(new DefaultIOPort(gw), eventStore, childRunId)
+    await port.attach(start)
+    return { port, finish: (c) => port.detach(c) }
+  }
+}
+```
+`invoke`/`resume` 改用 `const makeChildPort = this.buildMakeChildPort()`。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run src/__tests__/Trace.test.ts -t "child config"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/runtime/Milkie.ts src/__tests__/Trace.test.ts
+git commit -m "feat(trace): child port uses child's own model gateway (#47)"
+```
+
+---
+
+## Task 7: 全量回归
+
+- [ ] **Step 1: 跑整个测试套件**
+
+Run: `npx vitest run`
+Expected: 全绿。重点确认无回归：`Replay.test.ts`（既有单 run）、`AgentRuntime.test.ts`（supervisor 中断/恢复、checkpoint）、`Trace.test.ts`（#24 spawn/returned、fsm.transition、skill 生命周期）。
+
+- [ ] **Step 2: 类型检查 / 构建**
+
+Run: `npx tsc --noEmit`（或项目既有 `npm run build` / `npm run typecheck`，先 `cat package.json` 确认脚本名）
+Expected: 无类型错误。
+
+- [ ] **Step 3: 若有失败** 按 superpowers:systematic-debugging 逐个定位；修复后回到 Step 1。不得用 `--no-verify` 跳过。
+
+---
+
+## Self-Review 备忘（计划作者已核对）
+
+- **Spec 覆盖**：独立 runId+子流(Task1) / 子生命周期(Task2) / 父 replay 转绿(Task3) / 子独立 replay(Task4) / childRunId 持久化(Task5) / 子 gateway(Task6) / 回归(Task7)。`agent.spawned/returned.childRunId` 升级为真 runId 在 Task1 落地、Task1 Step5 验证 #24 不回归。
+- **deferral**（spec 已列）：递归 replay（模型 II）、父 resume→子按稳定键续跑的**执行**、fork、`causedBy` —— 本计划不含，符合预期。
+- **类型一致**：`MakeChildPort`（AgentRuntime 导出）= `(childRunId, childConfig, start) => Promise<{port, finish}>`，在 AgentFactory/Milkie/AgentRuntime 三处签名一致；`ChildAgentRecord.runId?: string` 在 store.ts 定义、recordChild 各调用点填充。
+- **已知取舍**：`makeChildPort` 仅在 `eventStore` 存在时注入 ⟺ 子才有独立 RecordingIOPort；无 eventStore 时子 port 回退父 ioPort（DefaultIOPort，不录事件，无 runId 错配）。

--- a/docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md
+++ b/docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md
@@ -1,0 +1,197 @@
+# sub-agent 一类公民化：独立 runId + 独立可 replay（#47）
+
+**Issue:** #47 [replay/fork P0] sub-agent 一类公民化：独立 runId + nested sub-trace + 递归 replay
+**Parent:** #20（Trace substrate gap）
+**Depends on:** #24（父锚点 agent.spawned/returned + childRunId 字段，已合并）
+**Date:** 2026-05-29
+
+## 背景
+
+#24 落地了 ARCH invariant #11 目标态的前半「one event」——父 run emit `agent.spawned` /
+`agent.returned` 锚点。本 issue 落地后半「nested sub-trace」：让子 agent 成为一类公民
+（独立 runId、自己的 `<childRunId>.jsonl`、自己的 `agent.run.started/completed`、可被独立
+replay）。
+
+### 现状（被 #47 修复的洞）
+
+子 agent 经 `makeSubAgentTool` 调用，调用本身走父的 `ioPort.invokeTool`
+（`AgentRuntime.ts:1066`）。spawn 时子复用父的 `agentRunId` 与父的 `RecordingIOPort`
+（`AgentRuntime.ts:242,245`）：
+
+- 子的 llm/tool/clock/uuid 事件全 append 到**父的** runId，挤在父的一条 jsonl，没有独立
+  sub-trace；
+- 子不调 `attach/detach`，**不** emit 自己的 `agent.run.started/completed`；
+- 子即便声明了不同 model，LLM 调用实际走的是**父的** gateway（子复用父 ioPort，其 inner
+  `DefaultIOPort` 包的是父 gateway）——一个连带的隐 bug。
+
+### 关键事实：sub-agent 的 output 被记成父的 tool 结果
+
+子 agent tool 的 handler 在父的 `ioPort.invokeTool(agentId, {goal,input}, execute)` 内执行，
+返回值是子 `AgentResult.output`。于是 record 时父流里产生一对
+`tool.requested` / `tool.responded`，**`tool.responded.output` 即子的最终 output**。
+
+而 `ReplayingIOPort.invokeTool` 从 cache 按 `hashToolCall` 吐 output、**不调 execute()**
+（`ReplayingIOPort.ts:38-55`）。因此父 replay 到子 tool 时**不会重跑子**——子的 output 直接从
+父 cache 取。
+
+由此推断（机制层面，当前无测试覆盖）：**带 sub-agent 的 run 今天 replay 是坏的**——子内部
+llm/clock/uuid 事件在父流里、而父 replay 短路了子 tool，这些事件无人消费 → tail under-consume
+→ `ReplayDivergenceError`。`Replay.test.ts` 9 个用例无一带 sub-agent，故未被撞到。这正是本
+issue 的核心要修的。
+
+## Scope 决策（重要）：模型 I 而非递归 replay
+
+#47 正文 Scope 第 4 条与验收第 4 条字面写的是「`Milkie.replay` 沿 spawn 树**递归下钻**」。
+本设计**不采用递归**，改用「子是不透明 tool 结果 + 每条 run 独立可 replay」的模型 I。
+
+两个模型：
+
+- **模型 I（采用）**：父 replay 到子 tool 时照常从父 cache 吐录好的 output、不重跑子。子 I/O
+  移入 `<childRunId>.jsonl` 后，父 cache 里子相关只剩那一条 `tool.responded` → 父 replay 干净
+  消费。要看/replay 子，单独 `Milkie.replay(childRunId)` 重放子文件。「nested sub-trace」退化
+  为导航/视图概念（顺 `agent.spawned.childRunId` 加载、按需独立 replay）。
+- **模型 II（否决）**：父 replay 重新 spawn 子、子从自己 cache 跑。代价：(1) **双真相**——子
+  output 既是父 cache 的 `tool.responded` 又是重跑子的产物，二者必须永远相等，且为强制递归还得
+  把父那条 `tool.responded` 排除出 cache（连 record 侧也要改）；(2) **吞错捕获**——子 `run()`
+  把异常吞成 `status:'error'`（`AgentRuntime.ts:793-799`），子的 `ReplayDivergenceError` 不会
+  上抛，须给每个子 port 套 divergence-capture proxy 并让其穿过整棵树冒到顶层重抛。
+
+模型 II 的唯一收益是 **fork**（父 replay 到某点后让子活着跑出不同结果）。fork 在 #47 是
+Related/Blocks 的未来项，验收只要求「replay 结果一致」。模型 I 直接满足该意图——父的结果完全由
+其 cache 里那条子 output 决定，子的内部确定性对父无关紧要——且避免了双真相与吞错捕获两个根
+问题。故：**收益不明显的递归不做。**
+
+**与 #47 字面的偏离需记账**：本设计满足 #47 验收的*意图*（replay 一致 + 子有独立 sub-trace +
+子独立可 replay），但机制上不递归。建议**更新 #47 正文**：把「递归下钻」改为「子独立可 replay +
+导航跟随」，并把递归 replay 归入未来 fork issue（fork 时双真相会被正面解决，那才是它该被解决的
+地方）。
+
+## 设计
+
+### 1. Record 侧（本 issue 主体）
+
+**(a) 注入 per-child port 工厂**（仿现有 `childRecorderFactory`，Milkie → AgentRuntime）：
+
+```ts
+makeChildPort?: (childRunId: string, childConfig: AgentConfig) => IIOPort
+```
+
+Milkie 实现：
+
+```ts
+(childRunId, childConfig) =>
+  new RecordingIOPort(
+    new DefaultIOPort(this.gatewayOverride ?? createGateway(childConfig.model)),
+    this.eventStore!,
+    childRunId,
+  )
+```
+
+`createGateway` / `RecordingIOPort` 留在 Milkie（它们本就住那），runtime 只拿一个 `IIOPort`
+工厂 → 不违反 invariant #3（runtime 不依赖 Agent Trace）。子用自己的 model gateway，顺带修掉
+「子走父 model」隐 bug。`gatewayOverride` 仍优先。
+
+**(b) spawn 路径改写**（`makeSubAgentTool.handler` 内 + 构造子 runtime 的 `spawnFn`）：
+
+- 子不再复用 `this.ioPort`，改用 `makeChildPort(childRunId, subConfig)` 铸的独立 port；
+- 子 `AgentRuntime`：`agentRunId = childRunId`（独立）、`parentId = this.agentRunId`；
+- 在子 `run()` 前后对子 port 调 `attach({parentId})` / `detach({status})` → 子 emit 自己的
+  `agent.run.started{parentId}` / `agent.run.completed{status}` 进 `<childRunId>.jsonl`；
+- 回退：`makeChildPort` 未注入时回退到 `this.ioPort`（replay 路径不注入；replay 也不进 handler，
+  见 §2）。
+
+attach/detach 是 `RecordingIOPort` 上的方法（非 `IIOPort` 契约）。在 spawn seam 用
+`instanceof RecordingIOPort` 守卫调用，与 `Milkie.invoke`（`Milkie.ts:219`）同款处理。
+
+**(c) childRunId 用直 `uuidv4()`（信息性，绕 cache）**。模型 I 下父 replay 不重跑子，childRunId
+无需 replay 可复现；其可发现性由 `agent.spawned.childRunId` 保证。
+
+**(d) 关键收口：父侧子边界 id 改信息性。** 今天 `childContextId` / `childTraceId` / `taskId`
+走 `this.ioPort.uuid()`（`AgentRuntime.ts:217,218,220`）→ 进父 cache。模型 I 下 replay 短路子
+tool、不进 handler → 这些 uuid 不被消费 → under-consume 散度。解法：三者改直 `uuidv4()`
+（对父 replay 它们是信息性的；子独立 replay 用的是子文件里自己的 contextId）。**这是模型 I
+自洽的前提**。注意 `batchId`（`AgentRuntime.ts:1009`，在 `invokeTool` 之前的 executeTools 里）
+保持走 ioPort.uuid()——它在 handler 之外、replay 照常分配与消费，不受影响。
+
+### 2. Replay 侧（近乎零改动）
+
+`Milkie.replay(父runId)`：**基本不动**。子 tool 照常被 `ReplayingIOPort.invokeTool` 从父 cache
+吐 output、不重跑子。配合 §1，父 cache 里子相关只剩那条 `tool.responded` → over/under-consume
+皆通过。
+
+子独立 replay：`Milkie.replay(childRunId)` 直接把 `<childRunId>.jsonl` 当顶层 run 重放——已有
+机制即可（`extractRunSnapshot` 读子文件 `agent.run.started` 拿 goal/input/contextId/parentId）。
+
+`parentId` 无需新增 schema：`AgentRunStartedPayload.parentId` 已是可选字段（`types.ts:87`）且
+`extractRunSnapshot` 已读取（`RunSnapshot.ts:37`），顶层目前传 undefined。本 issue 只需在子的
+`attach()` 时**填** `parentId = 父 runId`，满足验收「子 `agent.run.started.parentId` == 父
+runId」。
+
+### 3. 数据模型 + resume
+
+- `ChildAgentRecord` 加 `runId` 字段（= childRunId），随父 checkpoint 的 `children[]` 持久化
+  →给出子的**持久身份**，支撑 lineage 与 resume 续跑。
+- `agent.spawned` / `agent.returned` 的 `childRunId` 值从 childContextId 升级为真 childRunId
+  （只换值，schema 不变——#24 已留好）。
+
+**resume 续跑（B 的归属）**：用户选 B（子延续同一 runId，理由：runId 是 run 的稳定身份，中断是
+暂停非结束；不然 invariant #11「一个事件 + 一条 sub-trace」只对没被中断过的子成立；且与 fork
+焊死）。本 issue **把身份做到位**（持久化 `runId`），但完整的「父 resume → 子按稳定键续跑同一
+`<childRunId>.jsonl`」留明确 follow-up，理由：
+
+- 当前无测试要求 resume 续跑（现有 supervisor 测试只覆盖中断传播 + 子 checkpoint 记录，
+  `AgentRuntime.test.ts:375`）；
+- resume 时父重新 spawn 要**匹配回**之前的 `ChildAgentRecord` 才能复用 runId，而当前
+  `taskId`/`contextId` 每次 spawn 新生成、无稳定匹配键。完整续跑需引入稳定 spawn 键（如
+  父 turn + 子 agentId + 调用序号），属独立工作量。
+
+故本 issue：身份持久化（runId 进 record）+ 留 follow-up issue 做稳定键与续跑执行。
+
+### 4. 错误处理
+
+- 子 run 报错：父 `tool.responded` 记 error（已有路径，`RecordingIOPort.ts:184-204`）+ 父
+  `agent.returned{status:'error'}`（#24 已有）；子文件含子自己的
+  `agent.run.completed{status:'error'}`。
+- 无新增吞错风险：模型 I 不重跑子，不存在「子 run() 吞 divergence」的捕获问题。
+- 子 port 写入失败：沿用 `RecordingIOPort` best-effort 语义，不改子业务结果。
+
+## 测试（`src/__tests__/`，沿用 StubGateway + sub-agent harness）
+
+1. 父 spawn 子 → 子 llm/tool/clock/uuid 落 `<childRunId>.jsonl`；父流子相关只含 sub-agent 的
+   `tool.requested/responded` + `agent.spawned/returned`（无子 llm 事件）；
+2. 子文件含 `agent.run.started{parentId == 父runId}` / `agent.run.completed{status}`；
+   `agent.spawned.childRunId == 子文件 runId == agent.returned.childRunId`；
+3. **`Milkie.replay(父runId)` 结果与原 run 一致、无 divergence**（今天坏的，本 issue 转绿——
+   核心验收）；
+4. `Milkie.replay(childRunId)` 独立重放子、无 divergence；
+5. 子声明的 model 与父不同时，子 LLM 走子自己的 gateway；
+6. `ChildAgentRecord.runId` 持久化进父 checkpoint；
+7. 现有单 run replay（`Replay.test.ts`）+ supervisor 中断/恢复（`AgentRuntime.test.ts`）全绿。
+
+## 验收（本 issue 范围内）
+
+- [ ] 子 agent 拥有独立 `agentRunId`，I/O 落 `<childRunId>.jsonl`
+- [ ] 子 emit `agent.run.started{parentId == 父runId}` / `agent.run.completed{status}`
+- [ ] `agent.spawned.childRunId` == 子 run 文件的 runId（值升级为真 childRunId）；
+      `agent.returned.childRunId` 与之一致、status 与子 `agent.run.completed.status` 一致
+- [ ] `Milkie.replay(父runId)` 能 replay 含 sub-agent 的 run，结果与原 run 一致、不
+      over/under-consume（经模型 I：子 tool 由父 cache 吐 output；父侧子边界 id 信息性化）
+- [ ] `Milkie.replay(childRunId)` 能独立重放子 run
+- [ ] 子用自己 model 的 gateway（修连带 bug）
+- [ ] `ChildAgentRecord.runId` 持久化
+- [ ] 现有单 run replay + supervisor 中断/恢复 + skill 生命周期测试全绿
+
+## 显式 deferral（不在本 issue）
+
+- 递归 replay（模型 II）：否决，归入未来 fork issue；
+- 父 resume → 子按稳定键续跑同一 `<childRunId>.jsonl` 的**执行**（本 issue 只做身份持久化）→
+  新 follow-up（稳定 spawn 键 + 续跑）；
+- fork（replay 到某点后子活着分叉）；
+- `causedBy`（→ #30）。
+
+## Related
+
+- ARCH.md invariant #11、L17（runs addressable/replayable）、L402
+- 依据：`docs/superpowers/specs/2026-05-29-agent-spawn-return-events-design.md`（#24，(1)/(2) 焊缝）
+- Blocks: #27（sub-agent tree 跨 run 导航）；lineage 跨 run（#37 / #41）
+- Follow-on: 父 resume→子续跑（稳定 spawn 键）；fork issue（递归 replay 在此落地）

--- a/docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md
+++ b/docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md
@@ -70,11 +70,21 @@ Related/Blocks 的未来项，验收只要求「replay 结果一致」。模型 
 
 ### 1. Record 侧（本 issue 主体）
 
-**(a) 注入 per-child port 工厂**（仿现有 `childRecorderFactory`，Milkie → AgentRuntime）：
+**(a) 给子铸一个绑 childRunId 的 RecordingIOPort（record-only）。** 子要把自己的 I/O 录进独立的
+`<childRunId>.jsonl`，而 `RecordingIOPort` 构造时绑死一个 `runId`、每条事件都盖它
+（`RecordingIOPort.ts:57-62,127`）；今天子复用父 port 故事件盖成父 runId。要分流，子必须有自己
+的、绑到 childRunId 的 `RecordingIOPort`。
+
+造它需要 inner gateway，而 gateway/`createGateway` 只住在 Milkie（runtime 只收一个包装好的
+`IIOPort`、够不到 gateway）。故由 Milkie 注入一个工厂（仿现有 `childRecorderFactory`），runtime
+保持对 Agent Trace 无知（invariant #3）：
 
 ```ts
 makeChildPort?: (childRunId: string, childConfig: AgentConfig) => IIOPort
 ```
+
+此工厂**仅 record 用、同步、单分支**——replay 不重跑子故不调它（与模型 II 截然不同：模型 II 的
+工厂还要异步读子文件、建子 CacheIndex、套 ReplayingIOPort、接散度聚合器）。
 
 Milkie 实现：
 

--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -419,6 +419,53 @@ describe('AgentRuntime', () => {
       expect(parentCp.children.every(c => c.checkpointId)).toBe(true)
     })
 
+    it('persists child runId in the parent checkpoint children records', async () => {
+      const stateStore = new MemoryStore()
+      const milkie = new Milkie({
+        stateStore,
+        gateway: new SupervisorGateway(),
+      })
+
+      milkie.registerAgent(makeConfig({
+        agentId: 'worker-a',
+        fsm: { states: [{ name: 'react', type: 'llm' }] },
+      }))
+      milkie.registerAgent(makeConfig({
+        agentId: 'worker-b',
+        fsm: { states: [{ name: 'react', type: 'llm' }] },
+      }))
+      milkie.registerAgent(makeConfig({
+        agentId: 'supervisor',
+        fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 3 }] },
+        subAgents: {
+          'worker-a': '1.0.0',
+          'worker-b': '1.0.0',
+        },
+      }))
+
+      const runPromise = milkie.invoke({
+        agentId:   'supervisor',
+        goal:      'coordinate workers',
+        input:     'start workers',
+        contextId: 'ctx-supervisor-runid',
+      })
+
+      await waitFor(async () => {
+        const children = await stateStore.get('context:ctx-supervisor-runid:children') as Array<{ status: string }> | undefined
+        return (children ?? []).filter(c => c.status === 'running').length === 2
+      })
+
+      await milkie.interrupt('ctx-supervisor-runid')
+      await runPromise
+
+      const parentCp = await stateStore.get('context:ctx-supervisor-runid:checkpoint:latest') as AgentCheckpoint
+      expect(parentCp.children.length).toBeGreaterThan(0)
+      for (const c of parentCp.children) {
+        expect(typeof c.runId).toBe('string')
+        expect((c.runId ?? '').length).toBeGreaterThan(0)
+      }
+    })
+
     it('emits agent.returned interrupted when sub-agents are interrupted', async () => {
       const stateStore = new MemoryStore()
       const eventStore = new MemoryEventStore()

--- a/src/__tests__/Replay.test.ts
+++ b/src/__tests__/Replay.test.ts
@@ -23,6 +23,50 @@ const text = (s: string): ModelResponse => ({
   content: [{ type: 'text', text: s }], toolCalls: [], finishReason: 'end_turn',
 })
 
+// ---- StubGateway + helpers (shared with sub-agent replay test) ----
+
+class StubGateway implements IModelGateway {
+  private responses: ModelResponse[]
+  constructor(responses: ModelResponse[]) { this.responses = responses }
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const r = this.responses.shift()
+    if (!r) throw new Error('No more stub responses')
+    return r
+  }
+  async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+
+const textResponse = (t: string): ModelResponse => ({
+  content: [{ type: 'text', text: t }], toolCalls: [], finishReason: 'end_turn',
+})
+
+const toolCallResponse = (id: string, name: string, input: unknown): ModelResponse => ({
+  content:      [{ type: 'tool_use', id, name, input }],
+  toolCalls:    [{ id, name, input }],
+  finishReason: 'tool_use',
+})
+
+function supervisorConfig(): AgentConfig {
+  return {
+    agentId:      'supervisor',
+    version:      '0.0.0',
+    systemPrompt: 'system',
+    fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 3 }] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+    subAgents: { worker: '1.0.0' },
+  }
+}
+
+function workerConfig(): AgentConfig {
+  return {
+    agentId:      'worker',
+    version:      '0.0.0',
+    systemPrompt: 'system',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  }
+}
+
 const oneShotAgent = (agentId = 'a1'): AgentConfig => ({
   agentId,
   version: '0.0.0',
@@ -305,5 +349,43 @@ describe('Milkie.replay', () => {
     expect(replayed.status).toBe(original.status)
     expect(replayed.output).toBe(original.output)
     expect(replayGateway.callCount).toBe(0)
+  })
+
+  // ── Test: Sub-agent replay (issue #47) ────────────────────────────────────
+  //
+  // A parent run that spawned a sub-agent must replay cleanly with no
+  // divergence: no over-consume (cache miss mid-run) and no under-consume
+  // (recorded events left unconsumed at the end). Under model-I the child
+  // I/O is recorded under its own childRunId stream; the parent records the
+  // sub-agent call as a tool.responded. The parent-side boundary ids
+  // (childRunId, childContextId, taskId, childTraceId) are plain uuidv4(),
+  // so no ioPort cache entries are generated for them — the parent cache
+  // only contains what the parent itself consumed.
+  it('replays a run containing a sub-agent with no divergence', async () => {
+    const eventStore = new MemoryEventStore()
+    const record = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+        textResponse('worker done'),
+        textResponse('all done'),
+      ]),
+      eventStore,
+    })
+    record.registerAgent(supervisorConfig())
+    record.registerAgent(workerConfig())
+    const orig = await record.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+
+    const replay = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([]),   // replay must not touch the gateway
+      eventStore,
+    })
+    replay.registerAgent(supervisorConfig())
+    replay.registerAgent(workerConfig())
+
+    const replayed = await replay.replay(orig.agentRunId)
+    expect(replayed.status).toBe('completed')
+    expect(replayed.output).toBe(orig.output)   // 'all done'
   })
 })

--- a/src/__tests__/Replay.test.ts
+++ b/src/__tests__/Replay.test.ts
@@ -6,6 +6,7 @@ import { ReplayDivergenceError } from '../trace/ReplayDivergenceError'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
 import type { ToolDefinition } from '../types/tool'
+import type { AgentSpawnedPayload } from '../trace/types'
 
 class SequentialGateway implements IModelGateway {
   public callCount = 0
@@ -387,5 +388,31 @@ describe('Milkie.replay', () => {
     const replayed = await replay.replay(orig.agentRunId)
     expect(replayed.status).toBe('completed')
     expect(replayed.output).toBe(orig.output)   // 'all done'
+  })
+
+  it('replays a child run standalone by its childRunId', async () => {
+    const eventStore = new MemoryEventStore()
+    const record = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+        textResponse('worker done'),
+        textResponse('all done'),
+      ]),
+      eventStore,
+    })
+    record.registerAgent(supervisorConfig())
+    record.registerAgent(workerConfig())
+    const orig = await record.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+    const parentEvents = await eventStore.readByRunId(orig.agentRunId)
+    const childRunId = (parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload).childRunId
+
+    const replay = new Milkie({ stateStore: new MemoryStore(), gateway: new StubGateway([]), eventStore })
+    replay.registerAgent(supervisorConfig())
+    replay.registerAgent(workerConfig())
+
+    const child = await replay.replay(childRunId)
+    expect(child.status).toBe('completed')
+    expect(child.output).toBe('worker done')
   })
 })

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -21,6 +21,8 @@ import type {
   SkillLifecyclePayload,
   AgentSpawnedPayload,
   AgentReturnedPayload,
+  AgentRunStartedPayload,
+  AgentRunCompletedPayload,
 } from '../trace/types'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
@@ -639,6 +641,34 @@ describe('agent.spawned / agent.returned events', () => {
     const childLlm = childEvents.filter(e => e.type === 'llm.requested')
     expect(childLlm.length).toBeGreaterThan(0)
     expect(parentLlm.length).toBe(2)
+  })
+
+  it('child run emits agent.run.started{parentId} and agent.run.completed in its own stream', async () => {
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+        textResponse('worker done'),
+        textResponse('all done'),
+      ]),
+      eventStore,
+    })
+    milkie.registerAgent(supervisorConfig())
+    milkie.registerAgent(workerConfig())
+
+    const result = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+    const parentEvents = await eventStore.readByRunId(result.agentRunId)
+    const spawned = parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload
+
+    const childEvents = await eventStore.readByRunId(spawned.childRunId)
+    const started = childEvents.find(e => e.type === 'agent.run.started')!
+    const completed = childEvents.find(e => e.type === 'agent.run.completed')!
+    expect(childEvents[0]!.type).toBe('agent.run.started')
+    expect((started.payload as AgentRunStartedPayload).parentId).toBe(result.agentRunId)
+    expect((started.payload as AgentRunStartedPayload).agentId).toBe('worker')
+    expect((completed.payload as AgentRunCompletedPayload).status).toBe('completed')
+    expect(started.runId).toBe(spawned.childRunId)
   })
 })
 

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -670,6 +670,17 @@ describe('agent.spawned / agent.returned events', () => {
     expect((completed.payload as AgentRunCompletedPayload).status).toBe('completed')
     expect(started.runId).toBe(spawned.childRunId)
   })
+
+  it('child port factory resolves gateway from child config', async () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
+    const make = (milkie as any)['buildMakeChildPort']()
+    expect(make).not.toBeNull()
+    expect(make).not.toBeUndefined()
+    const bogus = { ...workerConfig(), model: { provider: 'x', model: 'm', adapter: 'no-such-adapter' } }
+    await expect(make('child-run-1', bogus, {
+      agentId: 'worker', goal: 'g', input: 'i', contextId: 'c', parentId: 'p',
+    })).rejects.toThrow(/no-such-adapter/)
+  })
 })
 
 // ---- fsm.transition (#21) ----

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -613,6 +613,33 @@ describe('agent.spawned / agent.returned events', () => {
     expect(returned.status).toBe('error')
     expect(returned.childRunId).toBe(spawned.childRunId)
   })
+
+  it('records child LLM I/O under an independent childRunId, not the parent run', async () => {
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+        textResponse('worker done'),
+        textResponse('all done'),
+      ]),
+      eventStore,
+    })
+    milkie.registerAgent(supervisorConfig())
+    milkie.registerAgent(workerConfig())
+
+    const result = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+    const parentEvents = await eventStore.readByRunId(result.agentRunId)
+
+    const spawned = parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload
+    expect(spawned.childRunId).not.toBe(result.agentRunId)
+
+    const parentLlm = parentEvents.filter(e => e.type === 'llm.requested')
+    const childEvents = await eventStore.readByRunId(spawned.childRunId)
+    const childLlm = childEvents.filter(e => e.type === 'llm.requested')
+    expect(childLlm.length).toBeGreaterThan(0)
+    expect(parentLlm.length).toBe(2)
+  })
 })
 
 // ---- fsm.transition (#21) ----

--- a/src/runtime/AgentFactory.ts
+++ b/src/runtime/AgentFactory.ts
@@ -15,7 +15,9 @@ export interface AgentSpawnOptions {
   stateStore:  IStateStore
   recorder:    ITrajectoryRecorder
   ioPort:      IIOPort
-  extraTools?: ToolDefinition[]
+  extraTools?:    ToolDefinition[]
+  eventStore?:    import('../trace/EventStore.js').IEventStore
+  makeChildPort?: import('./AgentRuntime.js').MakeChildPort
 }
 
 // Forward declaration to avoid circular import — resolved at runtime

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -239,15 +239,15 @@ export class AgentRuntime {
 
         let childPort: IIOPort = this.ioPort
         let finish: ((c: AgentRunCompletedPayload) => Promise<void>) | null = null
-        if (this.makeChildPort) {
-          const built = await this.makeChildPort(childRunId, subConfig, {
-            agentId, goal, input: subInput, contextId: childContextId, parentId: this.agentRunId,
-          })
-          childPort = built.port
-          finish    = built.finish
-        }
 
         try {
+          if (this.makeChildPort) {
+            const built = await this.makeChildPort(childRunId, subConfig, {
+              agentId, goal, input: subInput, contextId: childContextId, parentId: this.agentRunId,
+            })
+            childPort = built.port
+            finish    = built.finish
+          }
           const result = await ctx.agentFactory.spawn({
             config:        subConfig,
             goal,

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -35,7 +35,13 @@ import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
 import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
 import type { Region } from '../context/Region.js'
-import type { SkillLifecyclePayload } from '../trace/types.js'
+import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload } from '../trace/types.js'
+
+export type MakeChildPort = (
+  childRunId:  string,
+  childConfig: AgentConfig,
+  start:       AgentRunStartedPayload,
+) => Promise<{ port: IIOPort; finish: (c: AgentRunCompletedPayload) => Promise<void> }>
 
 export interface AgentRuntimeOptions {
   config:            AgentConfig
@@ -59,6 +65,7 @@ export interface AgentRuntimeOptions {
   extraTools?:       ToolDefinition[]
   subAgentConfigs?:  Map<string, AgentConfig>  // agentId → config, for spawning
   childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
+  makeChildPort?: MakeChildPort
 }
 
 type SkillLoadRequest = {
@@ -81,6 +88,7 @@ export class AgentRuntime {
   private readonly traceObjectStore?: ITraceObjectStore
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
+  private readonly makeChildPort?: MakeChildPort
   private readonly extraTools:      ToolDefinition[]
 
   private readonly fsm:         FSMEngine
@@ -116,6 +124,7 @@ export class AgentRuntime {
     this.traceObjectStore = opts.traceObjectStore
     this.subAgentConfigs = opts.subAgentConfigs
     this.childRecorderFactory = opts.childRecorderFactory
+    this.makeChildPort   = opts.makeChildPort
     this.extraTools      = opts.extraTools ?? []
 
     this.fsm     = new FSMEngine(opts.config.fsm)
@@ -135,8 +144,10 @@ export class AgentRuntime {
     this.factory = new AgentFactory(async (spawnOpts: AgentSpawnOptions) => {
       const child = new AgentRuntime({
         ...spawnOpts,
-        parentId: this.agentRunId,
+        parentId:             this.agentRunId,
         childRecorderFactory: this.childRecorderFactory,
+        eventStore:           this.eventStore,
+        makeChildPort:        this.makeChildPort,
       })
       return child.run(spawnOpts.input)
     })
@@ -214,65 +225,64 @@ export class AgentRuntime {
           throw new Error(`Sub-agent config not found: ${agentId}. Pass subAgentConfigs to AgentRuntime.`)
         }
 
-        const childTraceId = this.ioPort.uuid()
-        const childContextId = this.ioPort.uuid()
+        const childTraceId   = uuidv4()
+        const childContextId = uuidv4()
+        const taskId         = uuidv4()
+        const childRunId     = uuidv4()
+
         const childRecorder = this.childRecorderFactory?.(subConfig, childContextId, childTraceId) ?? this.recorder
-        const taskId = this.ioPort.uuid()
         const spawnSpan = this.recorder.startSpan('agent.spawn', {
-          childAgentId: agentId,
-          taskId,
-          turn:         this.turnNumber,
-          childTraceId,
-          childContextId,
+          childAgentId: agentId, taskId, turn: this.turnNumber, childTraceId, childContextId, childRunId,
         })
-        await this.recordChild({
-          taskId,
-          agentId,
-          contextId: childContextId,
-          status: 'running',
-        })
-        this.emitAgentSpawned(childContextId, agentId, goal)
+        await this.recordChild({ taskId, agentId, runId: childRunId, contextId: childContextId, status: 'running' })
+        this.emitAgentSpawned(childRunId, agentId, goal)
+
+        let childPort: IIOPort = this.ioPort
+        let finish: ((c: AgentRunCompletedPayload) => Promise<void>) | null = null
+        if (this.makeChildPort) {
+          const built = await this.makeChildPort(childRunId, subConfig, {
+            agentId, goal, input: subInput, contextId: childContextId, parentId: this.agentRunId,
+          })
+          childPort = built.port
+          finish    = built.finish
+        }
 
         try {
           const result = await ctx.agentFactory.spawn({
-            config:      subConfig,
+            config:        subConfig,
             goal,
-            input:       subInput,
-            contextId:   childContextId,
-            agentRunId:   this.agentRunId,
-            stateStore:  this.stateStore,
-            recorder:    childRecorder,
-            ioPort:      this.ioPort,
-            extraTools:  this.extraTools,
+            input:         subInput,
+            contextId:     childContextId,
+            agentRunId:    childRunId,
+            stateStore:    this.stateStore,
+            recorder:      childRecorder,
+            ioPort:        childPort,
+            extraTools:    this.extraTools,
+            eventStore:    this.eventStore,
+            makeChildPort: this.makeChildPort,
           })
+          await finish?.({ status: result.status, lastTextOutput: result.output })
+
           const childCheckpoint = result.status === 'interrupted'
             ? await this.stateStore.get(`context:${childContextId}:checkpoint:latest`) as AgentCheckpoint | undefined
             : undefined
           await this.recordChild({
-            taskId,
-            agentId,
-            contextId:     childContextId,
-            checkpointId:  childCheckpoint?.checkpointId,
-            status:        result.status === 'interrupted' ? 'interrupted' : result.status === 'completed' ? 'success' : 'error',
+            taskId, agentId, runId: childRunId, contextId: childContextId,
+            checkpointId: childCheckpoint?.checkpointId,
+            status: result.status === 'interrupted' ? 'interrupted' : result.status === 'completed' ? 'success' : 'error',
           })
           this.recorder.recordEvent(spawnSpan, 'agent.spawn.complete', { resultStatus: result.status })
-          this.emitAgentReturned(childContextId, result.status)
-          spawnSpan.attributes['resultStatus']  = result.status
-          spawnSpan.attributes['childTraceId']  = childTraceId
+          this.emitAgentReturned(childRunId, result.status)
+          spawnSpan.attributes['resultStatus']   = result.status
+          spawnSpan.attributes['childTraceId']   = childTraceId
           spawnSpan.attributes['childContextId'] = childContextId
-          if (childCheckpoint?.checkpointId) {
-            spawnSpan.attributes['checkpointId'] = childCheckpoint.checkpointId
-          }
+          if (childCheckpoint?.checkpointId) spawnSpan.attributes['checkpointId'] = childCheckpoint.checkpointId
           this.recorder.endSpan(spawnSpan, 'ok')
           return result.output
         } catch (err) {
-          await this.recordChild({
-            taskId,
-            agentId,
-            contextId: childContextId,
-            status: 'error',
-          })
-          this.emitAgentReturned(childContextId, 'error')
+          await finish?.({ status: 'error', error: err instanceof Error ? err.message : String(err) })
+          await this.recordChild({ taskId, agentId, runId: childRunId, contextId: childContextId, status: 'error' })
+          this.emitAgentReturned(childRunId, 'error')
           spawnSpan.attributes['resultStatus'] = 'error'
           this.recorder.endSpan(spawnSpan, 'error')
           throw err

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -67,6 +67,18 @@ export class Milkie {
       : base
   }
 
+  private buildMakeChildPort(): import('./AgentRuntime.js').MakeChildPort | undefined {
+    if (!this.eventStore) return undefined
+    const eventStore = this.eventStore
+    const gatewayOverride = this.gatewayOverride
+    return async (childRunId, childConfig, start) => {
+      const gw   = gatewayOverride ?? createGateway(childConfig.model)
+      const port = new RecordingIOPort(new DefaultIOPort(gw), eventStore, childRunId)
+      await port.attach(start)
+      return { port, finish: (c) => port.detach(c) }
+    }
+  }
+
   registerTool(tool: ToolDefinition): void {
     this.extraTools.push(tool)
   }
@@ -195,6 +207,7 @@ export class Milkie {
       : new InMemoryRecorder(undefined, config.agentId)
 
     const ioPort = this.wrapIOPort(gateway, agentRunId)
+    const makeChildPort = this.buildMakeChildPort()
 
     const runtime = new AgentRuntime({
       config,
@@ -210,6 +223,7 @@ export class Milkie {
       extraTools:      this.extraTools,
       subAgentConfigs: this.agents,
       childRecorderFactory,
+      makeChildPort,
     })
 
     if (restoredCheckpoint) {
@@ -287,6 +301,7 @@ export class Milkie {
       extraTools:      this.extraTools,
       subAgentConfigs: this.agents,
       childRecorderFactory,
+      makeChildPort:   this.buildMakeChildPort(),
     })
 
     await runtime.loadCheckpoint(checkpoint)

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -287,6 +287,8 @@ export class Milkie {
       })
       : new InMemoryRecorder(checkpoint.meta.traceId || undefined, config.agentId)
 
+    const makeChildPort = this.buildMakeChildPort()
+
     const runtime = new AgentRuntime({
       config,
       goal,
@@ -301,7 +303,7 @@ export class Milkie {
       extraTools:      this.extraTools,
       subAgentConfigs: this.agents,
       childRecorderFactory,
-      makeChildPort:   this.buildMakeChildPort(),
+      makeChildPort,
     })
 
     await runtime.loadCheckpoint(checkpoint)

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -97,8 +97,8 @@ export interface AgentSpawnedPayload {
   /** 父 AgentRuntime.agentRunId。 */
   parentRunId: string
   /**
-   * 子运行的稳定身份。今天子复用父 runId，此字段填子的 contextId；
-   * #47（sub-agent 一类公民化）落地后改填子的独立 runId——只换值不换 schema。
+   * 子运行的独立 runId（父在 spawn 时铸造）。子的 I/O 事件以此 id 存入 event store，
+   * 可经 Milkie.replay(childRunId) 独立重放。
    */
   childRunId:  string
   agentId:     string

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -48,7 +48,8 @@ export interface AgentEvent {
 export interface ChildAgentRecord {
   taskId:        string
   agentId:       string
-  contextId?:     string
+  runId?:        string
+  contextId?:    string
   checkpointId?: string
   status:        'running' | 'success' | 'error' | 'interrupted'
 }


### PR DESCRIPTION
## Summary

让 sub-agent 成为 Agent Trace 的一类公民(#47,parent #20),采用 **模型 I**(子=不透明 tool 结果 + 每条 run 独立可 replay),**不做递归 replay**。

- 子 spawn 时获得**独立 `runId`** + 自己的 `RecordingIOPort`(用子自己 model 的 gateway),I/O 落 `<childRunId>.jsonl`,不再挤进父流
- 子 emit 自己的 `agent.run.started{parentId=父runId}` / `agent.run.completed{status}`
- `agent.spawned/returned.childRunId` 升级为子的真 runId(只换值不改 schema)
- 父侧子边界 id(childTraceId/childContextId/taskId/childRunId)改为信息性 `uuidv4()`(绕 replay cache)—— 这是父 replay 无 divergence 的关键收口
- **父 replay 不重跑子**:子 tool 由父 cache 吐 output。含 sub-agent 的 run 此前 replay 是坏的(under-consume),本 PR 转绿
- 子可经 `Milkie.replay(childRunId)` **独立重放**
- `ChildAgentRecord.runId` 持久化(子的稳定身份)
- 顺带修掉「子复用父 ioPort 导致子实际走父 model」的隐 bug

### 为何不做递归 replay
递归(模型 II)的唯一收益是 fork(未来项),代价是双真相 + 子 `run()` 吞 divergence 的捕获难题。模型 I 直接满足「replay 结果一致」的验收意图。偏离 #47 原文「递归下钻」一节已在 spec 记账,issue 正文已更新。

设计与计划:
- `docs/superpowers/specs/2026-05-29-sub-agent-first-class-replay-design.md`
- `docs/superpowers/plans/2026-05-29-sub-agent-first-class-replay.md`

## Test plan

- [x] 子 I/O 落 `<childRunId>.jsonl`,父流不含子 llm 事件
- [x] 子 `agent.run.started{parentId}` / `completed`(子流第一帧)
- [x] `Milkie.replay(父runId)` 含 sub-agent 无 divergence(核心,此前坏)
- [x] `Milkie.replay(childRunId)` 独立重放子
- [x] `ChildAgentRecord.runId` 持久化进父 checkpoint
- [x] 子用自己 model 的 gateway
- [x] 全量回归:284/284 单测 + `tsc` build 干净;#24 spawn/returned、supervisor 中断/恢复无回归

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)