### PR TITLE
feat(#33): why-this-transition explainer (pure event-log projection)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-why-this-transition.md
+++ b/docs/superpowers/plans/2026-05-30-why-this-transition.md
@@ -1,0 +1,547 @@
+# why-this-transition explainer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 点 trace 报告里的 `fsm.transition` 能读懂"为什么这次跳转"——纯 event-log 投影出触发事件 + guard + 因果链,并能一键跳到上游事件。
+
+**Architecture:** 新建 `src/trace/diagnostics/`(#36 CLI 也将复用):`walkCausedBy`(沿 causedBy 上溯)+ `summarizeEvent`(事件→人类标签)+ `explainTransition`(核心投影,返回普通可序列化对象)。HTML 渲染层(`html.ts`)给 fsm 条目加可读 "Why?" 块,给所有事件条目加 `id="ev-<eventId>"` 锚点。零 LLM、零存储、零事件 schema 变更。
+
+**Tech Stack:** TypeScript;Jest(`npx jest <file>`);现有 `src/trace/render/html.ts`、`Event`/`FsmTransitionPayload`/`GuardEvaluation`/`EventKind`/`FsmEventDomain` 类型。
+
+参考 spec:`docs/superpowers/specs/2026-05-30-why-this-transition-design.md`
+
+**测试运行器是 JEST**(不是 vitest)。
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `src/trace/diagnostics/walkCausedBy.ts` | 沿 causedBy 上溯遍历(通用) | 新建 |
+| `src/trace/diagnostics/summarizeEvent.ts` | 事件 → 人类可读标签 | 新建 |
+| `src/trace/diagnostics/explainTransition.ts` | 核心投影 + `TransitionExplanation` 类型 | 新建 |
+| `src/trace/render/html.ts` | fsm 条目 "Why?" 块 + 事件锚点 id | 修改 |
+| `src/__tests__/walkCausedBy.test.ts` | 单测 | 新建 |
+| `src/__tests__/summarizeEvent.test.ts` | 单测 | 新建 |
+| `src/__tests__/explainTransition.test.ts` | 单测 | 新建 |
+| `src/__tests__/render-html.test.ts` | "Why?" + 锚点断言 | 修改 |
+
+> 测试用**手工构造的 `Event[]`**(纯投影函数,合成输入比跑 runtime 更聚焦、确定性更强,且天然满足"无 LLM 调用")。
+
+---
+
+## Task 1: walkCausedBy — 沿 causedBy 上溯
+
+**Files:**
+- Create: `src/trace/diagnostics/walkCausedBy.ts`
+- Test: `src/__tests__/walkCausedBy.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { walkCausedBy } from '../trace/diagnostics/walkCausedBy'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload: {}, ...(causedBy ? { causedBy } : {}) })
+
+describe('walkCausedBy', () => {
+  it('walks the causedBy chain from an event up to the root', () => {
+    const events: Event[] = [
+      ev('start', 'agent.run.started'),
+      ev('llm1', 'llm.responded', 'start'),
+      ev('treq', 'tool.requested', 'llm1'),
+      ev('tres', 'tool.responded', 'treq'),
+      ev('fsm', 'fsm.transition', 'tres'),
+    ]
+    const chain = walkCausedBy(events, 'fsm')
+    expect(chain.map(e => e.id)).toEqual(['fsm', 'tres', 'treq', 'llm1', 'start'])
+  })
+
+  it('stops gracefully when a causedBy points to a missing event', () => {
+    const events: Event[] = [ev('fsm', 'fsm.transition', 'gone')]
+    const chain = walkCausedBy(events, 'fsm')
+    expect(chain.map(e => e.id)).toEqual(['fsm'])
+  })
+
+  it('does not loop forever on a cycle', () => {
+    const events: Event[] = [ev('a', 'x', 'b'), ev('b', 'x', 'a')]
+    const chain = walkCausedBy(events, 'a')
+    expect(chain.map(e => e.id)).toEqual(['a', 'b'])  // stops when 'a' seen again
+  })
+
+  it('returns empty when the start id is unknown', () => {
+    expect(walkCausedBy([], 'nope')).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/walkCausedBy.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event } from '../types.js'
+
+/**
+ * Walk the causedBy chain upstream from `startId`, nearest-first, until an
+ * event has no causedBy, its causedBy points outside `events`, or a cycle is
+ * detected. Pure: reads only the provided events. Reusable by #32/#36.
+ */
+export function walkCausedBy(events: Event[], startId: string): Event[] {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const chain: Event[] = []
+  const seen = new Set<string>()
+  let current = byId.get(startId)
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    chain.push(current)
+    current = current.causedBy ? byId.get(current.causedBy) : undefined
+  }
+  return chain
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/walkCausedBy.test.ts`
+Expected: PASS（4 用例）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/walkCausedBy.ts src/__tests__/walkCausedBy.test.ts
+git commit -m "feat(#33): walkCausedBy — upstream causal chain traversal"
+```
+
+---
+
+## Task 2: summarizeEvent — 事件 → 人类标签
+
+**Files:**
+- Create: `src/trace/diagnostics/summarizeEvent.ts`
+- Test: `src/__tests__/summarizeEvent.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { summarizeEvent } from '../trace/diagnostics/summarizeEvent'
+import type { Event } from '../trace/types'
+
+const ev = (type: string, payload: unknown): Event =>
+  ({ id: 'x', runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+
+describe('summarizeEvent', () => {
+  it('labels tool events with the tool name', () => {
+    expect(summarizeEvent(ev('tool.responded', { toolName: 'classify_intent', output: {} })))
+      .toBe('tool.responded(classify_intent)')
+    expect(summarizeEvent(ev('tool.requested', { toolName: 'search', input: {} })))
+      .toBe('tool.requested(search)')
+  })
+
+  it('falls back to the bare type for events without a tool name', () => {
+    expect(summarizeEvent(ev('llm.responded', {}))).toBe('llm.responded')
+    expect(summarizeEvent(ev('agent.run.started', { agentId: 'x' }))).toBe('agent.run.started')
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/summarizeEvent.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event } from '../types.js'
+
+/**
+ * Human-readable one-line label for an event. Shared by the HTML "Why?" block
+ * and (future) the CLI explainer (#36), so both speak the same language.
+ */
+export function summarizeEvent(event: Event): string {
+  const p = event.payload as { toolName?: unknown }
+  if ((event.type === 'tool.requested' || event.type === 'tool.responded')
+      && typeof p?.toolName === 'string') {
+    return `${event.type}(${p.toolName})`
+  }
+  return event.type
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/summarizeEvent.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/summarizeEvent.ts src/__tests__/summarizeEvent.test.ts
+git commit -m "feat(#33): summarizeEvent — human-readable event label"
+```
+
+---
+
+## Task 3: explainTransition — 核心投影
+
+**Files:**
+- Create: `src/trace/diagnostics/explainTransition.ts`
+- Test: `src/__tests__/explainTransition.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { explainTransition } from '../trace/diagnostics/explainTransition'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+
+function routingEvents(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }),
+    ev('llm1', 'llm.responded', {}, 'start'),
+    ev('treq', 'tool.requested', { toolName: 'classify_intent', input: {} }, 'llm1'),
+    ev('tres', 'tool.responded', { toolName: 'classify_intent', output: {} }, 'treq'),
+    ev('fsm', 'fsm.transition', {
+      from: 'classify', to: 'handle_b',
+      trigger: { domain: 'business', name: 'INTENT_B' },
+      guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9, threshold: 0.75 } }],
+    }, 'tres'),
+  ]
+}
+
+describe('explainTransition', () => {
+  it('projects a readable explanation from the event log (no LLM)', () => {
+    const exp = explainTransition(routingEvents(), 'fsm')
+    expect(exp.from).toBe('classify')
+    expect(exp.to).toBe('handle_b')
+    expect(exp.trigger.name).toBe('INTENT_B')
+    expect(exp.trigger.causedByEventId).toBe('tres')
+    expect(exp.trigger.causedBySummary).toBe('tool.responded(classify_intent)')
+    expect(exp.guards).toEqual([{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9, threshold: 0.75 } }])
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['fsm', 'tres', 'treq', 'llm1', 'start'])
+    expect(exp.summary).toContain('classify → handle_b')
+    expect(exp.summary).toContain('INTENT_B')
+    expect(exp.summary).toContain('intent-threshold')
+  })
+
+  it('every causalChain eventId resolves to a real event', () => {
+    const events = routingEvents()
+    const ids = new Set(events.map(e => e.id))
+    const exp = explainTransition(events, 'fsm')
+    for (const c of exp.causalChain) expect(ids.has(c.eventId)).toBe(true)
+  })
+
+  it('omits guards when the transition carries none', () => {
+    const events: Event[] = [
+      ev('start', 'agent.run.started', {}),
+      ev('fsm', 'fsm.transition', { from: 's0', to: 'end', trigger: { domain: 'lifecycle', name: 'DONE' } }, 'start'),
+    ]
+    const exp = explainTransition(events, 'fsm')
+    expect(exp.guards).toEqual([])
+    expect(exp.summary).toContain('s0 → end')
+  })
+
+  it('throws on a non-fsm.transition event id', () => {
+    expect(() => explainTransition(routingEvents(), 'llm1')).toThrow(/fsm\.transition/)
+  })
+
+  it('throws on an unknown event id', () => {
+    expect(() => explainTransition(routingEvents(), 'nope')).toThrow(/nope/)
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/explainTransition.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event, EventKind, FsmEventDomain, FsmTransitionPayload, GuardEvaluation } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+
+export interface TransitionExplanation {
+  transitionEventId: string
+  from: string
+  to:   string
+  trigger: {
+    name:             string
+    domain:           FsmEventDomain
+    causedByEventId?: string
+    causedBySummary?: string
+  }
+  guards: GuardEvaluation[]
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure event-log projection: explain why a given fsm.transition fired.
+ * Reads only `events` — no LLM, no I/O, no stored snapshot. Returns a plain
+ * serializable object (also the JSON shape the CLI explainer #36 will emit).
+ */
+export function explainTransition(events: Event[], transitionEventId: string): TransitionExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(transitionEventId)
+  if (!evt) throw new Error(`explainTransition: unknown event id "${transitionEventId}"`)
+  if (evt.type !== 'fsm.transition') {
+    throw new Error(`explainTransition: event "${transitionEventId}" is "${evt.type}", expected "fsm.transition"`)
+  }
+
+  const p = evt.payload as FsmTransitionPayload
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const guards = p.guardEvaluations ?? []
+
+  const causalChain = walkCausedBy(events, transitionEventId).map(e => ({
+    eventId: e.id,
+    type:    e.type,
+    summary: summarizeEvent(e),
+  }))
+
+  const guardPart = guards.length
+    ? `;guard ${guards.map(g => `${g.guardId} 判定 ${String(g.result)}`).join('、')}`
+    : ''
+  const triggerSource = causeEvt ? summarizeEvent(causeEvt) : '(无上游记录)'
+  const summary = `${p.from} → ${p.to}:由 ${triggerSource} 发出的 ${p.trigger.name} 触发${guardPart}`
+
+  return {
+    transitionEventId,
+    from: p.from,
+    to:   p.to,
+    trigger: {
+      name:   p.trigger.name,
+      domain: p.trigger.domain,
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeEvt ? { causedBySummary: summarizeEvent(causeEvt) } : {}),
+    },
+    guards,
+    causalChain,
+    summary,
+  }
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/explainTransition.test.ts`
+Expected: PASS（5 用例）。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/explainTransition.ts src/__tests__/explainTransition.test.ts
+git commit -m "feat(#33): explainTransition — pure event-log projection of why-this-transition"
+```
+
+---
+
+## Task 4: HTML "Why?" 渲染 + 事件锚点
+
+**Files:**
+- Modify: `src/trace/render/html.ts`
+- Test: `src/__tests__/render-html.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`src/__tests__/render-html.test.ts`,复用文件已有的 `e({...})` 助手与 `renderHtml`/`Event` 导入)
+
+```ts
+it('renders a Why? block on fsm.transition with anchor links to upstream events', () => {
+  const events: Event[] = [
+    e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+        payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 2, causedBy: 'start',
+        payload: { toolName: 'classify_intent', input: {}, requestHash: 'h' } }),
+    e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 3, causedBy: 'treq',
+        payload: { toolName: 'classify_intent', output: {}, requestHash: 'h' } }),
+    e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 4, causedBy: 'tres',
+        payload: { from: 'classify', to: 'handle_b', trigger: { domain: 'business', name: 'INTENT_B' },
+          guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9 } }] } }),
+  ]
+  const html = renderHtml(events)
+  // readable Why summary present
+  expect(html).toContain('class="why"')
+  expect(html).toContain('classify → handle_b')
+  expect(html).toContain('intent-threshold')
+  // a jump link to the upstream tool.responded, and that target id exists
+  expect(html).toContain('href="#ev-tres"')
+  expect(html).toContain('id="ev-tres"')
+})
+
+it('renders a Why? block for an fsm.transition without guards', () => {
+  const events: Event[] = [
+    e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+        payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 2, causedBy: 'start',
+        payload: { from: 's0', to: 'end', trigger: { domain: 'lifecycle', name: 'DONE' } } }),
+  ]
+  const html = renderHtml(events)
+  expect(html).toContain('class="why"')
+  expect(html).toContain('s0 → end')
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/render-html.test.ts -t "Why?"`
+Expected: FAIL（无 `class="why"` / 无 `id="ev-..."`）。
+
+- [ ] **Step 3: 改 html.ts — 锚点 id**
+
+在 `src/trace/render/html.ts` 顶部 import 处加:
+
+```ts
+import { explainTransition, type TransitionExplanation } from '../diagnostics/explainTransition.js'
+```
+
+新增一个助手(放在 `renderEntry` 之前):返回某条目覆盖的所有事件 id(合并条目覆盖 requested+responded 两个 id):
+
+```ts
+function entryEventIds(entry: TimelineEntry): string[] {
+  if (entry.kind === 'llm' || entry.kind === 'tool') {
+    return entry.respondedId ? [entry.requestedId, entry.respondedId] : [entry.requestedId]
+  }
+  return [entry.eventId]
+}
+```
+
+- [ ] **Step 4: 改 html.ts — Why? 块渲染**
+
+新增 Why 块助手(放在 `renderEntry` 之前):
+
+```ts
+function renderWhy(exp: TransitionExplanation): string {
+  const trigger = exp.trigger.causedByEventId
+    ? `<div class="why-trigger">触发: <a href="#ev-${esc(exp.trigger.causedByEventId)}">${esc(exp.trigger.causedBySummary ?? exp.trigger.causedByEventId)}</a></div>`
+    : ''
+  const guards = exp.guards.length
+    ? `<div class="why-guards">guard: ${esc(exp.guards.map(g => `${g.guardId}=${String(g.result)}`).join(', '))}</div>`
+    : ''
+  const chain = `<div class="why-chain">`
+    + exp.causalChain.map(c => `<a href="#ev-${esc(c.eventId)}">${esc(c.summary)}</a>`).join(' → ')
+    + `</div>`
+  return `<div class="why">`
+       + `<div class="why-summary">${esc(exp.summary)}</div>`
+       + trigger + guards + chain
+       + `</div>`
+}
+```
+
+- [ ] **Step 5: 改 html.ts — renderEntry 接入锚点 + Why 块**
+
+`renderEntry` 改签名,接收 `explanations` map,渲染锚点 id 与(fsm 条目的)Why 块:
+
+```ts
+function renderEntry(
+  entry: TimelineEntry,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+): string {
+  const icon = entry.kind === 'llm' ? '◆'
+             : entry.kind === 'tool' ? '▣'
+             : entry.kind === 'region'
+               ? (entry.eventType === 'context.boundary.applied' ? '⌖'
+                 : entry.eventType === 'region.added' ? '＋' : '－')
+             : entry.kind === 'fsm' ? '⇒'
+             : '●'
+  const ids = entryEventIds(entry)
+  const primaryId = ids[0]!
+  const extraAnchors = ids.slice(1).map(id => `<span class="anchor" id="ev-${esc(id)}"></span>`).join('')
+  const why = entry.kind === 'fsm' && explanations.has(entry.eventId)
+    ? renderWhy(explanations.get(entry.eventId)!)
+    : ''
+  return `<div class="entry ${entry.kind}" data-kind="${entry.kind}" id="ev-${esc(primaryId)}">`
+       + extraAnchors
+       + `<div class="entry-head">`
+       + `<span class="icon">${icon}</span>`
+       + `<span class="summary">${summaryFor(entry)}</span>`
+       + `<span class="ts">${entry.timestamp}</span>`
+       + `</div>`
+       + why
+       + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
+       + `</div>`
+}
+```
+
+`renderNode` 把 `explanations` 透传给 `renderEntry`:
+
+```ts
+function renderNode(
+  node: TimelineNode,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+): string {
+  const status = node.status ?? 'in-flight'
+  const badgeClass = BADGE_STATUS_CLASSES.has(status) ? ' ' + status : ''
+  return `<section class="run" data-run-id="${esc(node.runId)}">`
+       + `<div class="run-head">`
+       + `<strong>${esc(node.agentId ?? '(unknown)')}</strong>`
+       + `<span class="run-id">${esc(node.runId)}</span>`
+       + `<span class="badge${badgeClass}">${esc(status)}</span>`
+       + `</div>`
+       + node.entries.map(en => renderEntry(en, eventById, explanations)).join('')
+       + (node.children.length > 0
+           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById, explanations)).join('')}</div>`
+           : '')
+       + `</section>`
+}
+```
+
+- [ ] **Step 6: 改 html.ts — renderHtml 预算解释并下传**
+
+在 `renderHtml` 里,`eventById` 构建后、`return` 之前加:
+
+```ts
+const explanations = new Map<string, TransitionExplanation>()
+for (const evt of events) {
+  if (evt.type === 'fsm.transition') explanations.set(evt.id, explainTransition(events, evt.id))
+}
+```
+
+并把 `tree.map(n => renderNode(n, eventById)).join('')` 改为 `tree.map(n => renderNode(n, eventById, explanations)).join('')`。
+
+- [ ] **Step 7: 运行,确认通过**
+
+Run: `npx jest src/__tests__/render-html.test.ts && npx jest src/__tests__/render-tree.test.ts`
+Expected: PASS（含原有用例,无回归)。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add src/trace/render/html.ts src/__tests__/render-html.test.ts
+git commit -m "feat(#33): HTML Why? block on fsm.transition + event anchors for jump links"
+```
+
+---
+
+## 收尾
+
+- [ ] **全量测试 + 构建**
+
+Run: `npx jest && npm run build`
+Expected: 全绿。
+
+- [ ] **开 PR**:body 带 `Closes #33`,引用 spec 与本 plan;说明 region 部分按设计暂缓(等 #26),CLINK 投影(`walkCausedBy`/`explainTransition`)已为 #36 CLI 备好。
+
+---
+
+## Self-Review(plan 作者已核对)
+
+**Spec 覆盖:** §4.1 walkCausedBy → Task 1 ✓ §4.2 explainTransition + summarizeEvent → Task 2/3 ✓ §5 HTML Why? + 锚点 → Task 4 ✓ §6 错误处理 → Task 3 抛错用例 + walkCausedBy 断链/环用例 ✓ §7 测试 → 各任务测试 ✓ §9 验收(可读解释/无 LLM/跳转链接/纯 event-log)→ Task 3+4 ✓。region 按 Non-goals 不做 ✓。
+
+**占位扫描:** 无 TBD/TODO;每个改代码步骤含完整代码。
+
+**类型一致性:** `TransitionExplanation`(Task 3 定义)字段 `from/to/trigger.{name,domain,causedByEventId,causedBySummary}/guards/causalChain/summary` 在 Task 4 `renderWhy` 中引用一致;`walkCausedBy(events, id)`(Task 1)签名在 Task 3 调用一致;`summarizeEvent(event)`(Task 2)在 Task 3 调用一致;`GuardEvaluation`/`Event`/`EventKind`/`FsmEventDomain`/`FsmTransitionPayload` 均取自 `src/trace/types`。

