### PR TITLE
feat(#31): FSM guard 评估留痕 (option A self-report)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-fsm-guard-trace.md
+++ b/docs/superpowers/plans/2026-05-30-fsm-guard-trace.md
@@ -1,0 +1,591 @@
+# FSM Guard 评估留痕 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让工具在触发 FSM 转移时可选地自报"判断依据"(guard evaluation),依据被捕获进 `fsm.transition` 事件、可在 trace 中排查,且不破坏 replay 确定性。
+
+**Architecture:** 选项 A(内嵌)。新增 `GuardEvaluation` 类型;`ctx.emit` 加第三参把依据透传到 `FSMEngine` → `onTransition` 回调 → `setupFSMCallbacks` 写进 `fsm.transition.payload.guardEvaluations`。框架只搬运,不产生/不求值 guard。复用 #30 的写入路径(绕过 IOPort,零新增 IOPort 调用 → replay 不破)。
+
+**Tech Stack:** TypeScript、Vitest/Jest 风格测试(`describe/it/expect`)、现有 `Milkie`/`AgentRuntime`/`FSMEngine`/`MemoryEventStore` 测试设施。
+
+参考 spec:`docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `src/trace/types.ts` | 事件类型契约 | +`GuardEvaluation`;`FsmTransitionPayload` 加 `guardEvaluations?` |
+| `src/fsm/FSMEngine.ts` | FSM 引擎 | `FSMEvent` 加 `guard?`;`emitEvent` 加第三参并归一化为数组存入 `pendingEvent` |
+| `src/types/tool.ts` | 工具上下文契约 | `ToolContext.emit` 签名加第三参 `guard?` |
+| `src/runtime/AgentRuntime.ts` | 运行时 | `buildToolContext` 透传 guard;两个 emit 闭包传 guard;`setupFSMCallbacks` 写 `guardEvaluations` |
+| `tests/e2e/s-011-*.e2e.test.ts` | 真实 producer | 3 个工具补上报 + live 断言 |
+| `src/__tests__/FSMEngine.test.ts` | 单测 | guard 透传 |
+| `src/__tests__/AgentRuntime.test.ts` | 单测 | 捕获进 fsm.transition |
+| `src/__tests__/Replay.test.ts` | 单测 | replay 确定性 |
+| (可选/建议延后) `src/trace/render/tree.ts` `html.ts` | HTML 时间线 | 新增 fsm.transition 渲染分支 + guard |
+
+> **说明**:`fsm.transition` 当前**根本未在 HTML 时间线(`tree.ts`)渲染**。把它(连同 guard)加进时间线是一个独立的小特性(#21 渲染缺口),因此放在 **Task 5,建议延后到 #33 或单独 issue**。guard 数据本身在事件 payload 里,已满足 #31 验收("事件流可还原"),可经原始事件日志 / CLI trace 查看。
+
+---
+
+## Task 1: GuardEvaluation 类型 + FSMEngine 透传 guard
+
+**Files:**
+- Modify: `src/trace/types.ts`(`FsmTransitionPayload` 附近,约 `:192`)
+- Modify: `src/fsm/FSMEngine.ts:4-14`(`FSMEvent`)与 `:55-61`(`emitEvent`)
+- Test: `src/__tests__/FSMEngine.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/__tests__/FSMEngine.test.ts` 的 `describe('ctx.emit() / processPendingEvent()')` 块内追加:
+
+```ts
+it('carries guard evaluations through to the onTransition callback', () => {
+  const fsm = new FSMEngine(routingFSM)   // classify, on INTENT_A: handle_a
+  let received: import('../fsm/FSMEngine').FSMEvent | undefined
+  fsm.onTransitionCallback((_from, _to, event) => { received = event })
+
+  fsm.emitEvent('INTENT_A', undefined, {
+    guardId: 'g', result: 'INTENT_A', contextSlice: { s: 1 },
+  })
+  fsm.processPendingEvent()
+
+  expect(received?.guard).toEqual([
+    { guardId: 'g', result: 'INTENT_A', contextSlice: { s: 1 } },
+  ])
+})
+
+it('normalizes a guard array argument as-is', () => {
+  const fsm = new FSMEngine(routingFSM)
+  let received: import('../fsm/FSMEngine').FSMEvent | undefined
+  fsm.onTransitionCallback((_f, _t, e) => { received = e })
+  const arr = [{ guardId: 'a', result: 1, contextSlice: {} }, { guardId: 'b', result: 2, contextSlice: {} }]
+  fsm.emitEvent('INTENT_A', undefined, arr)
+  fsm.processPendingEvent()
+  expect(received?.guard).toEqual(arr)
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx vitest run src/__tests__/FSMEngine.test.ts -t "carries guard"`
+Expected: FAIL —— `emitEvent` 不接受第三参 / `event.guard` 为 undefined（类型错误或断言失败）。
+
+- [ ] **Step 3: 加类型**(`src/trace/types.ts`,在 `FsmTransitionPayload` 之前)
+
+```ts
+export interface GuardEvaluation {
+  /** 判断标识,如 'intent-threshold'。 */
+  guardId:      string
+  /** 判断结果:产出的事件名或布尔/任意值。 */
+  result:       unknown
+  /** 决定结果真假的最小输入切片(约定最小化,框架不强制)。 */
+  contextSlice: unknown
+}
+```
+
+并在 `FsmTransitionPayload` 末尾加字段:
+
+```ts
+export interface FsmTransitionPayload {
+  from: string
+  to:   string
+  trigger: {
+    domain: FsmEventDomain
+    name:   string
+    payload?: unknown
+  }
+  /** #31:本次转移背后的判断依据(工具自报,可选)。 */
+  guardEvaluations?: GuardEvaluation[]
+}
+```
+
+- [ ] **Step 4: 改 FSMEngine**(`src/fsm/FSMEngine.ts`)
+
+顶部 import 处加:
+
+```ts
+import type { FsmEventDomain, GuardEvaluation } from '../trace/types.js'
+```
+
+`FSMEvent` 接口加字段(在 `domain?` 之后):
+
+```ts
+  /** #31:触发本次转移的判断依据(由 ctx.emit 第三参带入)。 */
+  guard?: GuardEvaluation[]
+```
+
+`emitEvent` 改签名与实现:
+
+```ts
+emitEvent(
+  event: string,
+  payload?: unknown,
+  guard?: GuardEvaluation | GuardEvaluation[],
+): void {
+  if (this.pendingEvent) {
+    // First event wins within a single tool execution
+    return
+  }
+  this.pendingEvent = {
+    name:    event,
+    payload,
+    domain:  'business',
+    ...(guard ? { guard: Array.isArray(guard) ? guard : [guard] } : {}),
+  }
+}
+```
+
+- [ ] **Step 5: 运行,确认通过**
+
+Run: `npx vitest run src/__tests__/FSMEngine.test.ts`
+Expected: PASS(含原有用例,无回归)。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/trace/types.ts src/fsm/FSMEngine.ts src/__tests__/FSMEngine.test.ts
+git commit -m "feat(#31): GuardEvaluation type + FSMEngine carries guard to onTransition"
+```
+
+---
+
+## Task 2: ctx.emit 第三参 + 捕获进 fsm.transition
+
+**Files:**
+- Modify: `src/types/tool.ts`(`ToolContext.emit`)
+- Modify: `src/runtime/AgentRuntime.ts`(`buildToolContext` 约 `:815`;两个 emit 闭包 `:1017` 与 `:1092`;`setupFSMCallbacks` `:170-211`)
+- Test: `src/__tests__/AgentRuntime.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/__tests__/AgentRuntime.test.ts` 末尾合适 `describe` 内追加(复用文件已有的 `routingConfig`、`SequentialGateway`、`toolCallResponse`、`InMemoryRecorder`、`DefaultIOPort`、`MemoryEventStore`、`MemoryStore` 导入):
+
+```ts
+describe('#31 guard evaluation capture', () => {
+  it('writes guardEvaluations onto the fsm.transition event', async () => {
+    const eventStore = new MemoryEventStore()
+    const guardTool: ToolDefinition = {
+      name:        'classify_intent',
+      description: 'classify',
+      inputSchema: { type: 'object', properties: {} },
+      handler:     async (_input, ctx) => {
+        ctx.emit('INTENT_DONE', undefined, {
+          guardId: 'intent-threshold', result: 'INTENT_DONE',
+          contextSlice: { confidence: 0.9, threshold: 0.75 },
+        })
+        return { ok: true }
+      },
+    }
+    const runtime = new AgentRuntime({
+      config:     routingConfig,
+      goal:       'classify',
+      input:      'hello',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([
+        toolCallResponse('tc-1', 'classify_intent', {}),
+      ])),
+      extraTools: [guardTool],
+      eventStore,
+    })
+
+    const result = await runtime.run('hello')
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const transitions = events.filter(e => e.type === 'fsm.transition')
+    const withGuard = transitions.find(
+      t => (t.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations,
+    )
+    expect((withGuard!.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
+      .toEqual([{ guardId: 'intent-threshold', result: 'INTENT_DONE', contextSlice: { confidence: 0.9, threshold: 0.75 } }])
+  })
+
+  it('omits guardEvaluations when the tool does not report one', async () => {
+    const eventStore = new MemoryEventStore()
+    const plainTool: ToolDefinition = {
+      name:        'classify_intent',
+      description: 'classify',
+      inputSchema: { type: 'object', properties: {} },
+      handler:     async (_input, ctx) => { ctx.emit('INTENT_DONE'); return {} },
+    }
+    const runtime = new AgentRuntime({
+      config:     routingConfig,
+      goal:       'classify',
+      input:      'hello',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([
+        toolCallResponse('tc-1', 'classify_intent', {}),
+      ])),
+      extraTools: [plainTool],
+      eventStore,
+    })
+    const result = await runtime.run('hello')
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const transition = events.find(
+      e => e.type === 'fsm.transition'
+        && (e.payload as import('../trace/types').FsmTransitionPayload).trigger.name === 'INTENT_DONE',
+    )
+    expect((transition!.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
+      .toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx vitest run src/__tests__/AgentRuntime.test.ts -t "#31 guard"`
+Expected: FAIL —— `ctx.emit` 不接受第三参（类型错误）/ `guardEvaluations` 为 undefined。
+
+- [ ] **Step 3: 改 ToolContext.emit 签名**（`src/types/tool.ts`）
+
+顶部 import 加:
+
+```ts
+import type { GuardEvaluation } from '../trace/types.js'
+```
+
+`emit` 字段改为:
+
+```ts
+  emit: (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void
+```
+
+- [ ] **Step 4: 改 AgentRuntime 透传与写入**（`src/runtime/AgentRuntime.ts`）
+
+`buildToolContext` 的形参类型改为带 guard:
+
+```ts
+private buildToolContext(
+  emitFn: (event: string, payload?: unknown, guard?: import('../trace/types.js').GuardEvaluation | import('../trace/types.js').GuardEvaluation[]) => void,
+): ToolContext {
+```
+
+两个构造 ctx 的闭包(`runActionState` 约 `:1017`、`executeSingleTool` 约 `:1092`)各改为透传第三参:
+
+```ts
+const ctx = this.buildToolContext((event, payload, guard) => {
+  this.fsm.emitEvent(event, payload, guard)
+})
+```
+
+`setupFSMCallbacks` 里组装 `fsm.transition` payload 处(`:198-208`),在 `trigger` 之后加入 guardEvaluations:
+
+```ts
+payload: {
+  from,
+  to,
+  trigger: {
+    domain:  event.domain ?? 'business',
+    name:    event.name,
+    ...(event.payload !== undefined ? { payload: event.payload } : {}),
+  },
+  ...(event.guard?.length ? { guardEvaluations: event.guard } : {}),
+},
+```
+
+- [ ] **Step 5: 运行,确认通过**
+
+Run: `npx vitest run src/__tests__/AgentRuntime.test.ts`
+Expected: PASS（两个新用例 + 无回归）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/types/tool.ts src/runtime/AgentRuntime.ts src/__tests__/AgentRuntime.test.ts
+git commit -m "feat(#31): ctx.emit 3rd arg captures guardEvaluations into fsm.transition"
+```
+
+---
+
+## Task 3: Replay 确定性(byte-identical 验收)
+
+**Files:**
+- Test: `src/__tests__/Replay.test.ts`
+
+- [ ] **Step 1: 写测试**
+
+在 `src/__tests__/Replay.test.ts` 的 `describe('Milkie.replay')` 内追加。复用文件已有 `Milkie`/`MemoryStore`/`MemoryEventStore`/`SequentialGateway`/`text`/`toolCallResponse`:
+
+```ts
+it('replays a run whose tool reported a guard, identically and with zero gateway calls (#31)', async () => {
+  const agentWithGuard: AgentConfig = {
+    agentId: 'guard-agent', version: '0.0.0', systemPrompt: 'sys',
+    fsm: { states: [
+      { name: 's0', type: 'llm', tools: ['classify_intent'], on: { INTENT_DONE: 'end' } },
+      { name: 'end', type: 'action', terminal: true },
+    ] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  }
+  const guardTool: ToolDefinition = {
+    name: 'classify_intent', description: 'c', inputSchema: { type: 'object', properties: {} },
+    handler: async (_i, ctx) => {
+      ctx.emit('INTENT_DONE', undefined, { guardId: 'g', result: 'INTENT_DONE', contextSlice: { confidence: 0.9 } })
+      return {}
+    },
+  }
+  // record
+  const store = new MemoryEventStore()
+  const recordGateway = new SequentialGateway([
+    toolCallResponse('tc-1', 'classify_intent', {}),
+    text('done'),
+  ])
+  const recordMilkie = new Milkie({ stateStore: new MemoryStore(), gateway: recordGateway, eventStore: store, tools: [guardTool] })
+  recordMilkie.registerAgent(agentWithGuard)
+  const original = await recordMilkie.invoke({ agentId: 'guard-agent', goal: 'g', input: 'i' })
+
+  // assert guard was recorded
+  const recorded = await store.readByRunId(original.agentRunId)
+  const trans = recorded.find(e => e.type === 'fsm.transition'
+    && (e.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
+  expect(trans).toBeDefined()
+
+  // replay
+  const replayGateway = new SequentialGateway([text('this would be wrong')])
+  const replayMilkie = new Milkie({ stateStore: new MemoryStore(), gateway: replayGateway, eventStore: store, tools: [guardTool] })
+  replayMilkie.registerAgent(agentWithGuard)
+  const replayed = await replayMilkie.replay(original.agentRunId)
+
+  expect(replayed.status).toBe(original.status)
+  expect(replayed.output).toBe(original.output)
+  expect(replayGateway.callCount).toBe(0)   // cache served everything → determinism intact
+})
+```
+
+- [ ] **Step 2: 运行,确认通过**
+
+Run: `npx vitest run src/__tests__/Replay.test.ts -t "#31"`
+Expected: PASS。原理:guardEvaluations 仅是 `fsm.transition`(绕过 IOPort)的额外 payload,不新增任何 `ioPort.uuid()/now()` 调用,缓存序列不变,replay 命中、gateway 调用为 0。
+若 FAIL 且 `callCount > 0` 或 divergence:说明 guard 写入误用了 IOPort —— 回查 Task 2 Step 4,确认仍在 `setupFSMCallbacks` 的 `uuidv4()/Date.now()` 直接生成分支内,未引入 `this.ioPort.*`。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/__tests__/Replay.test.ts
+git commit -m "test(#31): replay determinism preserved with guardEvaluations"
+```
+
+---
+
+## Task 4: s-011 真实 producer 接线 + live 断言
+
+**Files:**
+- Modify: `tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts`（`classify_intent` `:42-62`、`collect_slot` `:80` 附近、`confirm_action`）
+
+- [ ] **Step 1: classify_intent 两个 emit 点补上报**
+
+```ts
+// confidence < 0.75 分支
+ctx.emit('ESCALATE', undefined, {
+  guardId: 'intent-threshold', result: 'ESCALATE',
+  contextSlice: { intent, confidence, threshold: 0.75 },
+})
+// 正常分支
+ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
+  guardId: 'intent-threshold', result: eventMap[intent] ?? 'ESCALATE',
+  contextSlice: { intent, confidence, threshold: 0.75 },
+})
+```
+
+- [ ] **Step 2: collect_slot 补上报**
+
+```ts
+if (allFilled) ctx.emit('SLOTS_COMPLETE', undefined, {
+  guardId: 'slots-complete', result: 'SLOTS_COMPLETE',
+  contextSlice: { filled: Object.keys(slots), required: ['orderId', 'reason', 'preferRefund'] },
+})
+```
+
+- [ ] **Step 3: confirm_action 补上报**
+
+```ts
+ctx.emit(confirmed ? 'USER_CONFIRMED' : 'USER_REJECTED', undefined, {
+  guardId: 'user-confirm', result: confirmed ? 'USER_CONFIRMED' : 'USER_REJECTED',
+  contextSlice: { confirmed },
+})
+```
+
+- [ ] **Step 4: 加 live 断言**
+
+在 s-011 已有的 `live('classify_intent 调用意图为 cancellation...')` 用例附近追加一条(复用文件读取 trace 的方式;trace 来自 e2e 的 `Trajectory`/事件,断言对应 `fsm.transition` payload):
+
+```ts
+live('classify 的硬转移带 intent-threshold guard 依据', () => {
+  const t = trace.events.find(e => e.type === 'fsm.transition'
+    && String((e.payload as { trigger: { name: string } }).trigger.name).startsWith('INTENT_'))
+  const ge = (t?.payload as import('../../src/trace/types').FsmTransitionPayload | undefined)?.guardEvaluations
+  expect(ge?.[0]?.guardId).toBe('intent-threshold')
+  expect((ge?.[0]?.contextSlice as { confidence?: number })?.confidence).toBeGreaterThan(0)
+})
+```
+
+> 若 s-011 现有断言读的是 `Trajectory` span 而非事件日志,改为按该文件既有取事件的方式获取 `fsm.transition` 事件(文件顶部已 import 相关类型);断言内容不变。
+
+- [ ] **Step 5: 运行(需 live token,否则 skip 属正常)**
+
+Run: `VOLCENGINE_TOKEN=... VOLCENGINE_API_BASE=... npx vitest run tests/e2e/s-011-*.e2e.test.ts`
+Expected: 有 token → 新断言 PASS;无 token → 整组 skip(预期,确定性验证由 Task 2/3 保证)。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts
+git commit -m "test(#31): wire s-011 tools to report guard evaluations + live assertion"
+```
+
+---
+
+## Task 5(可选,建议延后): HTML 时间线渲染 fsm.transition + guard
+
+> **决策提示**:`fsm.transition` 当前未在 `tree.ts` 渲染,本任务等于"给时间线新增转移条目"——属 #21 渲染缺口,非 guard 特有。guard 数据已在事件 payload(Task 2 已满足 #31 验收)。**建议延后到 #33(why-this-transition)或单独 issue**;若现在就要在 HTML 里看到,按下列执行。
+
+**Files:**
+- Modify: `src/trace/render/tree.ts`(`TimelineEntry` 联合 `:37`;`buildTimelineTree` 分支 `:125` 之后)
+- Modify: `src/trace/render/html.ts`(`summaryFor` `:17`、details `:26`、icon `:41`、filter chips `:104`)
+- Test: `src/__tests__/render-tree.test.ts`、`src/__tests__/render-html.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`src/__tests__/render-tree.test.ts`,新增用例)
+
+```ts
+it('renders an fsm.transition entry carrying guardEvaluations', () => {
+  const events: Event[] = [
+    { id: 's', runId: 'r1', actor: 'a', type: 'agent.run.started', timestamp: 1,
+      payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } },
+    { id: 't', runId: 'r1', actor: 'a', type: 'fsm.transition', timestamp: 2,
+      payload: { from: 'classify', to: 'handle_b',
+        trigger: { domain: 'business', name: 'INTENT_B' },
+        guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.7 } }] } },
+  ]
+  const tree = buildTimelineTree(events)
+  const entry = tree[0]!.entries.find(e => e.kind === 'fsm')
+  expect(entry).toBeDefined()
+  expect((entry as { summary: string }).summary).toContain('intent-threshold')
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx vitest run src/__tests__/render-tree.test.ts -t "fsm.transition entry"`
+Expected: FAIL —— 无 `kind === 'fsm'` 条目。
+
+- [ ] **Step 3: tree.ts 加 FsmEntry 类型与分支**
+
+`TimelineEntry` 联合前新增:
+
+```ts
+export interface FsmEntry {
+  kind:      'fsm'
+  eventId:   string
+  eventType: 'fsm.transition'
+  timestamp: number
+  summary:   string
+  payload:   unknown
+}
+```
+
+并入联合:
+
+```ts
+export type TimelineEntry = LlmEntry | ToolEntry | LifecycleEntry | RegionEntry | FsmEntry
+```
+
+`buildTimelineTree` 中 `context.boundary.applied` 分支(`:125`)之后追加 `else if`:
+
+```ts
+} else if (evt.type === 'fsm.transition') {
+  const p = evt.payload as import('../types.js').FsmTransitionPayload
+  const guards = p.guardEvaluations?.length
+    ? ' [' + p.guardEvaluations.map(g => `${g.guardId}→${String(g.result)}`).join(', ') + ']'
+    : ''
+  entries.push({
+    kind:      'fsm',
+    eventId:   evt.id,
+    eventType: 'fsm.transition',
+    timestamp: evt.timestamp,
+    summary:   `${p.from} → ${p.to} (${p.trigger.name})${guards}`,
+    payload:   evt.payload,
+  })
+}
+```
+
+> 注:`import('../types.js')` 路径以 `tree.ts` 实际相对位置为准(同目录其他分支若已 import `Event` from `'../types.js'`,复用同一 import,不要重复内联)。
+
+- [ ] **Step 4: html.ts 处理 'fsm' kind**
+
+`summaryFor`(`:17-21`)加一行(`region` 分支后):
+
+```ts
+if (entry.kind === 'fsm')       return esc(entry.summary)
+```
+
+details 段(`:26-30`)的 `region` 分支并列加:
+
+```ts
+} else if (entry.kind === 'fsm') {
+  sections.push(JSON.stringify(entry.payload, null, 2))
+```
+
+icon(`:41-45`)加:
+
+```ts
+: entry.kind === 'fsm' ? '⇒'
+```
+
+filter chips(`:104` 附近)加:
+
+```ts
+<span class="chip" data-kind="fsm">fsm</span>
+```
+
+- [ ] **Step 5: 写 html 渲染测试**(`src/__tests__/render-html.test.ts`,新增用例)
+
+```ts
+it('renders fsm.transition with guard summary in html', () => {
+  const events: Event[] = [
+    e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+        payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    e({ id: 't', runId: 'r1', type: 'fsm.transition', timestamp: 2,
+        payload: { from: 'classify', to: 'handle_b', trigger: { domain: 'business', name: 'INTENT_B' },
+          guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: {} }] } }),
+  ]
+  const html = renderHtml(events)
+  expect(html).toContain('intent-threshold')
+  expect(html).toContain('data-kind="fsm"')
+})
+```
+
+- [ ] **Step 6: 运行,确认通过**
+
+Run: `npx vitest run src/__tests__/render-tree.test.ts src/__tests__/render-html.test.ts`
+Expected: PASS（含原有用例,无回归）。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add src/trace/render/tree.ts src/trace/render/html.ts src/__tests__/render-tree.test.ts src/__tests__/render-html.test.ts
+git commit -m "feat(#31): render fsm.transition + guardEvaluations in HTML timeline"
+```
+
+---
+
+## 收尾
+
+- [ ] **全量测试 + 构建**
+
+Run: `npx vitest run && npm run build`
+Expected: 全绿。
+
+- [ ] **更新 issue / PR**:开 PR,body 带 `Closes #31`,引用 spec 与本 plan。
+
+---
+
+## Self-Review(plan 作者已核对)
+
+**Spec 覆盖:**
+- §4 形状 → Task 1 ✓ §5 上报 API(甲) → Task 2 ✓ §6 捕获 → Task 1+2 ✓ §7 replay → Task 3 ✓ §8 producer → Task 4 ✓ §9 渲染 → Task 5(标注延后)✓ §10 测试 → Task 1–4 测试 ✓ §12 验收 → Task 2(还原)/Task 4(最小化示例)/Task 3(byte-identical)✓
+
+**占位扫描:** 无 TBD/TODO;每个改代码步骤均含完整代码。唯二"以实际为准"提示(tree.ts import 路径、s-011 取事件方式)是因这两处依赖目标文件既有写法,已给出明确判定方法,非内容缺失。
+
+**类型一致性:** `GuardEvaluation{guardId,result,contextSlice}` 在 Task 1 定义,Task 2/3/4/5 引用一致;`FsmTransitionPayload.guardEvaluations?: GuardEvaluation[]` 全程一致;`emitEvent`/`ctx.emit` 第三参 `guard?: GuardEvaluation | GuardEvaluation[]`、归一化为数组,前后一致。

--- a/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
+++ b/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
@@ -1,0 +1,142 @@
+# #31 FSM guard 评估留痕 — 设计 spec
+
+**Issue:** #31（依赖 #21 fsm.transition；阻塞 #33 why-this-transition；场景 s-011）
+**日期:** 2026-05-30
+**定位:** 小型可观测性补丁(选项 A 自觉上报),**不是**决策完备性的结构保证。
+
+---
+
+## 1. 问题与范围
+
+milkie 的转移是纯事件名查表(`current.on[event.name]`),**没有框架级 guard**。"该跳哪"的判断溶解在应用工具/LLM 内部(如 s-011 `classify_intent` 里的 `confidence < 0.75`)。今天 trace 看得到"跳到了 handle_b",看不到"凭什么判成 B"。
+
+本 issue 让工具在触发转移时,**可选地**把"判断依据"上报一句,写进 `fsm.transition`,使 routing 决策可在事后排查。
+
+**采用选项 A(内嵌)**:依据挂在 `fsm.transition.payload` 的新字段上,不新增事件类型。
+
+## 2. Non-goals(明确不做,避免被误读)
+
+- **不建 guard 引擎**:框架不新增任何谓词求值;判断逻辑仍 100% 在应用工具内,本 issue 一行不改它。
+- **不强制完备**:上报是 opt-in。工具不报 → 该转移无 guard 数据,**不报错**。trace 完备性在这一层依赖工具作者自觉——这是选项 A 的已知边界,不在本 issue 解决(若要结构化完备,需走"真 conditional guard",见 ARCHITECTURE.md Transition 概念的 planned extension)。
+- **不强制 contextSlice 最小化**:框架无法知道"哪个字段决定了真假",只有工具自己知道。最小化是**约定**,不是校验。
+
+## 3. 现状:主干其实已被结构化记录(决定本 issue 增量很小)
+
+无需任何自觉,今天的 trace 已含:
+
+| 已有事件 | 内容 | 来源 |
+|---|---|---|
+| `tool.requested` | 工具入参,如 `{intent:'cancellation', confidence:0.95}` | 框架自动(工具调用过 IOPort) |
+| `fsm.transition.trigger.name` | `'INTENT_CANCELLATION'` | 框架自动 |
+| `causedBy`(#30) | 转移 → 触发它的 `tool.responded` | 框架自动 |
+
+即:LLM 的**感知**(intent/confidence)和**结论事件名**已可沿 `causedBy` 还原。本 issue 只补框架够不着的**增量**:
+1. 工具内部**常量/阈值**(如 `threshold: 0.75`,不是入参,藏在代码里);
+2. **哪些字段决定了真假**(最小化语义)。
+
+## 4. 数据结构
+
+`src/trace/types.ts`:
+
+```ts
+export interface GuardEvaluation {
+  /** 判断标识,如 'intent-threshold'。 */
+  guardId:      string
+  /** 判断结果:产出的事件名或布尔/任意值,如 'INTENT_CANCELLATION'。 */
+  result:       unknown
+  /** ★ 决定结果真假的最小输入切片,如 { intent, confidence, threshold }。约定最小化。 */
+  contextSlice: unknown
+}
+
+export interface FsmTransitionPayload {
+  from: string
+  to:   string
+  trigger: { domain: FsmEventDomain; name: string; payload?: unknown }   // 不变
+  /** #31:本次转移背后的判断依据(工具自报,可选)。 */
+  guardEvaluations?: GuardEvaluation[]
+}
+```
+
+`guardEvaluations` 与 `trigger.payload` **严格分离**——后者是"事件随带数据"的杂物位,前者语义明确为"为什么这么判"。两者不复用同一字段。
+
+## 5. 上报 API(authoring)
+
+**选定:给 `ctx.emit` 增加独立的第三参 `guard`**(`src/types/tool.ts`):
+
+```ts
+emit: (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void
+```
+
+工具改动(s-011 `classify_intent`,一处):
+
+```ts
+// 今天
+ctx.emit(eventMap[intent] ?? 'ESCALATE')
+
+// #31 之后
+ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
+  guardId:      'intent-threshold',
+  result:       eventMap[intent] ?? 'ESCALATE',
+  contextSlice: { intent, confidence, threshold: 0.75 },
+})
+```
+
+理由:① 现状 `emit` 第二参 `payload` 实际无人使用,但保留以免破坏签名;② guard 作为独立第三参,与 `trigger.payload` 语义不混;③ 一次调用原子完成"发事件 + 报依据",guard 恰好对应产生本次转移的那一次决策,无需缓冲生命周期。
+
+**备选(留给 spec review 取舍)**:单独 `ctx.recordGuard(evaluation)` 方法,多次调用累积成数组、由下一次转移消费。语义更显式、天然产出数组,但引入"记录了却没转移""记录顺序"等缓冲边界。若团队更看重 authoring 显式性,可改采此式。
+
+## 6. 捕获机制(复用 #30 模式,零新增 IOPort 调用)
+
+1. `FSMEngine.emitEvent(event, payload?, guard?)`:第三参存入 `pendingEvent`(`{ name, payload, domain, guard }`);"first event wins" 逻辑不变。
+2. `FSMEvent` 类型(`FSMEngine.ts`)加可选 `guard?: GuardEvaluation[]`(单个则归一化为数组)。
+3. `transition()` 的 `onTransition(from, to, event)` 回调已带 `event`,guard 随之传出。
+4. `AgentRuntime.setupFSMCallbacks`(`:170-211`)组装 `fsm.transition` payload 时,写入 `...(event.guard?.length ? { guardEvaluations: event.guard } : {})`。仍用 `uuidv4()/Date.now()` 直接生成 id/timestamp,**绕过 IOPort**。
+5. 框架自身的 lifecycle/signal/runtime-control 事件(DONE/interrupt/error/RETRY)不带 guard,自然无此字段。
+
+## 7. Replay / byte-identical
+
+- guardEvaluations 仅是 `fsm.transition` 上的额外 payload 内容。`fsm.transition` 本就绕过 IOPort、不进 nondet 缓存(`AgentRuntime.ts:178-183`)。
+- 因此本改动**不产生任何新的 `ioPort.uuid()/now()` 调用**,回放消费的 LLM/tool/clock/uuid 缓存序列与改动前**逐字节一致** → replay 确定性不破。这是 #31 "replay byte-identical" 验收的精确含义。
+- guard 数据在**录制时**(handler 真跑、`ctx.emit` 触发)捕获;回放时 handler 不重跑(`ReplayingIOPort.invokeTool` 忽略 execute thunk),这是既有行为,本 issue 不改变、也不依赖它。诊断对象是录制 run,数据齐全。
+- 诚实声明:`fsm.transition` 事件的 `id/timestamp` 在录制/回放间本就不同(直接生成),事件**日志字节**对这些信息性事件本就非逐字节一致——这是既有事实,非本 issue 引入。
+
+## 8. Producer 接线(给本 issue 一个真实水源)
+
+改 s-011 三个工具,各在 emit 处补一次上报,使端到端 trace 真能看到 guard:
+
+| 工具 | guardId | contextSlice |
+|---|---|---|
+| `classify_intent` | `intent-threshold` | `{ intent, confidence, threshold: 0.75 }` |
+| `collect_slot` | `slots-complete` | `{ filled: [...], required: ['orderId','reason','preferRefund'] }` |
+| `confirm_action` | `user-confirm` | `{ confirmed }` |
+
+## 9. 渲染
+
+`src/trace/render/`:`fsm.transition` 条目下,若有 `guardEvaluations`,多渲一行,如:
+`guard intent-threshold → INTENT_CANCELLATION（intent=cancellation, confidence=0.95 ≥ 0.75）`。无该字段时行为不变。
+
+## 10. 测试
+
+- **单元**:一个工具 `ctx.emit(name, undefined, guard)` → 断言对应 `fsm.transition` 事件 payload 含 `guardEvaluations`,内容匹配。
+- **不带 guard 的转移**:断言 payload **无** `guardEvaluations` 字段(保持干净、向后兼容)。
+- **replay 确定性**:沿用 s-005 模式——带 guard 的 run 回放后 `status/output` 一致、gateway 调用数为 0,证明缓存序列未受扰。
+- **渲染**:带 guard 的事件渲出额外行;不带的不渲。
+- **s-011 e2e**:live 路径下,trace 中 `classify_intent` 触发的 `fsm.transition` 含 `intent-threshold` 的 guardEvaluations。
+
+## 11. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/types.ts` | +`GuardEvaluation`;`FsmTransitionPayload` 加 `guardEvaluations?` |
+| `src/types/tool.ts` | `emit` 签名加第三参 `guard?` |
+| `src/fsm/FSMEngine.ts` | `FSMEvent` 加 `guard?`;`emitEvent` 加第三参并存入 `pendingEvent` |
+| `src/runtime/AgentRuntime.ts` | `buildToolContext` 透传 guard;`setupFSMCallbacks` 写入 `guardEvaluations` |
+| `src/trace/render/*` | 渲染分支 |
+| `tests/e2e/s-011-*.ts` | 三个工具补上报 |
+| `src/__tests__/*` | 新增单元 + replay 测试 |
+
+## 12. 验收对照(#31)
+
+- [x] 多 guard FSM 的事件流可还原"哪些 guard 真求值、值多少" → guardEvaluations(录制时捕获)
+- [x] contextSlice 最小化 → 约定 + s-011 示例;**不强制**(已在 Non-goals 声明)
+- [x] replay byte-identical → 零新增 IOPort 调用,缓存序列不变

--- a/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
+++ b/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
@@ -83,7 +83,7 @@ ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
 
 理由:① 现状 `emit` 第二参 `payload` 实际无人使用,但保留以免破坏签名;② guard 作为独立第三参,与 `trigger.payload` 语义不混;③ 一次调用原子完成"发事件 + 报依据",guard 恰好对应产生本次转移的那一次决策,无需缓冲生命周期。
 
-**备选(留给 spec review 取舍)**:单独 `ctx.recordGuard(evaluation)` 方法,多次调用累积成数组、由下一次转移消费。语义更显式、天然产出数组,但引入"记录了却没转移""记录顺序"等缓冲边界。若团队更看重 authoring 显式性,可改采此式。
+**决定:采用甲,锁定。** 备选乙(单独 `ctx.recordGuard(evaluation)` 方法,多次调用累积成数组、由下一次转移消费)已评估**不采用**——它引入"记录了却没转移""记录顺序""跨 emit 归属"等缓冲生命周期边界,违背最小自洽;甲 的一次调用原子绑定"发事件 + 报依据",更简单。
 
 ## 6. 捕获机制(复用 #30 模式,零新增 IOPort 调用)
 
@@ -122,6 +122,8 @@ ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
 - **replay 确定性**:沿用 s-005 模式——带 guard 的 run 回放后 `status/output` 一致、gateway 调用数为 0,证明缓存序列未受扰。
 - **渲染**:带 guard 的事件渲出额外行;不带的不渲。
 - **s-011 e2e**:live 路径下,trace 中 `classify_intent` 触发的 `fsm.transition` 含 `intent-threshold` 的 guardEvaluations。
+
+> **验证分工(诚实声明)**:s-011 是 live e2e,挂在 `VOLCENGINE_TOKEN` 后,无 token 即 skip——故 **每次都跑的确定性验证是单元测试**(自带假工具 + mock gateway);s-011 提供"真实多状态场景也通"的额外信心与一份 authoring 样例,但常在 CI 被 skip。两者都要:单元测试保确定性,s-011 保真实性。
 
 ## 11. 改动文件清单
 

--- a/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
+++ b/docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md
@@ -100,6 +100,13 @@ ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
 - guard 数据在**录制时**(handler 真跑、`ctx.emit` 触发)捕获;回放时 handler 不重跑(`ReplayingIOPort.invokeTool` 忽略 execute thunk),这是既有行为,本 issue 不改变、也不依赖它。诊断对象是录制 run,数据齐全。
 - 诚实声明:`fsm.transition` 事件的 `id/timestamp` 在录制/回放间本就不同(直接生成),事件**日志字节**对这些信息性事件本就非逐字节一致——这是既有事实,非本 issue 引入。
 
+**实现期发现(重要,影响验收的验证方式):**
+
+- guard 上报**只发生在 emit 驱动的转移**(工具 `ctx.emit` 触发)上。而 milkie 的 replay **不重跑工具 handler**(`ReplayingIOPort.invokeTool` 忽略 execute thunk),因此 **emit 驱动的转移在 replay 时根本不会重新触发** —— FSM 停在原状态、多发一次未缓存的 LLM 调用、抛 `ReplayDivergenceError`。这是 milkie **既有的 replay 限制**,影响所有 emit 驱动 FSM(含 s-011),**非 #31 引入**。
+- 推论:含 guard 的 run 无法靠"重执行"复现转移。但这对 #31 **无碍** —— guard 在录制时已落盘(诊断对象就是录制 run),#31 的职责是留痕、非 replay 复现。
+- 因此 Task 3 的验证**不**去 replay 一个 emit-FSM(那会撞上上述既有限制),而是直接验证 #31 真正承诺的点:**"加 guard 不产生任何新 IOPort 事件"**。做法:同一 emit-FSM 场景录制两次(工具一次带 guard、一次不带),断言两次的 IOPort 事件序列(`clock.read`/`uuid.generated`/`llm.*`/`tool.*`)**完全一致** → 证明 guard 写入零扰动 → replay 缓存序列不变。
+- 建议:emit 驱动 FSM 的 replay 限制本身值得**单独开 issue** 跟踪(超出 #31 范围)。
+
 ## 8. Producer 接线(给本 issue 一个真实水源)
 
 改 s-011 三个工具,各在 emit 处补一次上报,使端到端 trace 真能看到 guard:

--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -515,3 +515,86 @@ describe('AgentRuntime', () => {
     })
   })
 })
+
+describe('#31 guard evaluation capture', () => {
+  const routingConfig = makeConfig({
+    fsm: {
+      states: [
+        {
+          name:  'classify',
+          type:  'llm',
+          tools: ['classify_intent'],
+          on:    { INTENT_DONE: 'done' },
+        },
+        { name: 'done', type: 'action', terminal: true },
+      ],
+    },
+  })
+
+  it('writes guardEvaluations onto the fsm.transition event', async () => {
+    const eventStore = new MemoryEventStore()
+    const guardTool: ToolDefinition = {
+      name:        'classify_intent',
+      description: 'classify',
+      inputSchema: { type: 'object', properties: {} },
+      handler:     async (_input, ctx) => {
+        ctx.emit('INTENT_DONE', undefined, {
+          guardId: 'intent-threshold', result: 'INTENT_DONE',
+          contextSlice: { confidence: 0.9, threshold: 0.75 },
+        })
+        return { ok: true }
+      },
+    }
+    const runtime = new AgentRuntime({
+      config:     routingConfig,
+      goal:       'classify',
+      input:      'hello',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([
+        toolCallResponse('tc-1', 'classify_intent', {}),
+      ])),
+      extraTools: [guardTool],
+      eventStore,
+    })
+
+    const result = await runtime.run('hello')
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const transitions = events.filter(e => e.type === 'fsm.transition')
+    const withGuard = transitions.find(
+      t => (t.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations,
+    )
+    expect((withGuard!.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
+      .toEqual([{ guardId: 'intent-threshold', result: 'INTENT_DONE', contextSlice: { confidence: 0.9, threshold: 0.75 } }])
+  })
+
+  it('omits guardEvaluations when the tool does not report one', async () => {
+    const eventStore = new MemoryEventStore()
+    const plainTool: ToolDefinition = {
+      name:        'classify_intent',
+      description: 'classify',
+      inputSchema: { type: 'object', properties: {} },
+      handler:     async (_input, ctx) => { ctx.emit('INTENT_DONE'); return {} },
+    }
+    const runtime = new AgentRuntime({
+      config:     routingConfig,
+      goal:       'classify',
+      input:      'hello',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([
+        toolCallResponse('tc-1', 'classify_intent', {}),
+      ])),
+      extraTools: [plainTool],
+      eventStore,
+    })
+    const result = await runtime.run('hello')
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const transition = events.find(
+      e => e.type === 'fsm.transition'
+        && (e.payload as import('../trace/types').FsmTransitionPayload).trigger.name === 'INTENT_DONE',
+    )
+    expect((transition!.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
+      .toBeUndefined()
+  })
+})

--- a/src/__tests__/FSMEngine.test.ts
+++ b/src/__tests__/FSMEngine.test.ts
@@ -78,6 +78,31 @@ describe('FSMEngine', () => {
       expect(next).toBeNull()
       expect(fsm.currentStateName).toBe('classify')
     })
+
+    it('carries guard evaluations through to the onTransition callback', () => {
+      const fsm = new FSMEngine(routingFSM)   // classify, on INTENT_A: handle_a
+      let received: import('../fsm/FSMEngine').FSMEvent | undefined
+      fsm.onTransitionCallback((_from, _to, event) => { received = event })
+
+      fsm.emitEvent('INTENT_A', undefined, {
+        guardId: 'g', result: 'INTENT_A', contextSlice: { s: 1 },
+      })
+      fsm.processPendingEvent()
+
+      expect(received?.guard).toEqual([
+        { guardId: 'g', result: 'INTENT_A', contextSlice: { s: 1 } },
+      ])
+    })
+
+    it('normalizes a guard array argument as-is', () => {
+      const fsm = new FSMEngine(routingFSM)
+      let received: import('../fsm/FSMEngine').FSMEvent | undefined
+      fsm.onTransitionCallback((_f, _t, e) => { received = e })
+      const arr = [{ guardId: 'a', result: 1, contextSlice: {} }, { guardId: 'b', result: 2, contextSlice: {} }]
+      fsm.emitEvent('INTENT_A', undefined, arr)
+      fsm.processPendingEvent()
+      expect(received?.guard).toEqual(arr)
+    })
   })
 
   describe('processDone()', () => {

--- a/src/__tests__/Replay.test.ts
+++ b/src/__tests__/Replay.test.ts
@@ -6,7 +6,7 @@ import { ReplayDivergenceError } from '../trace/ReplayDivergenceError'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
 import type { ToolDefinition } from '../types/tool'
-import type { AgentSpawnedPayload } from '../trace/types'
+import type { AgentSpawnedPayload, FsmTransitionPayload } from '../trace/types'
 
 class SequentialGateway implements IModelGateway {
   public callCount = 0
@@ -414,5 +414,55 @@ describe('Milkie.replay', () => {
     const child = await replay.replay(childRunId)
     expect(child.status).toBe('completed')
     expect(child.output).toBe('worker done')
+  })
+
+  it('guardEvaluations adds zero IOPort events — replay cache sequence unchanged (#31)', async () => {
+    const IO_TYPES = ['clock.read', 'uuid.generated', 'llm.requested', 'llm.responded', 'tool.requested', 'tool.responded']
+
+    const recordOnce = async (withGuard: boolean): Promise<string[]> => {
+      const store = new MemoryEventStore()
+      const tool: ToolDefinition = {
+        name: 'classify_intent', description: 'c', inputSchema: { type: 'object', properties: {} },
+        handler: async (_i, ctx) => {
+          if (withGuard) {
+            ctx.emit('INTENT_DONE', undefined, { guardId: 'g', result: 'INTENT_DONE', contextSlice: { confidence: 0.9 } })
+          } else {
+            ctx.emit('INTENT_DONE')
+          }
+          return {}
+        },
+      }
+      const config: AgentConfig = {
+        agentId: 'guard-agent', version: '0.0.0', systemPrompt: 'sys',
+        fsm: { states: [
+          { name: 's0', type: 'llm', tools: ['classify_intent'], on: { INTENT_DONE: 'end' } },
+          { name: 'end', type: 'action', terminal: true },
+        ] },
+        model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+      }
+      const milkie = new Milkie({
+        stateStore: new MemoryStore(),
+        gateway: new SequentialGateway([toolCallResponse('tc-1', 'classify_intent', {})]),
+        eventStore: store, tools: [tool],
+      })
+      milkie.registerAgent(config)
+      const r = await milkie.invoke({ agentId: 'guard-agent', goal: 'g', input: 'i' })
+      expect(r.status).toBe('completed')           // sanity: emit-FSM completes in record mode
+      const evs = await store.readByRunId(r.agentRunId)
+      if (withGuard) {
+        const t = evs.find(e => e.type === 'fsm.transition'
+          && (e.payload as FsmTransitionPayload).guardEvaluations)
+        expect(t).toBeDefined()                    // sanity: guard actually recorded
+      }
+      return evs.filter(e => IO_TYPES.includes(e.type)).map(e => e.type)
+    }
+
+    const withGuard = await recordOnce(true)
+    const without   = await recordOnce(false)
+
+    // Guard write rides on fsm.transition (direct uuid/Date.now, NOT IOPort),
+    // so the IOPort-recorded event sequence is identical with/without the guard.
+    expect(withGuard).toEqual(without)
+    expect(withGuard.length).toBeGreaterThan(0)
   })
 })

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -90,4 +90,17 @@ describe('renderHtml', () => {
     // the status string when rendered as text content is escaped
     expect(html).not.toContain('class="badge ' + malicious)
   })
+
+  it('renders fsm.transition with guard summary in html', () => {
+    const events: Event[] = [
+      e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 't', runId: 'r1', type: 'fsm.transition', timestamp: 2,
+          payload: { from: 'classify', to: 'handle_b', trigger: { domain: 'business', name: 'INTENT_B' },
+            guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: {} }] } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('intent-threshold')
+    expect(html).toContain('data-kind="fsm"')
+  })
 })

--- a/src/__tests__/render-tree.test.ts
+++ b/src/__tests__/render-tree.test.ts
@@ -70,4 +70,20 @@ describe('buildTimelineTree', () => {
     expect(entry).toBeDefined()
     expect((entry as { summary: string }).summary).toContain('intent-threshold')
   })
+
+  it('renders an fsm.transition entry without guard evaluations (no bracket segment)', () => {
+    const events: Event[] = [
+      e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 't', runId: 'r1', type: 'fsm.transition', timestamp: 2,
+          payload: { from: 'classify', to: 'handle_a',
+            trigger: { domain: 'business', name: 'INTENT_A' } } }),
+    ]
+    const tree = buildTimelineTree(events)
+    const entry = tree[0]!.entries.find(en => en.kind === 'fsm')
+    expect(entry).toBeDefined()
+    const summary = (entry as { summary: string }).summary
+    expect(summary).toContain('classify → handle_a')
+    expect(summary).not.toContain('[')
+  })
 })

