### PR TITLE
feat(trace): tool.responded output metadata (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ The runtime, an event-sourced **Agent Trace**, and a deterministic
 - **Inter-agent parallelism** — sub-agents declared as named tools; orchestrators spawn them in parallel across independent FSM + context instances
 - **Interrupt / Resume** — cooperative yield points save checkpoints; any interrupted run resumes from the exact state
 - **Multi-turn conversations** — share a `contextId` across `invoke()` calls to accumulate history
-- **Event-sourced Agent Trace** — append-only event log records every LLM / tool I/O with `causedBy` chains; `Milkie.replay(runId)` re-runs a recorded run from the log with zero live LLM calls (Phase 3 structural replay)
+- **Event-sourced Agent Trace** — append-only event log records every LLM / tool I/O with `causedBy` chains; `Milkie.replay(runId)` re-runs a recorded run from the log with zero live LLM calls (byte-identical replay via a non-determinism log)
 - **`milkie` CLI** — `agent list / run / resume / interrupt` and `trace inspect / replay` over a `.milkie/agents.json` manifest; SQLite-backed default state store so interrupt / resume work across CLI processes. The CLI is the canonical agent-facing surface (ARCHITECTURE.md invariants 12–13) and every verb maps 1:1 to an SDK call
 - **Pluggable backends** — swap state stores (Memory / SQLite / Redis) and trajectory recorders (JSONL / in-memory / console) without touching agent logic
 - **Provider-agnostic** — Anthropic and any OpenAI-compatible endpoint out of the box
 
 **Target capabilities** still in development — fork / diff / lineage as
-first-class operations over the event log, a non-determinism log for
-byte-identical replay, and the Evolution experiment subsystem. See
-[ARCHITECTURE.md → Implementation Status](./ARCHITECTURE.md#implementation-status)
-for what's in code today vs. what's target architecture.
+first-class operations over the event log, and the Evolution experiment
+subsystem. See [roadmap.md](./roadmap.md) for what's in code today vs. what's
+target architecture.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-29-tool-responded-metadata.md
+++ b/docs/superpowers/plans/2026-05-29-tool-responded-metadata.md
@@ -1,0 +1,336 @@
+# tool.responded 产出 metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 `tool.responded` 事件加上 `outputHash` / `outputBytes`（+ 为 #37 预留 `artifactRefs?`），并 best-effort 把工具产出写透到 `traceObjectStore`（按 hash 去重），保留 `output` 内联使 replay 零改动。
+
+**Architecture:** 在 `RecordingIOPort.invokeTool` 成功分支，对 `output` 做一次 `canonicalize`，由它派生 `outputHash`（`contentAddressForCanonicalBytes`）与 `outputBytes`（UTF-8 字节数）填进 payload；若构造时注入了 `traceObjectStore` 则 `putCanonical` 写透（自带 `has` 去重）。全部 best-effort：canonicalize/put 失败则降级，不影响 tool 结果。`output` 仍内联 → `CacheIndex`/`ReplayingIOPort` 不动。
+
+**Tech Stack:** TypeScript (ESM, `.js` import 后缀)、jest（项目用 jest；`npx jest <file> -t "<name>"`）。`hash.ts`（`canonicalize` / `contentAddressForCanonicalBytes`）、`ITraceObjectStore`（Memory/File，内容寻址 + 去重）。
+
+**设计依据：** `docs/superpowers/specs/2026-05-29-tool-responded-metadata-design.md`
+
+---
+
+## File Structure
+
+- `src/trace/types.ts` — `ToolRespondedPayload` 加 `outputHash?` / `outputBytes?` / `artifactRefs?`。
+- `src/trace/RecordingIOPort.ts` — 构造函数加可选 `objectStore`；`invokeTool` 成功分支算 hash/bytes + 写透；新增私有 `outputMetadata()`。
+- `src/runtime/Milkie.ts` — `wrapIOPort` 把 `traceObjectStore` 传进 `RecordingIOPort`。
+- `src/__tests__/RecordingIOPort.metadata.test.ts` — 新建，单元测试（确定性 hash / bytes / 去重 / 无 store / best-effort / error 分支）。
+
+---
+
+## Task 1: 数据模型 + RecordingIOPort 计算 hash/bytes（核心）
+
+**Files:**
+- Modify: `src/trace/types.ts:66-78`（`ToolRespondedPayload`）
+- Modify: `src/trace/RecordingIOPort.ts`（imports、constructor `:57-62`、`invokeTool` 成功分支 `:172-183`、新增私有方法）
+- Modify: `src/runtime/Milkie.ts:63-68`（`wrapIOPort`）
+- Test: `src/__tests__/RecordingIOPort.metadata.test.ts`（新建）
+
+- [ ] **Step 1: 写失败测试** — 新建 `src/__tests__/RecordingIOPort.metadata.test.ts`：
+
+```ts
+import { RecordingIOPort } from '../trace/RecordingIOPort'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { MemoryTraceObjectStore } from '../trace/TraceObjectStore'
+import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash'
+import type { IIOPort } from '../runtime/IOPort'
+import type { ModelRequest, ModelResponse } from '../types/model'
+import type { ToolRespondedPayload } from '../trace/types'
+
+// inner port that runs the execute thunk (like DefaultIOPort) so tests control output
+class ExecInnerPort implements IIOPort {
+  private nextClock = 1000
+  private nextUuid  = 1
+  async invokeLLM(_req: ModelRequest): Promise<ModelResponse> {
+    return { content: [], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async invokeTool(_n: string, _i: unknown, execute: () => Promise<unknown>): Promise<unknown> {
+    return execute()
+  }
+  now():  number { return this.nextClock++ }
+  uuid(): string { return `uuid-${this.nextUuid++}` }
+}
+
+async function respondedPayload(store: MemoryEventStore): Promise<ToolRespondedPayload> {
+  const events = await store.readByRunId('r1')
+  return events.find(e => e.type === 'tool.responded')!.payload as ToolRespondedPayload
+}
+
+describe('RecordingIOPort — tool output metadata (#25)', () => {
+  it('adds outputHash and outputBytes derived from canonical output', async () => {
+    const inner = new ExecInnerPort()
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(inner, store, 'r1')
+
+    const output = { lines: ['a', 'b'], n: 2 }
+    await port.invokeTool('read_file', { path: 'x' }, async () => output)
+
+    const p = await respondedPayload(store)
+    const canonical = canonicalize(output)
+    expect(p.outputHash).toBe(contentAddressForCanonicalBytes(canonical))
+    expect(p.outputBytes).toBe(Buffer.byteLength(canonical, 'utf8'))
+    expect(p.output).toEqual(output)   // 仍内联
+  })
+
+  it('produces identical outputHash for identical output across runs', async () => {
+    const run = async () => {
+      const store = new MemoryEventStore()
+      await new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+        .invokeTool('t', { a: 1 }, async () => ({ z: 1, a: [2, 3] }))
+      return (await respondedPayload(store)).outputHash
+    }
+    expect(await run()).toBe(await run())
+  })
+
+  it('still records hash/bytes when no traceObjectStore is provided', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')   // no objectStore
+    await port.invokeTool('t', {}, async () => 'hello')
+    const p = await respondedPayload(store)
+    expect(typeof p.outputHash).toBe('string')
+    expect(p.outputBytes).toBe(Buffer.byteLength(canonicalize('hello'), 'utf8'))
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/RecordingIOPort.metadata.test.ts -t "tool output metadata"`
+Expected: FAIL（`outputHash`/`outputBytes` 还不存在，为 undefined）
+
+- [ ] **Step 3a: 扩展 `ToolRespondedPayload`** — `src/trace/types.ts`，在 `requestHash` 后加：
+
+```ts
+export interface ToolRespondedPayload {
+  toolName: string
+  output?: unknown
+  error?: {
+    message:    string
+    retryable?: boolean
+    code?:      string
+    name?:      string
+  }
+  /** Mirrors the requested-event hash. */
+  requestHash: string
+  /** #25: 成功时 hashCanonical(output) → "sha256:..."；error 分支不填。 */
+  outputHash?:   string
+  /** #25: canonicalize(output) 的 UTF-8 字节数（= 对象库中那份大小）。 */
+  outputBytes?:  number
+  /** #25: 为 #37 (object.created) 预留；本期不填。 */
+  artifactRefs?: string[]
+}
+```
+
+- [ ] **Step 3b: `RecordingIOPort` 加 objectStore + 计算逻辑** — `src/trace/RecordingIOPort.ts`：
+
+imports 顶部加：
+```ts
+import { hashModelRequest, hashToolCall, canonicalize, contentAddressForCanonicalBytes } from './hash.js'
+import type { ITraceObjectStore } from './TraceObjectStore.js'
+```
+（把 `canonicalize, contentAddressForCanonicalBytes` 合并进既有的 `from './hash.js'` import；`hashModelRequest`/`hashToolCall` 本来就在。）
+
+constructor（现 `:57-62`）加第 5 个可选参数：
+```ts
+  constructor(
+    private readonly inner: IIOPort,
+    private readonly store: IEventStore,
+    private readonly runId: string,
+    private readonly actor: string = 'runtime',
+    private readonly objectStore?: ITraceObjectStore,
+  ) {}
+```
+
+新增私有方法（放在 `invokeTool` 附近）：
+```ts
+  /**
+   * Best-effort 产出物元数据。canonicalize 对非普通对象会抛 TypeError —— 此时降级返回 {}，
+   * 不让 trace 记录影响 tool 结果。写透对象库同样吞错。
+   */
+  private async outputMetadata(output: unknown): Promise<{ outputHash?: string; outputBytes?: number }> {
+    let canonical: string
+    try {
+      canonical = canonicalize(output)
+    } catch {
+      return {}
+    }
+    if (this.objectStore) {
+      try { await this.objectStore.putCanonical(canonical) } catch { /* best-effort */ }
+    }
+    return {
+      outputHash:  contentAddressForCanonicalBytes(canonical),
+      outputBytes: Buffer.byteLength(canonical, 'utf8'),
+    }
+  }
+```
+
+`invokeTool` 成功分支（现 `:172-183`）改为先算 meta 再 append：
+```ts
+      const output = await this.inner.invokeTool(toolName, input, execute)
+      const meta = await this.outputMetadata(output)
+      await this.store.append({
+        id:        this.inner.uuid(),
+        runId:     this.runId,
+        type:      'tool.responded',
+        actor:     this.actor,
+        causedBy:  reqEventId,
+        timestamp: this.inner.now(),
+        payload:   { toolName, output, requestHash, ...meta } satisfies ToolRespondedPayload,
+      })
+      return output
+```
+（error 分支不动 —— 不加 hash/bytes。）
+
+- [ ] **Step 3c: `Milkie.wrapIOPort` 传 traceObjectStore** — `src/runtime/Milkie.ts:63-68`：
+
+```ts
+  private wrapIOPort(gateway: IModelGateway, runId: string): IIOPort {
+    const base = new DefaultIOPort(gateway)
+    return this.eventStore
+      ? new RecordingIOPort(base, this.eventStore, runId, undefined, this.traceObjectStore ?? undefined)
+      : base
+  }
+```
+（第 4 个参数 `undefined` 让 `actor` 取默认 `'runtime'`，第 5 个传对象库。）
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx jest src/__tests__/RecordingIOPort.metadata.test.ts`
+Expected: PASS（3 个用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trace/types.ts src/trace/RecordingIOPort.ts src/runtime/Milkie.ts src/__tests__/RecordingIOPort.metadata.test.ts
+git commit -m "feat(trace): tool.responded carries outputHash/outputBytes + write-through (#25)"
+```
+
+---
+
+## Task 2: 大 output 在对象库按 hash 去重
+
+**Files:**
+- Test: `src/__tests__/RecordingIOPort.metadata.test.ts`（追加）
+
+- [ ] **Step 1: 写测试** — 追加到同一 describe。`MemoryTraceObjectStore` 无公开 size，用 `has(hash)` + 包一层计数 put 来验证去重（同一 canonical 第二次 put 命中 `has` 不重复存）：
+
+```ts
+  it('dedupes large output by hash in the trace object store', async () => {
+    const objectStore = new MemoryTraceObjectStore()
+    let putCount = 0
+    const counting = {
+      putCanonical: async (b: string) => { putCount++; return objectStore.putCanonical(b) },
+      getCanonical: (h: string) => objectStore.getCanonical(h),
+      has:          (h: string) => objectStore.has(h),
+    }
+    const store = new MemoryEventStore()
+    const big = 'x'.repeat(100_000)
+    const out = { chapter: big }
+
+    // 同一 output 读三次（三次独立 tool call）
+    for (let i = 0; i < 3; i++) {
+      await new RecordingIOPort(new ExecInnerPort(), store, `r${i}`, undefined, counting)
+        .invokeTool('read_file', { path: 'ch1', n: i }, async () => out)
+    }
+
+    const hash = contentAddressForCanonicalBytes(canonicalize(out))
+    expect(await objectStore.has(hash)).toBe(true)
+    // putCanonical 被调 3 次，但对象库按 hash 去重 → 只存一份；getCanonical 返回那一份
+    expect(putCount).toBe(3)
+    expect(await objectStore.getCanonical(hash)).toBe(canonicalize(out))
+  })
+```
+（说明：`MemoryTraceObjectStore.putCanonical` 内部对相同 hash 是覆盖写同值、天然去重，不会膨胀；本测试验证“同一产出物始终归到同一 hash、可经 hash 取回一份”。`putCount===3` 仅证明每次 tool call 都尝试写透。）
+
+- [ ] **Step 2: 跑测试**
+
+Run: `npx jest src/__tests__/RecordingIOPort.metadata.test.ts -t "dedupes large output"`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/RecordingIOPort.metadata.test.ts
+git commit -m "test(trace): tool output deduped by hash in object store (#25)"
+```
+
+---
+
+## Task 3: best-effort 降级 + error 分支不带元数据
+
+**Files:**
+- Test: `src/__tests__/RecordingIOPort.metadata.test.ts`（追加）
+
+- [ ] **Step 1: 写测试** — 追加两个用例：
+
+```ts
+  it('degrades gracefully when output is not canonicalizable (no throw, no hash fields)', async () => {
+    class Weird { constructor(public v = 1) {} }   // 非普通对象 → canonicalize 抛 TypeError
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1', undefined, new MemoryTraceObjectStore())
+
+    const out = new Weird()
+    const ret = await port.invokeTool('t', {}, async () => out)
+
+    expect(ret).toBe(out)                       // tool 结果照常返回
+    const p = await respondedPayload(store)
+    expect(p.outputHash).toBeUndefined()        // 降级：无 hash/bytes
+    expect(p.outputBytes).toBeUndefined()
+    expect(p.output).toBe(out)                  // output 仍内联
+  })
+
+  it('error branch carries no output metadata', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1', undefined, new MemoryTraceObjectStore())
+
+    await expect(
+      port.invokeTool('t', {}, async () => { throw new Error('boom') })
+    ).rejects.toThrow('boom')
+
+    const p = await respondedPayload(store)
+    expect(p.error?.message).toBe('boom')
+    expect(p.outputHash).toBeUndefined()
+    expect(p.outputBytes).toBeUndefined()
+  })
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `npx jest src/__tests__/RecordingIOPort.metadata.test.ts -t "degrades gracefully|error branch"`
+Expected: PASS（注意：若 `Weird` 实例经 `inner.invokeTool` 原样返回，`canonicalize` 在 `outputMetadata` 内抛 → 被 catch → 返回 `{}`，append 照常）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/RecordingIOPort.metadata.test.ts
+git commit -m "test(trace): best-effort degrade + error branch has no output metadata (#25)"
+```
+
+---
+
+## Task 4: 全量回归 + 类型检查
+
+- [ ] **Step 1: 全量单测**
+
+Run: `npx jest src/__tests__ --runInBand`
+Expected: 全绿。重点确认 `Replay.test.ts` / `ReplayingIOPort*.test.ts` / `CacheIndex*.test.ts` 不回归（`output` 仍内联，replay 路径未变）；`Trace.test.ts` / `RecordingIOPort.nondet.test.ts` 不回归（新增构造参数可选、旧 3 参调用仍合法）。
+
+- [ ] **Step 2: 类型检查 / 构建**
+
+Run: `npm run build`（= `tsc`）
+Expected: EXIT 0，无类型错误。
+
+- [ ] **Step 3: 若失败** 按 superpowers:systematic-debugging 定位；修复后回 Step 1。不得用 `--no-verify`。
+
+---
+
+## Self-Review 备忘（计划作者已核对）
+
+- **Spec 覆盖**：数据模型(T1) / 确定性 hash(T1) / outputBytes(T1) / 无 store 不抛(T1) / 去重(T2) / best-effort 降级 + canonicalize 失败(T3) / error 分支(T3) / replay 不回归(T4)。全部验收项有对应 task。
+- **deferral**（spec 已列）：jsonl 卸载（方案 B）、`artifactRefs` emit（#37）—— 本计划不含。
+- **类型一致**：`ToolRespondedPayload` 三新字段（T1 定义）在 T1/T3 测试中按 `outputHash?: string` / `outputBytes?: number` 使用一致；`RecordingIOPort` 第 5 参 `objectStore?: ITraceObjectStore` 在 T1 wiring 与 T2/T3 测试构造中签名一致（`new RecordingIOPort(inner, store, runId, undefined, objectStore)`）。
+- **合并协调点**（spec §5）：PR #49 的 `buildMakeChildPort` 后合时需给子 port 也传 `traceObjectStore` —— 不在本计划，提醒后合方处理。
+- **已知取舍**：`outputBytes` 用 canonical 字节数（非 raw output 大小），与对象库存储的那份一致。

--- a/docs/superpowers/specs/2026-05-29-tool-responded-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-29-tool-responded-metadata-design.md
@@ -1,0 +1,135 @@
+# tool.responded 产出 metadata（#25）
+
+**Issue:** #25 [observable P0] tool.responded 产出 metadata
+**Parent:** #20（Trace substrate gap — 6-capability surface）
+**Date:** 2026-05-29
+**Blocks:** #37（object.created + tool 关联）
+
+## 背景
+
+今天 `ToolRespondedPayload`（`src/trace/types.ts:66-78`）只有 `output / error / requestHash`，
+工具产出没有稳定身份。两个下游需要它：
+
+- **lineage（#37 `object.created`）** 要一个稳定的产出物身份（hash）能被引用——否则所有
+  lineage 关系没有可挂的 id；
+- **replay 内容寻址** 可用 outputHash 作 cache key。
+
+附带：同一份大 output（如 1MB 章节被 `read_file` 读三次）今天在对象库层面没有去重锚点。
+
+## Scope 决策：方案 A（加元数据 + 写透对象库，保留内联）
+
+工具输出与 region 内容有一个**关键区别**：region 内容 replay 不消费（仅用于 UI 重建），所以
+#23 能在 `region.added` 里只存 `contentHash`、内容进 `traceObjectStore`；而
+`tool.responded.output` **被 replay 消费**——`CacheIndex.fromEvents` 读它建 tool cache、
+`ReplayingIOPort` 把它吐回 runtime。且 `traceObjectStore` 是**可选**的（多数 run/测试不带）。
+因此不能照搬 region 的“只存 hash、丢内联”，否则任何无对象库的 run 会失去 replay 能力。
+
+**采用方案 A**：
+- `tool.responded` 始终携带 `outputHash` / `outputBytes`（仅成功、output 存在时）；
+- `output` **仍内联**——replay / `CacheIndex` / `ReplayingIOPort` 零改动，不依赖对象库；
+- best-effort 写透 `traceObjectStore`（`putCanonical(canonicalize(output))`），其自带 `has(hash)`
+  去重 → 3×1MB 在对象库里 1 份，lineage 可按 hash 取字节。
+
+**显式不做（方案 B，YAGNI）**：不把大 output 移出 jsonl（不做阈值卸载）。#37 只需稳定 hash 身份，
+不需要 jsonl 瘦身；卸载会引入阈值 magic number + replay hydrate + “卸载过的 run 必须带对象库”的
+耦合。jsonl 内联副本是方案 A 的已知取舍，若日后 jsonl 体积成真问题，再单开 issue 做卸载。
+
+## 设计
+
+### 1. 数据模型（`src/trace/types.ts`）
+
+`ToolRespondedPayload` 增三个可选字段：
+
+```ts
+export interface ToolRespondedPayload {
+  toolName: string
+  output?: unknown
+  error?: { message: string; retryable?: boolean; code?: string; name?: string }
+  requestHash: string
+  /** 成功时：hashCanonical(output) → "sha256:..."（与 region contentHash 同款内容地址）。 */
+  outputHash?:   string
+  /** 成功时：Buffer.byteLength(canonicalize(output), 'utf8')，即对象库中那份 canonical 字节数。 */
+  outputBytes?:  number
+  /** 为 #37（object.created）预留的产出物引用接口；本 issue 不填。 */
+  artifactRefs?: string[]
+}
+```
+
+全部可选 → 既有事件与 replay 不受影响。`error` 分支（无 output）不填这三个字段。
+
+### 2. 计算 + 写透位置（`src/trace/RecordingIOPort.ts`）
+
+放在 `RecordingIOPort.invokeTool` 的成功分支——它本就构造 `tool.responded`、写事件那一刻手里就有
+`output` 值。（备选“放 AgentRuntime 像 region 那样”被否决：AgentRuntime 拿不到 tool 的 output
+值，要回传，绕。）
+
+- 给 `RecordingIOPort` 构造函数加一个可选 `traceObjectStore?: ITraceObjectStore`；
+- 成功分支：
+  - `const canonical = canonicalize(output)`；
+  - `outputHash = contentAddressForCanonicalBytes(canonical)`；`outputBytes = Buffer.byteLength(canonical, 'utf8')`；
+  - 这两个字段填进 `tool.responded` payload；
+  - 若 `traceObjectStore` 存在：`await traceObjectStore.putCanonical(canonical)`（其内部 `has(hash)`
+    去重）；
+- `Milkie.wrapIOPort`（`src/runtime/Milkie.ts:63-68`）把 `this.traceObjectStore ?? undefined`
+  传进 `new RecordingIOPort(...)`。
+
+### 3. 语义 & 边界
+
+- **hash/bytes 总是算**（只要 output 存在），与 `traceObjectStore` 是否存在无关——它们是事件自带
+  元数据（#37 id + replay cache-key 候选），不依赖对象库。
+- **写透仅当 `traceObjectStore` 存在**，且 **best-effort**：`canonicalize` / `putCanonical` 抛错
+  时降级——略过 put，必要时连 hash/bytes 一起省（与 region 的 `persistRegionContent` /
+  `buildRegionAddedPayload` 容错同姿势）。**绝不**改变 tool 调用结果或 agent 行为：tool 的
+  `output` 照常返回、`tool.responded` 照常写（只是可能缺这几个元数据字段）。
+- **replay 零改动**：`output` 仍内联；`CacheIndex.fromEvents` / `ReplayingIOPort` 不动；新字段
+  对 replay 是“读不到也不需要”。`RecordingIOPort` 只在 record 路径运行，故 hash 计算不进 replay、
+  无 nondeterminism。
+- **canonicalize 限制**：`canonicalize` 对非普通对象（自定义类实例）抛 `TypeError`
+  （`hash.ts:18-19`）。此时按 best-effort 降级（该 output 不出 hash/bytes、不入对象库），tool
+  仍正常返回。
+
+### 4. 错误处理
+
+- 工具报错（`error` 分支）：不加 hash/bytes/artifactRefs（无 output）。现有 error 记录路径不变。
+- 写透失败 / canonicalize 失败：见 §3 best-effort，不影响业务。
+
+## 测试（`src/__tests__/`，扩展 `Trace.test.ts` / `RecordingIOPort.nondet.test.ts` 既有 harness）
+
+1. 纯函数工具同 input 两次 run → 相同 `outputHash`（验收 #1）。
+2. `outputBytes` === `Buffer.byteLength(canonicalize(output), 'utf8')`（验收 #2）。
+3. 带 `traceObjectStore`：大 output 进对象库；同一 output 第二次 `putCanonical` 命中 `has` 去重
+   （对象库只存一份）（验收 #3）。
+4. 无 `traceObjectStore`：`outputHash` / `outputBytes` 仍在 payload，不抛错，tool 正常返回。
+5. error 分支：`tool.responded` 不含 outputHash/outputBytes。
+6. canonicalize 不支持的 output（如类实例）→ best-effort 降级，tool 正常返回、不抛。
+7. 现有 replay 测试全过（验收 #4：`Replay.test.ts` 不回归）。
+
+## 验收（本 issue 范围内）
+
+- [ ] `ToolRespondedPayload` 增 `outputHash` / `outputBytes` / `artifactRefs?`（可选）
+- [ ] 同一 tool input 两次 run 产生相同 `outputHash`（纯函数工具）
+- [ ] `outputBytes` 正确反映 canonical stringify 后字节数
+- [ ] 带 `traceObjectStore` 时大 output 按 hash 去重（对象库一份）
+- [ ] 无 `traceObjectStore` 时不抛错、hash/bytes 仍在 payload
+- [ ] error 分支不带这些字段；canonicalize 失败时 best-effort 降级
+- [ ] replay 测试全过（CacheIndex / ReplayingIOPort 零改动）
+
+## 显式 deferral（不在本 issue）
+
+- 大 output 移出 jsonl（方案 B 的阈值卸载 + replay hydrate）→ 若 jsonl 体积成真问题再单开 issue；
+- `artifactRefs` 的实际 emit（`object.created`）→ #37；
+- relation.created / lineage 查询 → #38 / #41。
+
+## 合并协调点
+
+`feat/47-sub-agent-first-class-replay`（PR #49，本 spec 写时未合）新增了 `Milkie.buildMakeChildPort`，
+其中也 `new RecordingIOPort(...)` 给子 agent 铸 port。本 issue 给 `RecordingIOPort` 构造函数加了
+`traceObjectStore` 参数——**后合的那个 PR** 应顺手给子 port 也传 `this.traceObjectStore`，否则子
+agent 的 tool output 不进对象库（功能正确，只是缺子 output 的去重）。
+
+## Related
+
+- ARCH.md §Implementation Status
+- 依据：#23 region 内容可寻址（`AgentRuntime.buildRegionAddedPayload` / `persistRegionContent`、
+  `ITraceObjectStore`、`hash.ts`）——本 issue 复用同一内容寻址与 best-effort 容错套路
+- Blocks: #37（object.created + tool 关联）

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,7 +13,7 @@ When code lands that closes a gap, update this file (Completed sections,
 Migration intentions, deferred items) before claiming the gap is closed
 elsewhere.
 
-Last updated: 2026-05-28
+Last updated: 2026-05-29
 
 ---
 
@@ -32,6 +32,12 @@ Last updated: 2026-05-28
   declare `scope: 'turn' | 'session'` lifetime, section schema is cache-aware.
 - **8 of 15 stories are `active`** (have green E2E tests). The 7 `draft`
   stories all depend on Phase 5–6 capabilities that haven't shipped yet.
+- **Active line:** #20 observable substrate (6-capability surface). The
+  observable.P0 substrate is essentially complete — `fsm.transition` /
+  `skill.loaded` / region content-hash / `agent.spawned·returned` merged
+  (#21–24); sub-agent first-class trace + replay (#47) and
+  `tool.responded` product metadata (#25) in review. Remaining: observable.P1
+  consumption (UI/CLI), then the diagnosable line (#30 causedBy onward).
 - **Next big rock:** Phase 5 fork / diff / suite replay. Phase 4 was its
   prerequisite for honest fork semantics — fork can now share recorded
   prefixes byte-for-byte across forks instead of structurally.
@@ -91,11 +97,19 @@ Last updated: 2026-05-28
   `paused` reserved FSM state + global `interrupt` event handler
   (`src/fsm/FSMEngine.ts:11,61-62`, `src/runtime/Milkie.ts:297-300`,
   `src/runtime/AgentRuntime.ts:238-242`).
-  **Substrate additions on top of Phase 3:**
+  **Substrate additions on top of Phase 3 (#20 observable.P0, merged):**
   - `fsm.transition` event with explicit `FsmEventDomain` taxonomy
     (lifecycle / signal / runtime-control / business) — #21,
     commit 7857423. Closes one node-class needed by future
     diagnosable causedBy chains (#30 onward).
+  - `skill.loaded` / `skill.unloaded` lifecycle events — #22.
+  - Region content-addressing: `region.added` carries `contentHash` /
+    `renderedHash`, content bytes offloaded to `ITraceObjectStore`
+    (`MemoryTraceObjectStore` / `FileTraceObjectStore`, content-addressed
+    + dedup) — #23.
+  - `agent.spawned` / `agent.returned` anchors on the parent run — #24
+    (PR #48). The supervisor tree is now an event, not a runtime-only
+    `ChildAgentRecord` reconstruction.
 - **Phase 4 — Non-determinism log + byte-identical replay.** New event
   kinds `clock.read` / `uuid.generated`. `RecordingIOPort` records every
   agent-facing `port.now()` / `port.uuid()` call via an internal pending
@@ -142,12 +156,23 @@ Full readiness view: `docs/stories/INDEX.md`.
 
 ## In progress
 
-**Nothing code-side actively in flight.** The Phase 4.5 Context Region
-Substrate just landed (PRs #6 / #7 / #8 / #9 / #10 merged); Phase 4
-non-determinism log + s-002 HTML report probe + agent-first CLI wave
-landed earlier in this development cycle.
+**Active line: #20 observable substrate (6-capability surface push).**
+Closing the observable-substrate gaps so the event log is a complete
+source of truth (every state visible as events, not reconstructed from
+runtime structures):
 
-**Two reasonable next pickups:**
+- **Merged:** `fsm.transition` (#21), `skill.loaded/unloaded` (#22),
+  region content-addressing (#23), `agent.spawned` / `agent.returned`
+  (#24).
+- **In review:** sub-agent first-class — independent `childRunId` +
+  nested sub-trace + independently replayable, "model I" (#47, PR #49);
+  `tool.responded` product metadata `outputHash` / `outputBytes` +
+  object-store write-through (#25, PR #50).
+- **Next in this line:** `tool.responded` was the last observable.P0
+  substrate gap; remaining #20 work is observable.P1 (consumption UI/CLI:
+  #26–29) and the diagnosable line (#30 causedBy onward).
+
+**Other reasonable next pickups:**
 
 - **Phase 4.6 — region trace events + cache health observability.**
   Smaller scope (~600 LOC). Adds `region.added` / `region.removed` /
@@ -436,10 +461,14 @@ Substrate gaps too small to phase but worth not losing:
   the "Replay side-effect policy" open question below.
 - **6-capability vocabulary status.** `ARCHITECTURE.md` describes
   observable / diagnosable / lineage / replay / fork / diff as a
-  6-capability surface. Today: **replay is complete**; **observable** is
-  partial (substrate gaps tracked under #20 — see `fsm.transition`,
-  `skill.loaded`, region content hash etc.); **diagnosable / lineage /
-  fork / diff** are absent or Phase-5/6 work.
+  6-capability surface. Today: **replay is complete** (incl. runs with
+  sub-agents once #47 lands); **observable.P0 substrate is essentially
+  complete** — `fsm.transition` (#21), `skill.loaded` (#22), region
+  content hash (#23), `agent.spawned/returned` (#24) merged; sub-agent
+  first-class trace (#47) + `tool.responded` metadata (#25) in review.
+  Remaining observable work is P1 consumption (UI/CLI, #26–29).
+  **diagnosable** starts at #30 (causedBy); **lineage / fork / diff** are
+  absent or Phase-5/6 work.
 
 ---
 

--- a/src/__tests__/RecordingIOPort.metadata.test.ts
+++ b/src/__tests__/RecordingIOPort.metadata.test.ts
@@ -1,0 +1,61 @@
+import { RecordingIOPort } from '../trace/RecordingIOPort'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { MemoryTraceObjectStore } from '../trace/TraceObjectStore'
+import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash'
+import type { IIOPort } from '../runtime/IOPort'
+import type { ModelRequest, ModelResponse } from '../types/model'
+import type { ToolRespondedPayload } from '../trace/types'
+
+class ExecInnerPort implements IIOPort {
+  private nextClock = 1000
+  private nextUuid  = 1
+  async invokeLLM(_req: ModelRequest): Promise<ModelResponse> {
+    return { content: [], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async invokeTool(_n: string, _i: unknown, execute: () => Promise<unknown>): Promise<unknown> {
+    return execute()
+  }
+  now():  number { return this.nextClock++ }
+  uuid(): string { return `uuid-${this.nextUuid++}` }
+}
+
+async function respondedPayload(store: MemoryEventStore): Promise<ToolRespondedPayload> {
+  const events = await store.readByRunId('r1')
+  return events.find(e => e.type === 'tool.responded')!.payload as ToolRespondedPayload
+}
+
+describe('RecordingIOPort — tool output metadata (#25)', () => {
+  it('adds outputHash and outputBytes derived from canonical output', async () => {
+    const inner = new ExecInnerPort()
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(inner, store, 'r1')
+
+    const output = { lines: ['a', 'b'], n: 2 }
+    await port.invokeTool('read_file', { path: 'x' }, async () => output)
+
+    const p = await respondedPayload(store)
+    const canonical = canonicalize(output)
+    expect(p.outputHash).toBe(contentAddressForCanonicalBytes(canonical))
+    expect(p.outputBytes).toBe(Buffer.byteLength(canonical, 'utf8'))
+    expect(p.output).toEqual(output)
+  })
+
+  it('produces identical outputHash for identical output across runs', async () => {
+    const run = async () => {
+      const store = new MemoryEventStore()
+      await new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+        .invokeTool('t', { a: 1 }, async () => ({ z: 1, a: [2, 3] }))
+      return (await respondedPayload(store)).outputHash
+    }
+    expect(await run()).toBe(await run())
+  })
+
+  it('still records hash/bytes when no traceObjectStore is provided', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+    await port.invokeTool('t', {}, async () => 'hello')
+    const p = await respondedPayload(store)
+    expect(typeof p.outputHash).toBe('string')
+    expect(p.outputBytes).toBe(Buffer.byteLength(canonicalize('hello'), 'utf8'))
+  })
+})

--- a/src/__tests__/RecordingIOPort.metadata.test.ts
+++ b/src/__tests__/RecordingIOPort.metadata.test.ts
@@ -58,4 +58,27 @@ describe('RecordingIOPort — tool output metadata (#25)', () => {
     expect(typeof p.outputHash).toBe('string')
     expect(p.outputBytes).toBe(Buffer.byteLength(canonicalize('hello'), 'utf8'))
   })
+
+  it('dedupes large output by hash in the trace object store', async () => {
+    const objectStore = new MemoryTraceObjectStore()
+    let putCount = 0
+    const counting = {
+      putCanonical: async (b: string) => { putCount++; return objectStore.putCanonical(b) },
+      getCanonical: (h: string) => objectStore.getCanonical(h),
+      has:          (h: string) => objectStore.has(h),
+    }
+    const store = new MemoryEventStore()
+    const big = 'x'.repeat(100_000)
+    const out = { chapter: big }
+
+    for (let i = 0; i < 3; i++) {
+      await new RecordingIOPort(new ExecInnerPort(), store, `r${i}`, undefined, counting)
+        .invokeTool('read_file', { path: 'ch1', n: i }, async () => out)
+    }
+
+    const hash = contentAddressForCanonicalBytes(canonicalize(out))
+    expect(await objectStore.has(hash)).toBe(true)
+    expect(putCount).toBe(3)
+    expect(await objectStore.getCanonical(hash)).toBe(canonicalize(out))
+  })
 })

--- a/src/__tests__/RecordingIOPort.metadata.test.ts
+++ b/src/__tests__/RecordingIOPort.metadata.test.ts
@@ -81,4 +81,33 @@ describe('RecordingIOPort — tool output metadata (#25)', () => {
     expect(putCount).toBe(3)
     expect(await objectStore.getCanonical(hash)).toBe(canonicalize(out))
   })
+
+  it('degrades gracefully when output is not canonicalizable (no throw, no hash fields)', async () => {
+    class Weird { constructor(public v = 1) {} }
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1', undefined, new MemoryTraceObjectStore())
+
+    const out = new Weird()
+    const ret = await port.invokeTool('t', {}, async () => out)
+
+    expect(ret).toBe(out)
+    const p = await respondedPayload(store)
+    expect(p.outputHash).toBeUndefined()
+    expect(p.outputBytes).toBeUndefined()
+    expect(p.output).toBe(out)
+  })
+
+  it('error branch carries no output metadata', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1', undefined, new MemoryTraceObjectStore())
+
+    await expect(
+      port.invokeTool('t', {}, async () => { throw new Error('boom') })
+    ).rejects.toThrow('boom')
+
+    const p = await respondedPayload(store)
+    expect(p.error?.message).toBe('boom')
+    expect(p.outputHash).toBeUndefined()
+    expect(p.outputBytes).toBeUndefined()
+  })
 })

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -63,7 +63,7 @@ export class Milkie {
   private wrapIOPort(gateway: IModelGateway, runId: string): IIOPort {
     const base = new DefaultIOPort(gateway)
     return this.eventStore
-      ? new RecordingIOPort(base, this.eventStore, runId)
+      ? new RecordingIOPort(base, this.eventStore, runId, undefined, this.traceObjectStore ?? undefined)
       : base
   }
 

--- a/src/trace/RecordingIOPort.ts
+++ b/src/trace/RecordingIOPort.ts
@@ -11,7 +11,8 @@ import type {
   ClockReadPayload,
   UuidGeneratedPayload,
 } from './types.js'
-import { hashModelRequest, hashToolCall } from './hash.js'
+import { hashModelRequest, hashToolCall, canonicalize, contentAddressForCanonicalBytes } from './hash.js'
+import type { ITraceObjectStore } from './TraceObjectStore.js'
 
 function cacheStatsFrom(response: ModelResponse): {
   readTokens:       number
@@ -59,7 +60,24 @@ export class RecordingIOPort implements IIOPort {
     private readonly store: IEventStore,
     private readonly runId: string,
     private readonly actor: string = 'runtime',
+    private readonly objectStore?: ITraceObjectStore,
   ) {}
+
+  private async outputMetadata(output: unknown): Promise<{ outputHash?: string; outputBytes?: number }> {
+    let canonical: string
+    try {
+      canonical = canonicalize(output)
+    } catch {
+      return {}
+    }
+    if (this.objectStore) {
+      try { await this.objectStore.putCanonical(canonical) } catch { /* best-effort */ }
+    }
+    return {
+      outputHash:  contentAddressForCanonicalBytes(canonical),
+      outputBytes: Buffer.byteLength(canonical, 'utf8'),
+    }
+  }
 
   /**
    * Drain pending nondet records to the store in input order. Called at
@@ -171,6 +189,7 @@ export class RecordingIOPort implements IIOPort {
 
     try {
       const output = await this.inner.invokeTool(toolName, input, execute)
+      const meta = await this.outputMetadata(output)
       await this.store.append({
         id:        this.inner.uuid(),
         runId:     this.runId,
@@ -178,7 +197,7 @@ export class RecordingIOPort implements IIOPort {
         actor:     this.actor,
         causedBy:  reqEventId,
         timestamp: this.inner.now(),
-        payload:   { toolName, output, requestHash } satisfies ToolRespondedPayload,
+        payload:   { toolName, output, requestHash, ...meta } satisfies ToolRespondedPayload,
       })
       return output
     } catch (err) {

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -75,6 +75,12 @@ export interface ToolRespondedPayload {
   }
   /** Mirrors the requested-event hash. */
   requestHash: string
+  /** #25: 成功时 hashCanonical(output) → "sha256:..."；error 分支不填。 */
+  outputHash?:   string
+  /** #25: canonicalize(output) 的 UTF-8 字节数（= 对象库中那份大小）。 */
+  outputBytes?:  number
+  /** #25: 为 #37 (object.created) 预留；本期不填。 */
+  artifactRefs?: string[]
 }
 
 // ---- Lifecycle payloads (Phase 3) ----


### PR DESCRIPTION
## Summary

给 `tool.responded` 事件加产出物身份元数据(#25,observable.P0,parent #20),解锁 lineage(#37)与 replay 内容寻址。采用**方案 A**(加字段 + 写透对象库,保留内联):

- `ToolRespondedPayload` 加可选 `outputHash`(`sha256:` 内容地址)/ `outputBytes`(canonical UTF-8 字节数)/ `artifactRefs?`(为 #37 预留)
- `RecordingIOPort.invokeTool` 成功分支:对 output 做一次 `canonicalize`,派生 hash/bytes 填进 payload;若注入了 `traceObjectStore` 则 `putCanonical` 写透(自带 `has` 去重 → 同一大 output 多次只存一份)
- 全程 **best-effort**:canonicalize/put 失败降级(省字段、不入库),绝不改变 tool 结果或抛错;error 分支不带元数据
- **replay 零改动**:`output` 仍内联,`CacheIndex`/`ReplayingIOPort` 不动,不依赖对象库
- `Milkie.wrapIOPort` 把 `traceObjectStore` 传进 `RecordingIOPort`

显式不做(YAGNI):大 output 移出 jsonl(方案 B 阈值卸载)、`artifactRefs` 的实际 emit(→ #37)。详见 spec。

设计/计划:
- `docs/superpowers/specs/2026-05-29-tool-responded-metadata-design.md`
- `docs/superpowers/plans/2026-05-29-tool-responded-metadata.md`

## Test plan

- [x] 同一 tool input 两次 run → 相同 `outputHash`
- [x] `outputBytes` == `Buffer.byteLength(canonicalize(output),'utf8')`
- [x] 带 `traceObjectStore`:大 output 按 hash 去重(对象库一份、可取回)
- [x] 无 `traceObjectStore`:hash/bytes 仍在 payload、不抛错
- [x] canonicalize 不支持的 output → best-effort 降级、tool 正常返回
- [x] error 分支不带 outputHash/outputBytes
- [x] 全量回归:284/284 单测 + `tsc` 干净;replay/CacheIndex 不回归

## 合并协调点

PR #49(#47,未合)的 `buildMakeChildPort` 也 `new RecordingIOPort(...)`。后合的 PR 应给子 port 也传 `this.traceObjectStore`,否则子 agent 的 tool output 不入对象库(功能正确,仅缺子 output 去重)。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)