--- a/docs/superpowers/specs/2026-05-30-why-this-transition-design.md
+++ b/docs/superpowers/specs/2026-05-30-why-this-transition-design.md
@@ -1,0 +1,116 @@
+# #33 why-this-transition explainer — 设计 spec
+
+**Issue:** #33（diagnosable P1;依赖 #21/#30/#31 已落地;Stories s-003 / s-011）
+**日期:** 2026-05-30
+**定位:** 把 diagnosable 做出可见效果——点 `fsm.transition` 能读懂"为什么这次跳转"。**纯 event-log 投影,零 LLM、零存储。**
+
+---
+
+## 1. 目标与范围
+
+今天点 trace 里的 transition 什么解释都没有,s-003「explain a decision」无交付物。本 issue:
+- 抽一个**共享投影函数** `explainTransition(events, eventId)`,把"为什么这次跳转"从 event log 折叠成结构化解释;
+- 在静态 HTML 报告的 `fsm.transition` 条目上加**可读的 "Why?" 展开**(摘要 + 触发事件 + guard + 因果链),并能**一键跳到上游事件**。
+
+**交付面**(已与用户确认):增强现有静态 HTML 报告 + 抽共享投影(给 #36 CLI 复用),**不**新建 playground/web app。
+
+## 2. Non-goals(明确不做)
+
+- **不做 region**:`region.added` 无 transition 标记、#26 region-link 未完成。本 issue 只交付 trigger + guard + 因果链;region 关联等 #26 落地再补。
+- **不调 LLM**:`summary` 是模板拼接的确定性字符串。
+- **零存储**:不新增事件类型、不写快照/缓存、不改任何事件 schema。每次现算(见 §4)。
+- **不做 CLI**:`trace why/explain/path` 是 #36;本 issue 只提供它要复用的投影函数(返回可序列化对象)。
+- **不做其它投影**:`explainLlmCall` / `failurePath`(#34/#35/#36)不在本 issue。
+
+## 3. 数据齐备性(全部来自已落地的存储)
+
+| 解释要素 | 来源字段 | 谁存的 |
+|---|---|---|
+| from / to / trigger.name / domain | `fsm.transition` payload | #21 |
+| guard 评估 | `fsm.transition` payload `.guardEvaluations` | **#31** |
+| 触发它的上游事件 | `fsm.transition` 的 `causedBy` | **#30** |
+| 因果链 | 沿 `causedBy` 遍历 Event[] | 现算 |
+
+`fsm.transition` 事件结构**一字段不加**——#33 只读。
+
+## 4. 架构:`src/trace/diagnostics/`(#36 也复用的共享投影之家)
+
+两个纯函数,只吃内存里的 `Event[]`(由调用方 `eventStore.readByRunId(runId)` 读出),**不做任何 I/O、不写任何东西**。符合 ARCHITECTURE.md「event-sourced view:从 append-only log 折叠,不作 canonical 存储」。
+
+### 4.1 `walkCausedBy(events, eventId): Event[]`
+
+- 文件:`src/trace/diagnostics/walkCausedBy.ts`
+- 从 `eventId` 沿 `causedBy` 上溯,返回 `[该事件, 其 cause, …, agent.run.started]`(含端点,顺序由近到远)。
+- **断链/缺失**:若某事件的 `causedBy` 指向的 id 不在 `events` 里(或无 `causedBy`),在该点优雅停止,返回已收集的链,不抛错。
+- **环防护**:用 `Set<eventId>` 去重,遇已访问 id 即停(防御性,正常不会成环)。
+- 通用:#32(causedBy 可视化)/#36(`trace path`)亦可复用。
+
+### 4.2 `explainTransition(events, transitionEventId): TransitionExplanation`
+
+- 文件:`src/trace/diagnostics/explainTransition.ts`
+- 输出(普通可序列化对象,既是 UI 渲染源,也是 #36 CLI 的 JSON 输出源):
+
+```ts
+export interface TransitionExplanation {
+  transitionEventId: string
+  from: string
+  to:   string
+  trigger: {
+    name:            string                    // 'INTENT_B' / 'DONE' / 'interrupt'
+    domain:          FsmEventDomain
+    causedByEventId?: string                   // 发出它的 tool.responded/llm.responded(= 事件的 causedBy)
+    causedBySummary?: string                   // 'tool.responded(classify_intent)' 之类的人类标签
+  }
+  guards: GuardEvaluation[]                     // 直接取自 payload.guardEvaluations(无则空数组)
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>  // 由 walkCausedBy 投影
+  summary: string                               // 模板拼接的可读一句话,无 LLM
+}
+```
+
+- **行为**:
+  - 找到 id 对应事件;若不存在或 `type !== 'fsm.transition'` → 抛 `Error`(#36 CLI 据此非零退出;UI 只对 fsm 条目调用,安全)。
+  - `from/to/trigger.{name,domain}` 取自 payload;`trigger.causedByEventId` = 该事件 `causedBy`;`causedBySummary` 由那条上游事件经 `summarizeEvent` 生成。
+  - `guards` = `payload.guardEvaluations ?? []`。
+  - `causalChain` = `walkCausedBy(events, transitionEventId).map(e => ({ eventId, type, summary: summarizeEvent(e) }))`。
+  - `summary` 模板(纯数据,示例):
+    `"{from} → {to}:由 {causedBySummary} 发出的 {trigger.name} 触发"` +(若有 guard)`";guard {g.guardId} 判定 {g.result}({contextSlice 紧凑串})"`。
+- 复用一个小工具 `summarizeEvent(e): string`(`src/trace/diagnostics/summarizeEvent.ts`),把事件转人类标签(如 `llm.responded`、`tool.responded(classify_intent)`、`agent.run.started`)。渲染层与 CLI 共用,避免两处各写一套。
+
+## 5. HTML "Why?" 渲染(`src/trace/render/`)
+
+- 对 `kind:'fsm'` 条目,在现有可展开 JSON 之外,增加一个**人类可读的 "Why?" 块**,内容由 `explainTransition` 投影而来:摘要、触发(带跳转链接)、guard 列表、因果链(每跳一个链接)。
+- **事件锚点**:为支持"一键跳上游",渲染每个事件条目时加 `id="ev-<eventId>"`;"Why?" 里的链接用 `href="#ev-<eventId>"`。这是纯加属性,不改现有点击展开行为。
+- 不带 guard 的 transition 也正常渲染(无 guard 行)。
+- 渲染层调用 `explainTransition(allEvents, entry.eventId)`;`renderHtml` 已持有全部 `Event[]`,直接传入。
+
+## 6. 错误处理
+
+- `explainTransition`:未知 id / 非 transition → 抛 `Error`(消息含 eventId 与实际 type)。
+- `walkCausedBy`:断链或缺失 cause → 优雅停止;成环 → Set 去重即停。
+- 渲染层只对 `kind:'fsm'` 调用,故不触发上面的抛错路径。
+
+## 7. 测试
+
+- **`walkCausedBy`**:① 正常链走到 `agent.run.started`;② `causedBy` 指向不存在 id → 在该点停、返回部分链;③ 人造环 → 不死循环。
+- **`explainTransition`**:用真实运行(routing FSM:`classify`→tool emit `INTENT_*`)产出的事件,断言 `from/to/trigger.name/causedByEventId/guards` 正确、`causalChain` 每个 `eventId` 都能在 events 里找到、`summary` 含关键字段;断言**全程无 gateway/LLM 调用**(用已录制事件,不跑 live)。③ 非 fsm.transition id → 抛错。
+- **渲染**:fsm 条目 HTML 含 "Why?" 块、摘要文本、`href="#ev-..."` 锚点链接、对应 `id="ev-..."` 存在;不带 guard 的转移也出 "Why?"(无 guard 行)。
+
+## 8. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/diagnostics/walkCausedBy.ts` | 新建:causedBy 上溯遍历 |
+| `src/trace/diagnostics/summarizeEvent.ts` | 新建:事件 → 人类标签 |
+| `src/trace/diagnostics/explainTransition.ts` | 新建:核心投影 + `TransitionExplanation` 类型(与函数同文件,它是投影结果、非事件 payload) |
+| `src/trace/render/html.ts` | fsm 条目渲染 "Why?" 块(调 `explainTransition`,`renderHtml` 已持有全部 events);`renderEntry` 给每个事件条目加 `id="ev-..."` 锚点。`tree.ts` 不动 |
+| `src/__tests__/walkCausedBy.test.ts` | 新建 |
+| `src/__tests__/explainTransition.test.ts` | 新建 |
+| `src/__tests__/render-*.test.ts` | 加 "Why?" 渲染 + 锚点断言 |
+
+## 9. 验收对照(#33)
+
+- [x] ReAct/routing 的每次 transition 点 "Why?" 都给可读解释 → `explainTransition` + HTML 块
+- [x] 解释生成不调用 LLM → 纯模板投影(测试断言无 gateway 调用)
+- [x] 解释链接可一键跳上游事件 → 事件锚点 `id="ev-..."` + `href="#ev-..."`
+- [x] 只用 event log、不依赖运行时副本 → 函数只吃 `Event[]`、零存储
+- 备注:region 部分按 Non-goals 暂缓(等 #26)

--- a/src/__tests__/explainTransition.test.ts
+++ b/src/__tests__/explainTransition.test.ts
@@ -1,0 +1,60 @@
+import { explainTransition } from '../trace/diagnostics/explainTransition'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+
+function routingEvents(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }),
+    ev('llm1', 'llm.responded', {}, 'start'),
+    ev('treq', 'tool.requested', { toolName: 'classify_intent', input: {} }, 'llm1'),
+    ev('tres', 'tool.responded', { toolName: 'classify_intent', output: {} }, 'treq'),
+    ev('fsm', 'fsm.transition', {
+      from: 'classify', to: 'handle_b',
+      trigger: { domain: 'business', name: 'INTENT_B' },
+      guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9, threshold: 0.75 } }],
+    }, 'tres'),
+  ]
+}
+
+describe('explainTransition', () => {
+  it('projects a readable explanation from the event log (no LLM)', () => {
+    const exp = explainTransition(routingEvents(), 'fsm')
+    expect(exp.from).toBe('classify')
+    expect(exp.to).toBe('handle_b')
+    expect(exp.trigger.name).toBe('INTENT_B')
+    expect(exp.trigger.causedByEventId).toBe('tres')
+    expect(exp.trigger.causedBySummary).toBe('tool.responded(classify_intent)')
+    expect(exp.guards).toEqual([{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9, threshold: 0.75 } }])
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['fsm', 'tres', 'treq', 'llm1', 'start'])
+    expect(exp.summary).toContain('classify → handle_b')
+    expect(exp.summary).toContain('INTENT_B')
+    expect(exp.summary).toContain('intent-threshold')
+  })
+
+  it('every causalChain eventId resolves to a real event', () => {
+    const events = routingEvents()
+    const ids = new Set(events.map(e => e.id))
+    const exp = explainTransition(events, 'fsm')
+    for (const c of exp.causalChain) expect(ids.has(c.eventId)).toBe(true)
+  })
+
+  it('omits guards when the transition carries none', () => {
+    const events: Event[] = [
+      ev('start', 'agent.run.started', {}),
+      ev('fsm', 'fsm.transition', { from: 's0', to: 'end', trigger: { domain: 'lifecycle', name: 'DONE' } }, 'start'),
+    ]
+    const exp = explainTransition(events, 'fsm')
+    expect(exp.guards).toEqual([])
+    expect(exp.summary).toContain('s0 → end')
+  })
+
+  it('throws on a non-fsm.transition event id', () => {
+    expect(() => explainTransition(routingEvents(), 'llm1')).toThrow(/fsm\.transition/)
+  })
+
+  it('throws on an unknown event id', () => {
+    expect(() => explainTransition(routingEvents(), 'nope')).toThrow(/nope/)
+  })
+})

