### PR TITLE
fix(trace): wire traceObjectStore into sub-agent child port (#25/#47)

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -33,11 +33,11 @@ Last updated: 2026-05-29
 - **8 of 15 stories are `active`** (have green E2E tests). The 7 `draft`
   stories all depend on Phase 5–6 capabilities that haven't shipped yet.
 - **Active line:** #20 observable substrate (6-capability surface). The
-  observable.P0 substrate is essentially complete — `fsm.transition` /
-  `skill.loaded` / region content-hash / `agent.spawned·returned` merged
-  (#21–24); sub-agent first-class trace + replay (#47) and
-  `tool.responded` product metadata (#25) in review. Remaining: observable.P1
-  consumption (UI/CLI), then the diagnosable line (#30 causedBy onward).
+  observable.P0 substrate is complete — `fsm.transition` / `skill.loaded` /
+  region content-hash / `agent.spawned·returned` (#21–24), sub-agent
+  first-class trace + replay (#47, PR #49), and `tool.responded` product
+  metadata (#25, PR #50) all merged. Remaining: observable.P1 consumption
+  (UI/CLI), then the diagnosable line (#30 causedBy onward).
 - **Next big rock:** Phase 5 fork / diff / suite replay. Phase 4 was its
   prerequisite for honest fork semantics — fork can now share recorded
   prefixes byte-for-byte across forks instead of structurally.
@@ -163,14 +163,14 @@ runtime structures):
 
 - **Merged:** `fsm.transition` (#21), `skill.loaded/unloaded` (#22),
   region content-addressing (#23), `agent.spawned` / `agent.returned`
-  (#24).
-- **In review:** sub-agent first-class — independent `childRunId` +
-  nested sub-trace + independently replayable, "model I" (#47, PR #49);
+  (#24); sub-agent first-class — independent `childRunId` + nested
+  sub-trace + independently replayable, "model I" (#47, PR #49);
   `tool.responded` product metadata `outputHash` / `outputBytes` +
-  object-store write-through (#25, PR #50).
+  object-store write-through (#25, PR #50, incl. child-port wiring).
 - **Next in this line:** `tool.responded` was the last observable.P0
-  substrate gap; remaining #20 work is observable.P1 (consumption UI/CLI:
-  #26–29) and the diagnosable line (#30 causedBy onward).
+  substrate gap — observable.P0 is now complete. Remaining #20 work is
+  observable.P1 (consumption UI/CLI: #26–29) and the diagnosable line
+  (#30 causedBy onward).
 
 **Other reasonable next pickups:**
 
@@ -464,8 +464,8 @@ Substrate gaps too small to phase but worth not losing:
   6-capability surface. Today: **replay is complete** (incl. runs with
   sub-agents once #47 lands); **observable.P0 substrate is essentially
   complete** — `fsm.transition` (#21), `skill.loaded` (#22), region
-  content hash (#23), `agent.spawned/returned` (#24) merged; sub-agent
-  first-class trace (#47) + `tool.responded` metadata (#25) in review.
+  content hash (#23), `agent.spawned/returned` (#24), sub-agent
+  first-class trace (#47), `tool.responded` metadata (#25) all merged.
   Remaining observable work is P1 consumption (UI/CLI, #26–29).
   **diagnosable** starts at #30 (causedBy); **lineage / fork / diff** are
   absent or Phase-5/6 work.

--- a/src/__tests__/Trace.test.ts
+++ b/src/__tests__/Trace.test.ts
@@ -10,6 +10,7 @@ import { RecordingIOPort } from '../trace/RecordingIOPort'
 import { DefaultIOPort } from '../runtime/IOPort'
 import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
+import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash'
 import type {
   Event,
   LlmRequestedPayload,
@@ -680,6 +681,39 @@ describe('agent.spawned / agent.returned events', () => {
     await expect(make('child-run-1', bogus, {
       agentId: 'worker', goal: 'g', input: 'i', contextId: 'c', parentId: 'p',
     })).rejects.toThrow(/no-such-adapter/)
+  })
+
+  it('child sub-agent tool output is written through to the trace object store', async () => {
+    const eventStore  = new MemoryEventStore()
+    const objectStore = new MemoryTraceObjectStore()
+    const big = { chapter: 'x'.repeat(50_000) }
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new StubGateway([
+        toolCallResponse('s1', 'worker',   { goal: 'g', input: 'i' }),  // supervisor spawns worker
+        toolCallResponse('w1', 'echo_big', {}),                         // worker calls echo_big
+        textResponse('worker done'),                                    // worker finishes
+        textResponse('all done'),                                       // supervisor finishes
+      ]),
+      eventStore,
+      traceObjectStore: objectStore,
+      tools: [{
+        name:         'echo_big',
+        description:  'returns a big object',
+        parallelSafe: true,
+        inputSchema:  { type: 'object', properties: {} },
+        handler:      async () => big,
+      }],
+    })
+    milkie.registerAgent(supervisorConfig())
+    milkie.registerAgent(workerConfig())
+
+    await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i' })
+
+    // echo_big is only ever called by the worker (child) — its output reaching the
+    // object store proves the child port was wired with traceObjectStore.
+    const hash = contentAddressForCanonicalBytes(canonicalize(big))
+    expect(await objectStore.has(hash)).toBe(true)
   })
 })
 

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -71,9 +71,10 @@ export class Milkie {
     if (!this.eventStore) return undefined
     const eventStore = this.eventStore
     const gatewayOverride = this.gatewayOverride
+    const objectStore = this.traceObjectStore ?? undefined
     return async (childRunId, childConfig, start) => {
       const gw   = gatewayOverride ?? createGateway(childConfig.model)
-      const port = new RecordingIOPort(new DefaultIOPort(gw), eventStore, childRunId)
+      const port = new RecordingIOPort(new DefaultIOPort(gw), eventStore, childRunId, undefined, objectStore)
       await port.attach(start)
       return { port, finish: (c) => port.detach(c) }
     }


### PR DESCRIPTION
## Summary

收口 #25 ↔ #47 的合并协调点(两份 PR body + #25 spec §5 都预先记了)。

#47 的 `Milkie.buildMakeChildPort` 构造子 agent 的 `RecordingIOPort` 时只传了 3 个参数、没带 `traceObjectStore`;#25 给 `RecordingIOPort` 加了第 5 个 `objectStore` 参数。两者独立合并后,子 sub-agent 的 tool 产出会算出 `outputHash`/`outputBytes`(始终计算),但字节**不写透对象库** —— lineage 能拿到子产出的 hash 身份却取不到字节。

- `buildMakeChildPort` 把 `this.traceObjectStore` 作为第 5 个参数传给子 port
- 新增集成测试:supervisor spawn worker,worker 调一个返回大对象的工具;断言该对象的 canonical 字节进了对象库(echo_big 只被 worker 调,故能证明是子 port 写的)
- 顺手把 roadmap 里 #25/#47 的状态从 "in review" 翻成 merged

## Test plan

- [x] 新测试:子 sub-agent tool output 写透对象库(修复前红、修复后绿)
- [x] 全量回归:291/291 单测 + `tsc` 干净

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)