--- a/src/__tests__/render-tree.test.ts
+++ b/src/__tests__/render-tree.test.ts
@@ -55,4 +55,19 @@ describe('buildTimelineTree', () => {
     expect(tree.map(n => n.runId)).toEqual(['parent'])
     expect(tree[0]!.children.map(n => n.runId)).toEqual(['child'])
   })
+
+  it('renders an fsm.transition entry carrying guardEvaluations', () => {
+    const events: Event[] = [
+      e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 't', runId: 'r1', type: 'fsm.transition', timestamp: 2,
+          payload: { from: 'classify', to: 'handle_b',
+            trigger: { domain: 'business', name: 'INTENT_B' },
+            guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.7 } }] } }),
+    ]
+    const tree = buildTimelineTree(events)
+    const entry = tree[0]!.entries.find(en => en.kind === 'fsm')
+    expect(entry).toBeDefined()
+    expect((entry as { summary: string }).summary).toContain('intent-threshold')
+  })
 })

--- a/src/fsm/FSMEngine.ts
+++ b/src/fsm/FSMEngine.ts
@@ -1,5 +1,5 @@
 import type { FSMDefinition, FSMState } from '../types/agent.js'
-import type { FsmEventDomain } from '../trace/types.js'
+import type { FsmEventDomain, GuardEvaluation } from '../trace/types.js'
 
 export interface FSMEvent {
   name:     string
@@ -11,6 +11,8 @@ export interface FSMEvent {
    * only path that doesn't set it is `ctx.emit()` from tool handlers.
    */
   domain?:  FsmEventDomain
+  /** #31:触发本次转移的判断依据(由 ctx.emit 第三参带入)。 */
+  guard?: GuardEvaluation[]
 }
 
 export type FSMTransitionHandler = (from: string, to: string, event: FSMEvent) => void
@@ -52,12 +54,21 @@ export class FSMEngine {
   // interrupt/error signals. Default domain is 'business' — the global
   // 'interrupt'/'error' branches in processPendingEvent re-tag those to
   // 'signal' on the transition itself, so this default is safe.
-  emitEvent(event: string, payload?: unknown): void {
+  emitEvent(
+    event: string,
+    payload?: unknown,
+    guard?: GuardEvaluation | GuardEvaluation[],
+  ): void {
     if (this.pendingEvent) {
       // First event wins within a single tool execution
       return
     }
-    this.pendingEvent = { name: event, payload, domain: 'business' }
+    this.pendingEvent = {
+      name:    event,
+      payload,
+      domain:  'business',
+      ...(guard ? { guard: Array.isArray(guard) ? guard : [guard] } : {}),
+    }
   }
 
   // Process the pending event (if any) and transition to the next state.

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -36,7 +36,7 @@ import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
 import type { CausalCursor } from '../trace/CausalCursor.js'
 import type { Region } from '../context/Region.js'
-import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload } from '../trace/types.js'
+import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation } from '../trace/types.js'
 
 export type MakeChildPort = (
   childRunId:  string,
@@ -205,6 +205,7 @@ export class AgentRuntime {
                 name:    event.name,
                 ...(event.payload !== undefined ? { payload: event.payload } : {}),
               },
+              ...(event.guard?.length ? { guardEvaluations: event.guard } : {}),
             },
           })
         })