--- a/src/__tests__/explainTransition.test.ts
+++ b/src/__tests__/explainTransition.test.ts
@@ -57,4 +57,15 @@ describe('explainTransition', () => {
   it('throws on an unknown event id', () => {
     expect(() => explainTransition(routingEvents(), 'nope')).toThrow(/nope/)
   })
+
+  it('handles a dangling causedBy: keeps causedByEventId, omits causedBySummary, falls back in summary', () => {
+    const events: Event[] = [
+      ev('fsm', 'fsm.transition', { from: 'a', to: 'b', trigger: { domain: 'business', name: 'GO' } }, 'missing'),
+    ]
+    const exp = explainTransition(events, 'fsm')
+    expect(exp.trigger.causedByEventId).toBe('missing')
+    expect(exp.trigger.causedBySummary).toBeUndefined()
+    expect(exp.summary).toContain('(无上游记录)')
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['fsm'])  // walkCausedBy stops at the dangling ref
+  })
 })

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -135,4 +135,12 @@ describe('renderHtml', () => {
     expect(html).toContain('class="why"')
     expect(html).toContain('s0 → end')
   })
+
+  it('includes Why-block styling', () => {
+    const html = renderHtml([
+      e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    ])
+    expect(html).toContain('.why {')
+  })
 })

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -103,4 +103,36 @@ describe('renderHtml', () => {
     expect(html).toContain('intent-threshold')
     expect(html).toContain('data-kind="fsm"')
   })