@@ -322,7 +323,7 @@ export class AgentRuntime {
     )
   }
 
-  private buildToolContext(emitFn: (event: string, payload?: unknown) => void): ToolContext {
+  private buildToolContext(emitFn: (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void): ToolContext {
     return {
       workingMemory: this.memory,
       agentFactory:  this.factory,
@@ -1014,8 +1015,8 @@ export class AgentRuntime {
       throw new Error(`Action handler "${state.handler}" not found in tool registry`)
     }
 
-    const ctx = this.buildToolContext((event, payload) => {
-      this.fsm.emitEvent(event, payload)
+    const ctx = this.buildToolContext((event, payload, guard) => {
+      this.fsm.emitEvent(event, payload, guard)
     })
 
     const span = this.recorder.startSpan('tool.call', {
@@ -1089,8 +1090,8 @@ export class AgentRuntime {
     call: { id: string; name: string; input: unknown },
     batchId: string | null,
   ): Promise<ToolResult> {
-    const ctx = this.buildToolContext((event, payload) => {
-      this.fsm.emitEvent(event, payload)
+    const ctx = this.buildToolContext((event, payload, guard) => {
+      this.fsm.emitEvent(event, payload, guard)
     })
 
     const maxRetries = 3

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -18,6 +18,7 @@ function summaryFor(entry: TimelineEntry): string {
   if (entry.kind === 'llm')       return 'LLM call' + (entry.respondedId ? '' : ' (no response)')
   if (entry.kind === 'tool')      return 'tool: ' + esc(entry.toolName) + (entry.respondedId ? '' : ' (no response)')
   if (entry.kind === 'region')    return esc(entry.summary)
+  if (entry.kind === 'fsm')       return esc(entry.summary)
   return entry.eventType === 'agent.run.started' ? 'run started' : 'run completed'
 }
 
@@ -27,6 +28,8 @@ function payloadFor(entry: TimelineEntry, eventById: Map<string, Event>): string
     const evt = eventById.get(entry.eventId)
     if (evt) sections.push(JSON.stringify(evt.payload, null, 2))
   } else if (entry.kind === 'region') {
+    sections.push(JSON.stringify(entry.payload, null, 2))
+  } else if (entry.kind === 'fsm') {
     sections.push(JSON.stringify(entry.payload, null, 2))
   } else {
     const req = eventById.get(entry.requestedId)
@@ -43,6 +46,7 @@ function renderEntry(entry: TimelineEntry, eventById: Map<string, Event>): strin
              : entry.kind === 'region'
                ? (entry.eventType === 'context.boundary.applied' ? '⌖'
                  : entry.eventType === 'region.added' ? '＋' : '－')
+             : entry.kind === 'fsm' ? '⇒'
              : '●'
   return `<div class="entry ${entry.kind}" data-kind="${entry.kind}">`
        + `<div class="entry-head">`
@@ -102,6 +106,7 @@ export function renderHtml(events: Event[]): string {
   <span class="chip" data-kind="tool">tool</span>
   <span class="chip" data-kind="lifecycle">lifecycle</span>
   <span class="chip" data-kind="region">region</span>
+  <span class="chip" data-kind="fsm">fsm</span>
 </div>
 ${tree.map(n => renderNode(n, eventById)).join('')}
 <script type="application/json" id="trace-data">${dataJson}</script>

--- a/src/trace/render/tree.ts
+++ b/src/trace/render/tree.ts
@@ -1,4 +1,4 @@
-import type { Event } from '../types.js'
+import type { Event, FsmTransitionPayload } from '../types.js'
 
 export interface LlmEntry {
   kind:          'llm'
@@ -34,7 +34,16 @@ export interface RegionEntry {
   payload:   unknown
 }
 
-export type TimelineEntry = LlmEntry | ToolEntry | LifecycleEntry | RegionEntry
+export interface FsmEntry {
+  kind:      'fsm'
+  eventId:   string
+  eventType: 'fsm.transition'
+  timestamp: number
+  summary:   string
+  payload:   unknown
+}
+
+export type TimelineEntry = LlmEntry | ToolEntry | LifecycleEntry | RegionEntry | FsmEntry
 
 export interface TimelineNode {
   runId:     string
@@ -134,6 +143,19 @@ export function buildTimelineTree(events: Event[]): TimelineNode[] {
           eventType: 'context.boundary.applied',
           timestamp: evt.timestamp,
           summary:   `boundary ${p.boundary} @ epoch ${p.epoch}${detail}`,
+          payload:   evt.payload,
+        })
+      } else if (evt.type === 'fsm.transition') {
+        const p = evt.payload as FsmTransitionPayload
+        const guards = p.guardEvaluations?.length
+          ? ' [' + p.guardEvaluations.map(g => `${g.guardId}→${String(g.result)}`).join(', ') + ']'
+          : ''
+        entries.push({
+          kind:      'fsm',
+          eventId:   evt.id,
+          eventType: 'fsm.transition',
+          timestamp: evt.timestamp,
+          summary:   `${p.from} → ${p.to} (${p.trigger.name})${guards}`,
           payload:   evt.payload,
         })
       }

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -189,6 +189,15 @@ export interface SkillLifecyclePayload {
  */
 export type FsmEventDomain = 'lifecycle' | 'signal' | 'runtime-control' | 'business'
 
+export interface GuardEvaluation {
+  /** 判断标识,如 'intent-threshold'。 */
+  guardId:      string
+  /** 判断结果:产出的事件名或布尔/任意值。 */
+  result:       unknown
+  /** 决定结果真假的最小输入切片(约定最小化,框架不强制)。 */
+  contextSlice: unknown
+}
+
 export interface FsmTransitionPayload {
   from: string
   to:   string
@@ -198,6 +207,8 @@ export interface FsmTransitionPayload {
     /** Optional structured payload (omit for lifecycle/signal which carry none). */
     payload?: unknown
   }
+  /** #31:本次转移背后的判断依据(工具自报,可选)。 */
+  guardEvaluations?: GuardEvaluation[]
 }
 
 // ---- Typed event aliases ----

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -2,12 +2,13 @@ import type { JSONSchema } from './common.js'
 import type { WorkingMemory } from '../store/WorkingMemory.js'
 import type { IStateStore } from './store.js'
 import type { AgentFactory } from '../runtime/AgentFactory.js'
+import type { GuardEvaluation } from '../trace/types.js'
 
 export interface ToolContext {
   workingMemory: WorkingMemory
   agentFactory:  AgentFactory
   stateStore:    IStateStore
-  emit:          (event: string, payload?: unknown) => void
+  emit:          (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void
   requestSkill?: (name: string, scope?: 'turn' | 'session') => { requested: string; status: string; version?: string; scope?: 'turn' | 'session' }
 }
 

--- a/tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts
+++ b/tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts
@@ -19,6 +19,8 @@ import { Milkie } from '../../src/runtime/Milkie.js'
 import { TrajectoryStore } from '../../src/trajectory/TrajectoryStore.js'
 import { RedisStore } from '../../src/store/RedisStore.js'
 import { MemoryStore } from '../../src/store/MemoryStore.js'
+import { MemoryEventStore } from '../../src/trace/MemoryEventStore.js'
+import type { FsmTransitionPayload } from '../../src/trace/types.js'
 import { createRedisStore } from './redis.js'
 
 const SKIP = !process.env['VOLCENGINE_TOKEN'] || !process.env['VOLCENGINE_API_BASE']
@@ -43,7 +45,10 @@ const classifyIntentTool: ToolDefinition = {
     ctx.workingMemory.set('intentConfidence', confidence)
 
     if (confidence < 0.75) {
-      ctx.emit('ESCALATE')
+      ctx.emit('ESCALATE', undefined, {
+        guardId: 'intent-threshold', result: 'ESCALATE',
+        contextSlice: { intent, confidence, threshold: 0.75 },
+      })
       return { accepted: false, reason: 'low_confidence', confidence }
     }
 
@@ -52,7 +57,10 @@ const classifyIntentTool: ToolDefinition = {
       billing:      'INTENT_BILLING',
       unclear:      'INTENT_UNCLEAR',
     }
-    ctx.emit(eventMap[intent] ?? 'ESCALATE')
+    ctx.emit(eventMap[intent] ?? 'ESCALATE', undefined, {
+      guardId: 'intent-threshold', result: eventMap[intent] ?? 'ESCALATE',
+      contextSlice: { intent, confidence, threshold: 0.75 },
+    })
     return { accepted: true, intent, confidence }
   },
 }
@@ -75,7 +83,10 @@ const collectSlotTool: ToolDefinition = {
     ctx.workingMemory.set('collectedSlots', slots)
 
     const allFilled = ['orderId', 'reason', 'preferRefund'].every(k => slots[k] !== undefined)
-    if (allFilled) ctx.emit('SLOTS_COMPLETE')
+    if (allFilled) ctx.emit('SLOTS_COMPLETE', undefined, {
+      guardId: 'slots-complete', result: 'SLOTS_COMPLETE',
+      contextSlice: { filled: Object.keys(slots), required: ['orderId', 'reason', 'preferRefund'] },
+    })
     return { collected: slots, complete: allFilled }
   },
 }
@@ -93,7 +104,10 @@ const confirmActionTool: ToolDefinition = {
   },
   handler: async (input: unknown, ctx) => {
     const { confirmed } = input as { confirmed: boolean }
-    ctx.emit(confirmed ? 'USER_CONFIRMED' : 'USER_REJECTED')
+    ctx.emit(confirmed ? 'USER_CONFIRMED' : 'USER_REJECTED', undefined, {
+      guardId: 'user-confirm', result: confirmed ? 'USER_CONFIRMED' : 'USER_REJECTED',
+      contextSlice: { confirmed },
+    })
     return { confirmed }
   },
 }
@@ -287,16 +301,18 @@ class SlotFillingGateway implements IModelGateway {
 
 async function createTestEnv() {
   const trajectoryStore = new TrajectoryStore({ jsonlDir: './test-output/trajectories' })
+  const eventStore      = new MemoryEventStore()
   const stateStore      = await createRedisStore(15)
   const milkie = new Milkie({
     stateStore,
     trajectoryStore,
+    eventStore,
     tools: [classifyIntentTool, collectSlotTool, confirmActionTool],
   })
   milkie.registerAgent(cancellationExecutorConfig)
   milkie.registerAgent(billingSpecialistConfig)
   milkie.registerAgent(customerServiceConfig)
-  return { milkie, trajectoryStore, stateStore }
+  return { milkie, trajectoryStore, eventStore, stateStore }
 }
 
 // ─────────────────────────────── Path A ──────────────────────────────────────
@@ -304,8 +320,10 @@ async function createTestEnv() {
 describe('Case 6 Path A: 主路径 — 取消订单', () => {
   let milkie: Milkie
   let trajectoryStore: TrajectoryStore
+  let eventStore: MemoryEventStore
   let stateStore: RedisStore
   let trajectory: Trajectory
+  let run1Result: AgentResult
   let run2Result: AgentResult
 
   const contextId = `ctx-case6-pathA-${Date.now()}`
@@ -318,10 +336,10 @@ describe('Case 6 Path A: 主路径 — 取消订单', () => {
   beforeAll(async () => {
     if (SKIP) return
     const env = await createTestEnv()
-    ;({ milkie, trajectoryStore, stateStore } = env)
+    ;({ milkie, trajectoryStore, eventStore, stateStore } = env)
 
     // Turn 1: all slot info provided upfront (more deterministic than 3 separate turns)
-    await sendTurn('我想取消订单 ORD-456，原因是商品损坏，需要退款')
+    run1Result = await sendTurn('我想取消订单 ORD-456，原因是商品损坏，需要退款')
 
     // Turn 2: confirm
     run2Result = await sendTurn('确认，请执行取消')
@@ -351,6 +369,20 @@ describe('Case 6 Path A: 主路径 — 取消订单', () => {
     const inp = classifySpan!.attributes['input'] as { intent?: string; confidence?: number }
     expect(inp.intent).toBe('cancellation')
     expect(inp.confidence).toBeGreaterThanOrEqual(0.75)
+  })
+
+  live('classify 的硬转移携带 intent-threshold guard 依据', async () => {
+    // guardEvaluations 落在 fsm.transition 事件 payload 上（不在 span attributes），
+    // 所以从 eventStore 读 turn 1 的事件流，定位 INTENT_* 业务硬转移那条。
+    const events = await eventStore.readByRunId(run1Result.agentRunId)
+    const transition = events.find(
+      e => e.type === 'fsm.transition' &&
+        (e.payload as FsmTransitionPayload).trigger.name.startsWith('INTENT_')
+    )
+    expect(transition).toBeDefined()
+    const ge = (transition!.payload as FsmTransitionPayload).guardEvaluations
+    expect(ge?.[0]?.guardId).toBe('intent-threshold')
+    expect((ge?.[0]?.contextSlice as { confidence?: number }).confidence).toBeGreaterThan(0)
   })
 
   live('collect_slot 收集了 orderId 槽位', () => {


### PR DESCRIPTION
Closes #31

## Summary

让工具在触发 FSM 转移时**可选地自报"判断依据"(guard evaluation)**,依据被捕获进 `fsm.transition` 事件、可在 trace 排查。小型可观测性补丁(选项 A),框架只搬运、**不建 guard 引擎、不强制完备**。

- `GuardEvaluation { guardId, result, contextSlice }`(`src/trace/types.ts`);`FsmTransitionPayload` 加 `guardEvaluations?`
- `ctx.emit(event, payload?, guard?)` 第三参 → `FSMEngine` 透传 → `setupFSMCallbacks` 写进 `fsm.transition`
- HTML 时间线新增 `fsm.transition` 渲染条目(此前未渲染)+ guard 展示
- s-011 三个工具(`classify_intent`/`collect_slot`/`confirm_action`)接线 + live 断言

## 关键设计点

- **Replay 安全**:guard 写入复用 `fsm.transition` 的直接 `uuidv4()/Date.now()` 路径,**零新增 IOPort 调用** → 回放缓存序列不变。`Replay.test.ts` 以"录制两次(带/不带 guard)、断言 IOPort 事件序列一致"验证。
- **已知边界(诚实声明)**:完备性依赖工具 opt-in;emit 驱动 FSM 的 `replay()` 是 milkie 既有限制(非本 PR 引入,值得单开 issue)。详见 spec §7。
- 设计与计划:`docs/superpowers/specs/2026-05-30-fsm-guard-trace-design.md`、`docs/superpowers/plans/2026-05-30-fsm-guard-trace.md`

## Test Plan

- [x] 全量单测:45 套件 / 426 通过 / 16 skip(s-011 live,需 token)
- [x] `tsc` 构建干净
- [x] 捕获(present + absent)、IOPort 零扰动、渲染(带/不带 guard)、s-011 接线均有测试
- [ ] (可选)live e2e:`VOLCENGINE_TOKEN` + `REDIS_E2E_REQUIRED=1` 下验证 s-011 guard 断言

🤖 Generated with [Claude Code](https://claude.com/claude-code)