+
+  it('renders a Why? block on fsm.transition with anchor links to upstream events', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 2, causedBy: 'start',
+          payload: { toolName: 'classify_intent', input: {}, requestHash: 'h' } }),
+      e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 3, causedBy: 'treq',
+          payload: { toolName: 'classify_intent', output: {}, requestHash: 'h' } }),
+      e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 4, causedBy: 'tres',
+          payload: { from: 'classify', to: 'handle_b', trigger: { domain: 'business', name: 'INTENT_B' },
+            guardEvaluations: [{ guardId: 'intent-threshold', result: 'INTENT_B', contextSlice: { confidence: 0.9 } }] } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('classify → handle_b')
+    expect(html).toContain('intent-threshold')
+    expect(html).toContain('href="#ev-tres"')
+    expect(html).toContain('id="ev-tres"')
+  })
+
+  it('renders a Why? block for an fsm.transition without guards', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 2, causedBy: 'start',
+          payload: { from: 's0', to: 'end', trigger: { domain: 'lifecycle', name: 'DONE' } } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('s0 → end')
+  })
 })

--- a/src/__tests__/summarizeEvent.test.ts
+++ b/src/__tests__/summarizeEvent.test.ts
@@ -1,0 +1,19 @@
+import { summarizeEvent } from '../trace/diagnostics/summarizeEvent'
+import type { Event } from '../trace/types'
+
+const ev = (type: string, payload: unknown): Event =>
+  ({ id: 'x', runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+
+describe('summarizeEvent', () => {
+  it('labels tool events with the tool name', () => {
+    expect(summarizeEvent(ev('tool.responded', { toolName: 'classify_intent', output: {} })))
+      .toBe('tool.responded(classify_intent)')
+    expect(summarizeEvent(ev('tool.requested', { toolName: 'search', input: {} })))
+      .toBe('tool.requested(search)')
+  })
+
+  it('falls back to the bare type for events without a tool name', () => {
+    expect(summarizeEvent(ev('llm.responded', {}))).toBe('llm.responded')
+    expect(summarizeEvent(ev('agent.run.started', { agentId: 'x' }))).toBe('agent.run.started')
+  })
+})

--- a/src/__tests__/walkCausedBy.test.ts
+++ b/src/__tests__/walkCausedBy.test.ts
@@ -1,0 +1,35 @@
+import { walkCausedBy } from '../trace/diagnostics/walkCausedBy'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload: {}, ...(causedBy ? { causedBy } : {}) })
+
+describe('walkCausedBy', () => {
+  it('walks the causedBy chain from an event up to the root', () => {
+    const events: Event[] = [
+      ev('start', 'agent.run.started'),
+      ev('llm1', 'llm.responded', 'start'),
+      ev('treq', 'tool.requested', 'llm1'),
+      ev('tres', 'tool.responded', 'treq'),
+      ev('fsm', 'fsm.transition', 'tres'),
+    ]
+    const chain = walkCausedBy(events, 'fsm')
+    expect(chain.map(e => e.id)).toEqual(['fsm', 'tres', 'treq', 'llm1', 'start'])
+  })
+
+  it('stops gracefully when a causedBy points to a missing event', () => {
+    const events: Event[] = [ev('fsm', 'fsm.transition', 'gone')]
+    const chain = walkCausedBy(events, 'fsm')
+    expect(chain.map(e => e.id)).toEqual(['fsm'])
+  })
+
+  it('does not loop forever on a cycle', () => {
+    const events: Event[] = [ev('a', 'x', 'b'), ev('b', 'x', 'a')]
+    const chain = walkCausedBy(events, 'a')
+    expect(chain.map(e => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('returns empty when the start id is unknown', () => {
+    expect(walkCausedBy([], 'nope')).toEqual([])
+  })
+})

--- a/src/trace/diagnostics/explainTransition.ts
+++ b/src/trace/diagnostics/explainTransition.ts
@@ -34,6 +34,7 @@ export function explainTransition(events: Event[], transitionEventId: string): T
 
   const p = evt.payload as FsmTransitionPayload
   const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const causeSummary = causeEvt ? summarizeEvent(causeEvt) : undefined
   const guards = p.guardEvaluations ?? []
 
   const causalChain = walkCausedBy(events, transitionEventId).map(e => ({
@@ -45,7 +46,7 @@ export function explainTransition(events: Event[], transitionEventId: string): T
   const guardPart = guards.length
     ? `;guard ${guards.map(g => `${g.guardId} 判定 ${String(g.result)}`).join('、')}`
     : ''
-  const triggerSource = causeEvt ? summarizeEvent(causeEvt) : '(无上游记录)'
+  const triggerSource = causeSummary ?? '(无上游记录)'
   const summary = `${p.from} → ${p.to}:由 ${triggerSource} 发出的 ${p.trigger.name} 触发${guardPart}`
 
   return {
@@ -56,7 +57,7 @@ export function explainTransition(events: Event[], transitionEventId: string): T
       name:   p.trigger.name,
       domain: p.trigger.domain,
       ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
-      ...(causeEvt ? { causedBySummary: summarizeEvent(causeEvt) } : {}),
+      ...(causeSummary ? { causedBySummary: causeSummary } : {}),
     },
     guards,
     causalChain,

--- a/src/trace/diagnostics/explainTransition.ts
+++ b/src/trace/diagnostics/explainTransition.ts
@@ -1,0 +1,65 @@
+import type { Event, EventKind, FsmEventDomain, FsmTransitionPayload, GuardEvaluation } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+
+export interface TransitionExplanation {
+  transitionEventId: string
+  from: string
+  to:   string
+  trigger: {
+    name:             string
+    domain:           FsmEventDomain
+    causedByEventId?: string
+    causedBySummary?: string
+  }
+  guards: GuardEvaluation[]
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure event-log projection: explain why a given fsm.transition fired.
+ * Reads only `events` — no LLM, no I/O, no stored snapshot. Returns a plain
+ * serializable object (also the JSON shape the CLI explainer #36 will emit).
+ */
+export function explainTransition(events: Event[], transitionEventId: string): TransitionExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(transitionEventId)
+  if (!evt) throw new Error(`explainTransition: unknown event id "${transitionEventId}"`)
+  if (evt.type !== 'fsm.transition') {
+    throw new Error(`explainTransition: event "${transitionEventId}" is "${evt.type}", expected "fsm.transition"`)
+  }
+
+  const p = evt.payload as FsmTransitionPayload
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const guards = p.guardEvaluations ?? []
+
+  const causalChain = walkCausedBy(events, transitionEventId).map(e => ({
+    eventId: e.id,
+    type:    e.type,
+    summary: summarizeEvent(e),
+  }))
+
+  const guardPart = guards.length
+    ? `;guard ${guards.map(g => `${g.guardId} 判定 ${String(g.result)}`).join('、')}`
+    : ''
+  const triggerSource = causeEvt ? summarizeEvent(causeEvt) : '(无上游记录)'
+  const summary = `${p.from} → ${p.to}:由 ${triggerSource} 发出的 ${p.trigger.name} 触发${guardPart}`
+
+  return {
+    transitionEventId,
+    from: p.from,
+    to:   p.to,
+    trigger: {
+      name:   p.trigger.name,
+      domain: p.trigger.domain,
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeEvt ? { causedBySummary: summarizeEvent(causeEvt) } : {}),
+    },
+    guards,
+    causalChain,
+    summary,
+  }
+}

--- a/src/trace/diagnostics/summarizeEvent.ts
+++ b/src/trace/diagnostics/summarizeEvent.ts
@@ -1,0 +1,14 @@
+import type { Event } from '../types.js'
+
+/**
+ * Human-readable one-line label for an event. Shared by the HTML "Why?" block
+ * and (future) the CLI explainer (#36), so both speak the same language.
+ */
+export function summarizeEvent(event: Event): string {
+  const p = event.payload as { toolName?: unknown }
+  if ((event.type === 'tool.requested' || event.type === 'tool.responded')
+      && typeof p?.toolName === 'string') {
+    return `${event.type}(${p.toolName})`
+  }
+  return event.type
+}

--- a/src/trace/diagnostics/walkCausedBy.ts
+++ b/src/trace/diagnostics/walkCausedBy.ts
@@ -1,0 +1,21 @@
+import type { Event } from '../types.js'
+
+/**
+ * Walk the causedBy chain upstream from `startId`, nearest-first, until an
+ * event has no causedBy, its causedBy points outside `events`, or a cycle is
+ * detected. Pure: reads only the provided events. Reusable by #32/#36.
+ */
+export function walkCausedBy(events: Event[], startId: string): Event[] {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const chain: Event[] = []
+  const seen = new Set<string>()
+  let current = byId.get(startId)
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    chain.push(current)
+    current = current.causedBy ? byId.get(current.causedBy) : undefined
+  }
+  return chain
+}

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -1,6 +1,7 @@
 import type { Event } from '../types.js'
 import { buildTimelineTree, type TimelineEntry, type TimelineNode } from './tree.js'
 import { STYLES, SCRIPT } from './template.js'
+import { explainTransition, type TransitionExplanation } from '../diagnostics/explainTransition.js'
 
 function esc(s: string): string {
   return s
@@ -40,7 +41,34 @@ function payloadFor(entry: TimelineEntry, eventById: Map<string, Event>): string
   return sections.length > 0 ? esc(sections.join('\n\n')) : ''
 }
 
-function renderEntry(entry: TimelineEntry, eventById: Map<string, Event>): string {
+function entryEventIds(entry: TimelineEntry): string[] {
+  if (entry.kind === 'llm' || entry.kind === 'tool') {
+    return entry.respondedId ? [entry.requestedId, entry.respondedId] : [entry.requestedId]
+  }
+  return [entry.eventId]
+}
+
+function renderWhy(exp: TransitionExplanation): string {
+  const trigger = exp.trigger.causedByEventId
+    ? `<div class="why-trigger">触发: <a href="#ev-${esc(exp.trigger.causedByEventId)}">${esc(exp.trigger.causedBySummary ?? exp.trigger.causedByEventId)}</a></div>`
+    : ''
+  const guards = exp.guards.length
+    ? `<div class="why-guards">guard: ${esc(exp.guards.map(g => `${g.guardId}=${String(g.result)}`).join(', '))}</div>`
+    : ''
+  const chain = `<div class="why-chain">`
+    + exp.causalChain.map(c => `<a href="#ev-${esc(c.eventId)}">${esc(c.summary)}</a>`).join(' → ')
+    + `</div>`
+  return `<div class="why">`
+       + `<div class="why-summary">${esc(exp.summary)}</div>`
+       + trigger + guards + chain
+       + `</div>`
+}
+
+function renderEntry(
+  entry: TimelineEntry,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+): string {
   const icon = entry.kind === 'llm' ? '◆'
              : entry.kind === 'tool' ? '▣'
              : entry.kind === 'region'
@@ -48,17 +76,29 @@ function renderEntry(entry: TimelineEntry, eventById: Map<string, Event>): strin
                  : entry.eventType === 'region.added' ? '＋' : '－')
              : entry.kind === 'fsm' ? '⇒'
              : '●'
-  return `<div class="entry ${entry.kind}" data-kind="${entry.kind}">`
+  const ids = entryEventIds(entry)
+  const primaryId = ids[0]!
+  const extraAnchors = ids.slice(1).map(id => `<span class="anchor" id="ev-${esc(id)}"></span>`).join('')
+  const why = entry.kind === 'fsm' && explanations.has(entry.eventId)
+    ? renderWhy(explanations.get(entry.eventId)!)
+    : ''
+  return `<div class="entry ${entry.kind}" data-kind="${entry.kind}" id="ev-${esc(primaryId)}">`
+       + extraAnchors
        + `<div class="entry-head">`
        + `<span class="icon">${icon}</span>`
        + `<span class="summary">${summaryFor(entry)}</span>`
        + `<span class="ts">${entry.timestamp}</span>`
        + `</div>`
+       + why
        + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
        + `</div>`
 }
 
-function renderNode(node: TimelineNode, eventById: Map<string, Event>): string {
+function renderNode(
+  node: TimelineNode,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+): string {
   const status = node.status ?? 'in-flight'
   const badgeClass = BADGE_STATUS_CLASSES.has(status) ? ' ' + status : ''
   return `<section class="run" data-run-id="${esc(node.runId)}">`
@@ -67,9 +107,9 @@ function renderNode(node: TimelineNode, eventById: Map<string, Event>): string {
        + `<span class="run-id">${esc(node.runId)}</span>`
        + `<span class="badge${badgeClass}">${esc(status)}</span>`
        + `</div>`
-       + node.entries.map(en => renderEntry(en, eventById)).join('')
+       + node.entries.map(en => renderEntry(en, eventById, explanations)).join('')
        + (node.children.length > 0
-           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById)).join('')}</div>`
+           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById, explanations)).join('')}</div>`
            : '')
        + `</section>`
 }
@@ -89,6 +129,10 @@ export function renderHtml(events: Event[]): string {
   const tree = buildTimelineTree(events)
   const eventById = new Map<string, Event>()
   for (const evt of events) eventById.set(evt.id, evt)
+  const explanations = new Map<string, TransitionExplanation>()
+  for (const evt of events) {
+    if (evt.type === 'fsm.transition') explanations.set(evt.id, explainTransition(events, evt.id))
+  }
   const dataJson = JSON.stringify(events)
     // close-tag-safe inlining: prevent the JSON from ending the script element.
     .replace(/<\/script/gi, '<\\/script')
@@ -108,7 +152,7 @@ export function renderHtml(events: Event[]): string {
   <span class="chip" data-kind="region">region</span>
   <span class="chip" data-kind="fsm">fsm</span>
 </div>
-${tree.map(n => renderNode(n, eventById)).join('')}
+${tree.map(n => renderNode(n, eventById, explanations)).join('')}
 <script type="application/json" id="trace-data">${dataJson}</script>
 <script>${SCRIPT}</script>
 </body>

--- a/src/trace/render/template.ts
+++ b/src/trace/render/template.ts
@@ -34,11 +34,20 @@ export const STYLES = `
              font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap;
              border-radius: 4px; max-height: 320px; overflow: auto; }
   .entry.open .payload { display: block; }
+  .why { margin: 4px 0 4px 22px; padding: 6px 10px; border-left: 3px solid #6b8;
+         background: rgba(0,0,0,0.03); font-size: 12px; line-height: 1.5; }
+  .why-summary { font-weight: 600; margin-bottom: 2px; }
+  .why-trigger, .why-guards { color: #444; }
+  .why-chain { margin-top: 3px; color: #666; word-break: break-word; }
+  .why a { color: #36a; text-decoration: none; }
+  .why a:hover { text-decoration: underline; }
+  .anchor { scroll-margin-top: 8px; }
 `
 
 export const SCRIPT = `
   (function () {
     document.addEventListener('click', function (ev) {
+      if (ev.target.closest && ev.target.closest('.why a')) return;
       var entry = ev.target.closest('.entry');
       if (entry) entry.classList.toggle('open');
       var chip = ev.target.closest('.chip');


### PR DESCRIPTION
Closes #33

## Summary

点 trace 报告里的 `fsm.transition` 能读懂"为什么这次跳转"——触发事件 + guard + 因果链,带一键跳上游链接。**纯 event-log 投影:零 LLM、零存储、零事件 schema 变更**(只读 #21/#30/#31 已存的数据)。

- `src/trace/diagnostics/` 新建三个纯函数:
  - `walkCausedBy` — 沿 causedBy 上溯因果链(#32/#36 也可复用)
  - `summarizeEvent` — 事件 → 人类标签
  - `explainTransition` — 核心投影,返回可序列化 `TransitionExplanation`(也是 #36 CLI 的 JSON 输出形状)
- `html.ts`:fsm 条目渲染可读 "Why?" 块 + 给事件加 `id="ev-<eventId>"` 锚点(合并的 llm/tool 条目吐双锚点,保证链上每个事件 id 都跳得到);`template.ts` 加 Why 面板样式 + 跳链不再误触发条目折叠。

## 设计取舍

- **region 暂缓**:`region.added` 无 transition 标记、#26 region-link 未完成 → 本 PR 只交付 trigger+guard+因果链,region 等 #26。
- **CLI 是 #36**:本 PR 只提供它要复用的投影函数;`trace why/explain/path` 不在范围。
- 设计/计划:`docs/superpowers/specs/2026-05-30-why-this-transition-design.md`、`docs/superpowers/plans/2026-05-30-why-this-transition.md`

## Test Plan

- [x] 全量单测:48 套件 / 441 通过 / 16 skip;`tsc` 构建干净
- [x] `walkCausedBy`(到根/断链/环/未知 id)、`explainTransition`(投影/链 id 可解析/无 guard/抛错/dangling)、`summarizeEvent`、render(带/不带 guard + 锚点往返 + CSS hook)
- [x] 解释纯投影、不调 LLM(测试用合成事件,无 gateway)

## 已知 minor(非阻塞,可后续)

- 理论上的悬空锚点:若因果链经过未渲染的事件类型,其跳链会失效——当前因果链只经过会渲染的类型,实际不可达。
- Why 块 guard 用 `guardId=result`,与 summary 的 `guardId 判定 result` 两种格式(cosmetic)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)