### PR TITLE
feat(#26): region composition + 内容预览 UI (core capability)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-region-composition-ui.md
+++ b/docs/superpowers/plans/2026-05-31-region-composition-ui.md
@@ -1,0 +1,443 @@
+# region composition + 内容预览 UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 核心静态报告里点 `llm.requested` 能看到 "Assembled by N regions"——参与 region 的 metadata + stability 配色 + 内容预览(折叠/全文)+ 同 hash 报告级去重标注复用次数。
+
+**Architecture:** 复用 #23 的 `RegionContextView.contextRefsAt`(某时刻活跃 region 集,纯)。新增纯函数 `regionReuseCounts`。`renderHtml` 加可选 `opts.regionContent`(`Map<contentHash, content>`),内容由 CLI `trace report` 从 objectStore hydrate 后传入——renderHtml 保持纯函数。内容按 hash 内联到一个 `<script id="region-content">` 注册表(去重),行按 `data-hash` 展开时从注册表取。
+
+**Tech Stack:** TypeScript;Jest(`npx jest <file>`);现有 `src/trace/render/{html,template,tree}.ts`、`src/trace/RegionContextView.ts`、`src/cli/main.ts`、`FileTraceObjectStore`。
+
+参考 spec:`docs/superpowers/specs/2026-05-31-region-composition-ui-design.md`。**测试运行器是 JEST**。
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `src/trace/RegionContextView.ts` | region-context 投影 | +`regionReuseCounts(events)` |
+| `src/trace/render/html.ts` | 静态报告渲染 | `renderHtml` 加 `opts.regionContent`;llm 条目渲 "Assembled by" 块;嵌入内容注册表 |
+| `src/trace/render/template.ts` | CSS/JS | stability 配色 + assembled/preview 样式 + 行展开 JS |
+| `src/cli/main.ts` | CLI | `trace report` hydrate region 内容并传入 renderHtml |
+| `src/__tests__/regionReuseCounts.test.ts` | 单测 | 新建 |
+| `src/__tests__/render-html.test.ts` | 单测 | Assembled-by + 去重 + 降级断言 |
+
+---
+
+## Task 1: regionReuseCounts — 报告级 contentHash 引用计数
+
+**Files:**
+- Modify: `src/trace/RegionContextView.ts`
+- Test: `src/__tests__/regionReuseCounts.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { regionReuseCounts } from '../trace/RegionContextView'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+
+const regionAdded = (id: string, contentHash?: string) =>
+  ev(`add-${id}`, 'region.added', { id, target: 'message', section: 's', stability: 'volatile', reason: 'r', ...(contentHash ? { contentHash } : {}) })
+
+describe('regionReuseCounts', () => {
+  it('counts how many llm.requested active-sets reference each contentHash', () => {
+    const events: Event[] = [
+      regionAdded('h', 'HASH'),                 // region h, content HASH
+      ev('llm1', 'llm.requested', {}),          // active set: {h} → HASH ×1 so far
+      ev('llm2', 'llm.requested', {}),          // h still active → HASH ×2
+    ]
+    const counts = regionReuseCounts(events)
+    expect(counts.get('HASH')).toBe(2)
+  })
+
+  it('single reference counts as 1', () => {
+    const events: Event[] = [regionAdded('h', 'HASH'), ev('llm1', 'llm.requested', {})]
+    expect(regionReuseCounts(events).get('HASH')).toBe(1)
+  })
+
+  it('ignores regions without a contentHash and llm calls with no active regions', () => {
+    const events: Event[] = [
+      ev('llm0', 'llm.requested', {}),          // no regions yet
+      regionAdded('h'),                         // no contentHash
+      ev('llm1', 'llm.requested', {}),
+    ]
+    expect(regionReuseCounts(events).size).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/regionReuseCounts.test.ts`
+Expected: FAIL（`regionReuseCounts` 未导出）。
+
+- [ ] **Step 3: 实现**(在 `src/trace/RegionContextView.ts` 末尾追加)
+
+```ts
+/**
+ * Report-wide reuse count: for every llm.requested, fold the active region set
+ * (contextRefsAt 'at') and tally each region's contentHash. The value is how
+ * many (llm.requested × region) references share that content — used by the UI
+ * to dedup identical content and annotate "复用 ×N". Pure.
+ */
+export function regionReuseCounts(events: Event[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const event of events) {
+    if (event.type !== 'llm.requested') continue
+    for (const ref of contextRefsAt(events, event.id, 'at').values()) {
+      if (!ref.contentHash) continue
+      counts.set(ref.contentHash, (counts.get(ref.contentHash) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/regionReuseCounts.test.ts`
+Expected: PASS（3 用例）。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/RegionContextView.ts src/__tests__/regionReuseCounts.test.ts
+git commit -m "feat(#26): regionReuseCounts — report-wide contentHash reference tally"
+```
+
+---
+
+## Task 2: renderHtml "Assembled by" 块 + 内容注册表 + 样式
+
+**Files:**
+- Modify: `src/trace/render/html.ts`
+- Modify: `src/trace/render/template.ts`
+- Test: `src/__tests__/render-html.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`src/__tests__/render-html.test.ts`,复用文件已有 `e({...})` 助手与 `renderHtml`/`Event` 导入)
+
+```ts
+describe('#26 Assembled by', () => {
+  const region = (id: string, stability: string, contentHash?: string) =>
+    e({ id: `add-${id}`, runId: 'r1', type: 'region.added', timestamp: 1,
+        payload: { id, target: 'message', section: 'history', stability, reason: 'turn-archived',
+          ...(contentHash ? { contentHash } : {}) } })
+
+  it('renders an Assembled by block on llm.requested with metadata + stability class', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['H1', 'SYSTEM PROMPT TEXT']]) })
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('header')
+    expect(html).toContain('stab-immutable')
+    expect(html).toContain('data-hash="H1"')
+    // content embedded once in the registry
+    expect(html).toContain('SYSTEM PROMPT TEXT')
+  })
+
+  it('dedups identical content across prompts and annotates reuse count', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm1', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+      e({ id: 'llm2', runId: 'r1', type: 'llm.requested', timestamp: 3, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['H1', 'SHARED-CONTENT-XYZ']]) })
+    // embedded once in the registry, not per-prompt
+    expect(html.split('SHARED-CONTENT-XYZ').length - 1).toBe(1)
+    expect(html).toContain('复用 ×2')
+  })
+
+  it('degrades gracefully without region content (metadata only)', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)   // no opts
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('header')
+    expect(html).toContain('(内容不可用)')
+  })
+
+  it('renders no Assembled by block for an llm.requested with no active regions', () => {
+    const events: Event[] = [
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).not.toContain('Assembled by')
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/render-html.test.ts -t "Assembled by"`
+Expected: FAIL。
+
+- [ ] **Step 3: html.ts — 导入 + renderHtml 签名与注册表**
+
+顶部 import 加(与现有 `.js` 风格一致):
+```ts
+import { contextRefsAt, regionReuseCounts, type RegionContentRef } from '../RegionContextView.js'
+```
+
+把 `renderHtml` 签名改为接收 opts,并构建 region 渲染上下文 + 内容注册表。替换现有 `renderHtml`:
+```ts
+export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+  const tree = buildTimelineTree(events)
+  const eventById = new Map<string, Event>()
+  for (const evt of events) eventById.set(evt.id, evt)
+
+  const explanations = new Map<string, TransitionExplanation>()
+  for (const evt of events) {
+    if (evt.type === 'fsm.transition') explanations.set(evt.id, explainTransition(events, evt.id))
+  }
+
+  const regionContent = opts.regionContent ?? new Map<string, string>()
+  const regionCtx: RegionCtx = { events, reuseCounts: regionReuseCounts(events), regionContent }
+
+  const registryJson = JSON.stringify(Object.fromEntries(regionContent))
+    .replace(/<\/script/gi, '<\\/script')
+  const dataJson = JSON.stringify(events).replace(/<\/script/gi, '<\\/script')
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>milkie trace report</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<h1>milkie trace report</h1>
+<div class="filters">
+  <span class="chip" data-kind="llm">LLM</span>
+  <span class="chip" data-kind="tool">tool</span>
+  <span class="chip" data-kind="lifecycle">lifecycle</span>
+  <span class="chip" data-kind="region">region</span>
+  <span class="chip" data-kind="fsm">fsm</span>
+</div>
+${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
+<script type="application/json" id="region-content">${registryJson}</script>
+<script type="application/json" id="trace-data">${dataJson}</script>
+<script>${SCRIPT}</script>
+</body>
+</html>`
+}
+```
+
+Add the `RegionCtx` type (near the top of the file, after imports):
+```ts
+interface RegionCtx {
+  events:        Event[]
+  reuseCounts:   Map<string, number>
+  regionContent: Map<string, string>
+}
+```
+
+- [ ] **Step 4: html.ts — Assembled by 渲染助手**
+
+在 `renderEntry` 之前加:
+```ts
+function renderAssembled(requestedId: string, ctx: RegionCtx): string {
+  const refs: RegionContentRef[] = [...contextRefsAt(ctx.events, requestedId, 'at').values()]
+  if (refs.length === 0) return ''
+  const rows = refs.map(ref => {
+    const hash    = ref.contentHash
+    const reuse   = hash ? (ctx.reuseCounts.get(hash) ?? 1) : 1
+    const reuseB  = reuse > 1 ? ` <span class="reuse">复用 ×${reuse}</span>` : ''
+    const avail   = !!(hash && ctx.regionContent.has(hash))
+    const note    = hash && !avail ? ` <span class="ar-note">(内容不可用)</span>` : ''
+    const meta    = `<span class="ar-id">${esc(ref.id)}</span> · ${esc(ref.section)} · ${esc(ref.target)} · ${esc(ref.reason)}`
+    const preview = avail ? `<pre class="region-preview"></pre>` : ''
+    const dataH   = hash ? ` data-hash="${esc(hash)}"` : ''
+    return `<div class="ar-row stab-${esc(ref.stability)}"${dataH}><div class="ar-meta">${meta}${reuseB}${note}</div>${preview}</div>`
+  }).join('')
+  return `<div class="assembled"><div class="ar-head">Assembled by ${refs.length} regions</div>${rows}</div>`
+}
+```
+
+- [ ] **Step 5: html.ts — renderEntry/renderNode 接 RegionCtx,llm 条目渲 Assembled**
+
+`renderEntry` 改签名,llm 条目加 Assembled 块(其它分支不变;保留 #33 的 `explanations`/`entryEventIds`/`renderWhy`/锚点逻辑):
+```ts
+function renderEntry(
+  entry: TimelineEntry,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+  regionCtx: RegionCtx,
+): string {
+  const icon = entry.kind === 'llm' ? '◆'
+             : entry.kind === 'tool' ? '▣'
+             : entry.kind === 'region'
+               ? (entry.eventType === 'context.boundary.applied' ? '⌖'
+                 : entry.eventType === 'region.added' ? '＋' : '－')
+             : entry.kind === 'fsm' ? '⇒'
+             : '●'
+  const ids = entryEventIds(entry)
+  const primaryId = ids[0]!
+  const extraAnchors = ids.slice(1).map(id => `<span class="anchor" id="ev-${esc(id)}"></span>`).join('')
+  const why = entry.kind === 'fsm' && explanations.has(entry.eventId)
+    ? renderWhy(explanations.get(entry.eventId)!)
+    : ''
+  const assembled = entry.kind === 'llm' ? renderAssembled(entry.requestedId, regionCtx) : ''
+  return `<div class="entry ${entry.kind}" data-kind="${entry.kind}" id="ev-${esc(primaryId)}">`
+       + extraAnchors
+       + `<div class="entry-head">`
+       + `<span class="icon">${icon}</span>`
+       + `<span class="summary">${summaryFor(entry)}</span>`
+       + `<span class="ts">${entry.timestamp}</span>`
+       + `</div>`
+       + why
+       + assembled
+       + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
+       + `</div>`
+}
+```
+
+`renderNode` 透传 `regionCtx`:
+```ts
+function renderNode(
+  node: TimelineNode,
+  eventById: Map<string, Event>,
+  explanations: Map<string, TransitionExplanation>,
+  regionCtx: RegionCtx,
+): string {
+  const status = node.status ?? 'in-flight'
+  const badgeClass = BADGE_STATUS_CLASSES.has(status) ? ' ' + status : ''
+  return `<section class="run" data-run-id="${esc(node.runId)}">`
+       + `<div class="run-head">`
+       + `<strong>${esc(node.agentId ?? '(unknown)')}</strong>`
+       + `<span class="run-id">${esc(node.runId)}</span>`
+       + `<span class="badge${badgeClass}">${esc(status)}</span>`
+       + `</div>`
+       + node.entries.map(en => renderEntry(en, eventById, explanations, regionCtx)).join('')
+       + (node.children.length > 0
+           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}</div>`
+           : '')
+       + `</section>`
+}
+```
+
+- [ ] **Step 6: template.ts — CSS + 行展开 JS**
+
+在 `STYLES` 模板末尾(反引号前)追加:
+```css
+  .assembled { margin: 4px 0 4px 22px; padding: 6px 10px; border-left: 3px solid #b58;
+               background: rgba(0,0,0,0.03); font-size: 12px; line-height: 1.5; }
+  .ar-head { font-weight: 600; margin-bottom: 4px; }
+  .ar-row { padding: 3px 0 3px 8px; border-left: 3px solid transparent; cursor: pointer; }
+  .ar-row[data-hash]:hover { background: rgba(0,0,0,0.04); }
+  .ar-id { font-family: ui-monospace, SFMono-Regular, monospace; }
+  .ar-note { color: #a13; }
+  .reuse { color: #8a5a00; font-size: 11px; }
+  .region-preview { display: none; margin-top: 4px; background: #fafafa; padding: 8px;
+                    font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap;
+                    border-radius: 4px; max-height: 280px; overflow: auto; }
+  .ar-row.open .region-preview { display: block; }
+  .stab-immutable      { border-left-color: #2d6a2d; }
+  .stab-session-stable { border-left-color: #1a56db; }
+  .stab-turn-stable    { border-left-color: #8a5a00; }
+  .stab-volatile       { border-left-color: #a13; }
+```
+
+在 `SCRIPT` 的 click 处理器里,**`.why a` 早退之后、entry toggle 之前**插入 region-row 展开逻辑(从注册表按 data-hash 取内容,首次展开时填充):
+```js
+      var arRow = ev.target.closest('.ar-row');
+      if (arRow && arRow.dataset.hash) {
+        ev.stopPropagation();
+        arRow.classList.toggle('open');
+        var pre = arRow.querySelector('.region-preview');
+        if (pre && !pre.dataset.loaded) {
+          var reg = JSON.parse((document.getElementById('region-content') || {}).textContent || '{}');
+          var c = reg[arRow.dataset.hash];
+          pre.textContent = (c != null) ? c : '(内容不可用)';
+          pre.dataset.loaded = '1';
+        }
+        return;
+      }
+```
+(放在 `if (ev.target.closest && ev.target.closest('.why a')) return;` 之后,`var entry = ev.target.closest('.entry');` 之前。)
+
+- [ ] **Step 7: 运行,确认通过**
+
+Run: `npx jest src/__tests__/render-html.test.ts && npx jest src/__tests__/render-tree.test.ts`
+Expected: PASS（含 #26 四用例 + 原有用例无回归)。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add src/trace/render/html.ts src/trace/render/template.ts src/__tests__/render-html.test.ts
+git commit -m "feat(#26): Assembled by block on llm.requested — regions, stability, content preview, hash dedup"
+```
+
+---
+
+## Task 3: CLI `trace report` —— hydrate region 内容并传入 renderHtml
+
+**Files:**
+- Modify: `src/cli/main.ts`(`report <runId>` 命令,约 `:177-192`)
+
+- [ ] **Step 1: 改 `trace report` 命令**
+
+先 READ `src/cli/main.ts` 的 `report` 命令,确认 `runsDir`/`milkieDir` 的推导方式(`:33-34` 与 `:203-204` 用 `path.join(milkieDir, 'objects')` 建 `FileTraceObjectStore`;`FileTraceObjectStore` 已在 `:6` 导入)。把 `report` 命令体改为:在读完 events 后,构造 objectStore、收集所有 `region.added` 的 `contentHash`、`getCanonical` 批量取、组装 `Map<hash,content>`,传给 `renderHtml`:
+
+```ts
+// 在 events 收集完之后、renderHtml 之前:
+const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
+const hashes = new Set<string>()
+for (const ev of events) {
+  if (ev.type === 'region.added') {
+    const h = (ev.payload as { contentHash?: string }).contentHash
+    if (h) hashes.add(h)
+  }
+}
+const regionContent = new Map<string, string>()
+for (const h of hashes) {
+  const c = await traceObjectStore.getCanonical(h)
+  if (c !== undefined) regionContent.set(h, c)
+}
+stdout.push(renderHtml(events, { regionContent }))
+```
+说明:`milkieDir` 是 `report` 命令里推导 `runsDir` 用到的同一个目录基(读代码确认它的变量名——若该命令只算了 `runsDir`,用 `path.dirname(runsDir)` 取回 milkieDir,或仿照 `:33` 重新算 `milkieDir`)。`render-html`(从 `--input` JSONL,无 objectStore)**保持不变**,继续 `renderHtml(events)`,自动降级 metadata-only。
+
+- [ ] **Step 2: 类型检查 + 构建**
+
+Run: `npx tsc --noEmit`
+Expected: 干净。(CLI 无现成单测;此命令是 I/O 装配,靠 tsc + Task 2 的 renderHtml 测试保证。)
+
+- [ ] **Step 3: 手验(可选,有 run 数据时)**
+
+Run: `node dist/cli/main.js trace report <某 runId> > /tmp/report.html` 后浏览器打开,确认 llm.requested 出 "Assembled by"、点 region 行展开看到内容、复用标注。无 run 数据则跳过。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/cli/main.ts
+git commit -m "feat(#26): trace report hydrates region content from objectStore into the HTML report"
+```
+
+---
+
+## 收尾
+
+- [ ] **全量测试 + 构建**
+
+Run: `npx jest && npm run build`
+Expected: 全绿。
+
+- [ ] **开 PR**:body 带 `Closes #26`;说明范围(核心能力 + 核心静态报告;示例 app audit panel 复用为 follow-up),复用 #23 的 RegionContextView。
+
+---
+
+## Self-Review(plan 作者已核对)
+
+**Spec 覆盖:** §4.1 regionReuseCounts → Task 1 ✓ §4.2 renderHtml opts → Task 2 Step 3 ✓ §4.3 CLI hydrate → Task 3 ✓ §5 Assembled-by(metadata/stability/预览/去重)→ Task 2 Step 4-6 ✓ §6 降级(无内容/无 contentHash/无 region)→ Task 2 测试三、四 ✓ §7 测试 → Task 1/2 ✓ §9 验收(清单/内容/长 prompt 去重)→ Task 2 ✓。
+
+**占位扫描:** 无 TBD/TODO;改代码步骤均含完整代码。Task 3 Step 1 的 `milkieDir` 变量名以实际 `report` 命令为准——已给出明确推导方法,非内容缺失。
+
+**类型一致性:** `RegionCtx { events, reuseCounts, regionContent }`(Task 2 Step 3 定义)在 renderAssembled/renderEntry/renderNode(Step 4-5)一致;`regionReuseCounts(events): Map<string,number>`(Task 1)在 Step 3 调用一致;`contextRefsAt`/`RegionContentRef` 取自 `RegionContextView`;`renderHtml(events, opts?)` 在 Task 3 调用一致;`opts.regionContent: Map<contentHash,string>` 全程一致。

--- a/docs/superpowers/specs/2026-05-31-region-composition-ui-design.md
+++ b/docs/superpowers/specs/2026-05-31-region-composition-ui-design.md
@@ -1,0 +1,102 @@
+# #26 region composition + 内容预览 UI — 设计 spec
+
+**Issue:** #26（observable P1;依赖 #23 region 内容可寻址,已落地;Parent #20）
+**日期:** 2026-05-31
+**定位:** 把"这次 LLM 调用的 prompt 由哪些 region 拼成、各 region 内容是什么"做成**核心库能力 + 核心静态报告的可见效果**。复用 #23 的 `RegionContextView`,renderHtml 保持纯函数。
+
+---
+
+## 1. 目标与范围
+
+排查 prompt 出问题时,点 `llm.requested` 能看到:**Assembled by** —— 参与 region 的 `{id, target, section, stability, reason}` + 内容预览(折叠/全文)、同 hash 去重标注复用次数、stability 视觉区分。
+
+**范围(已与用户确认):**
+- **下沉到核心库**:做成核心可复用能力,核心静态报告(`renderHtml` / `milkie trace report`)直接展示——这是可见效果的落点。
+- 示例 app(`examples/agent-docs-qa`)的 audit panel **本次不动**(它 Phase 4a 已有 metadata 版 Assembled-by;复用核心能力是 follow-up)。
+
+## 2. Non-goals
+
+- **不改示例 app**(留 follow-up)。
+- **不新增事件类型 / 不改事件 schema**:数据全来自已有 `region.added/removed` 事件 + #23 的 objectStore。
+- **renderHtml 保持纯函数**:读 objectStore 的 I/O 由 CLI 调用方做,内容作为数据传入。架构防火墙不破(ARCHITECTURE.md「UI is a pure projection」)。
+
+## 3. 数据齐备性(#23 已就绪)
+
+| 要素 | 来源 | 状态 |
+|---|---|---|
+| 某 llm.requested 时刻的活跃 region 集 | `contextRefsAt(events, eventId, 'at')`(`RegionContextView.ts:46`) | ✅ 现成,纯 |
+| region 的 {id,target,section,stability,reason,contentHash} | `RegionContentRef` | ✅ 现成 |
+| 按 hash 取内容 | `hydrateRegionContext` / `objectStore.getCanonical(hash)` | ✅ 现成(#23) |
+| CLI 的 objectStore 通路 | `FileTraceObjectStore(objects/)`(`cli/main.ts:34,204`) | ✅ 现成 |
+
+新增的只有:**报告级同 hash 去重 + 复用次数**,和 **renderHtml 接内容 + 渲染 Assembled-by 块**。
+
+## 4. 架构
+
+```
+renderHtml(events, opts?)                       // 仍是纯函数
+  ├─ 对每个 llm.requested:contextRefsAt(events, reqId, 'at')  → 活跃 region 集(纯)
+  ├─ regionReuseCounts(events)                  // 新增纯函数:报告级 contentHash → 引用次数
+  └─ opts.regionContent?: Map<contentHash,string> // 由 CLI hydrate 传入(可选)
+CLI `trace report`:
+  收集所有被引用的 contentHash → objectStore.getCanonical 批量取 → Map<hash,content> → 传给 renderHtml
+```
+
+### 4.1 新增纯函数(`src/trace/RegionContextView.ts` —— region-context 逻辑的归属,最可复用)
+
+- `regionReuseCounts(events: Event[]): Map<string, number>`
+  报告级聚合:遍历每个 `llm.requested` 的活跃 region 集(`contextRefsAt`),对每个 region 的 `contentHash` 计数——值 = 该内容被多少个 (llm.requested × region) 引用。用于"复用 ×N"。纯函数。
+
+### 4.2 renderHtml 扩展
+
+- 签名:`renderHtml(events: Event[], opts?: { regionContent?: Map<string, string> }): string`
+  - `regionContent` 键 = `contentHash`,值 = 内容字符串。**省略时**(如 `render-html` 从纯 JSONL,无 objectStore):Assembled-by 列表照常出(metadata),内容预览显示"(内容不可用)"。优雅降级。
+  - 向后兼容:现有 `renderHtml(events)` 调用不变。
+
+### 4.3 CLI `trace report` 改造(`src/cli/main.ts`)
+
+- 构造 `FileTraceObjectStore(objects/)`(路径已知);
+- 收集所有 llm.requested 活跃 region 的 `contentHash`,去重后 `getCanonical` 批量取,组装 `Map<hash, content>`;
+- `renderHtml(events, { regionContent })`。
+- `render-html`(从 --input JSONL,无 objectStore)继续调 `renderHtml(events)`,自动降级为 metadata-only。
+
+## 5. 静态报告渲染(`src/trace/render/`)
+
+给 `llm.requested` 条目(`LlmEntry`)加 **"Assembled by N regions" 展开块**(思路同 #33 的 "Why?" 块):
+
+- **region 来源清单**:每行 `{id} · {section} · {target} · {reason}`,带 **stability 配色 class**(`immutable` / `session-stable` / `turn-stable` / `volatile` 四档,template.ts 各一色)。
+- **内容预览**:每行一个可展开 `<pre>`,默认折叠、点击切全文。
+- **同 hash 去重**:内容**按 contentHash 在报告内只内联一次**(嵌入一个 `<script type="application/json" id="region-content">` hash→content 注册表或一组隐藏块);每行展开时从注册表取该 hash 内容显示;每行标注 **复用 ×N**(N = `regionReuseCounts` 值)。避免长 prompt 把 HTML 撑爆,满足">20 region 仍可读"。
+- **降级**:`regionContent` 缺该 hash → 该行预览显示"(内容不可用)",清单仍在。
+
+## 6. 错误处理 / 边界
+
+- llm.requested 无活跃 region → 不渲 Assembled-by 块(保持现状条目不变)。
+- region 无 `contentHash`(纯 metadata region)→ 该行只显示 metadata,无预览。
+- `getCanonical` 返回 undefined(hash 不在 store)→ 该 hash 不进 `regionContent`,渲染降级为"(内容不可用)"。
+- 长 prompt(>20 region):折叠默认 + 去重控制体积,保证可读(验收项)。
+
+## 7. 测试
+
+- **`regionReuseCounts`**:构造多个 llm.requested 共用同 contentHash 的事件流 → 断言计数正确;单次引用 = 1。
+- **renderHtml(带 regionContent)**:llm.requested 出 "Assembled by" 块、含某 region 的 id/section/stability class、内容可在注册表中找到、复用 ×N 标注;**省略 regionContent** → 清单在但预览为"(内容不可用)";向后兼容(无 region 的事件流照常渲染)。
+- **去重**:两个 llm.requested 引用同 hash → 内容注册表只内联一次、两行各标复用次数。
+- **CLI `trace report`**(可加轻量集成测试或手验):hydrate 后报告含内容;`render-html` 无 objectStore 时降级不报错。
+
+## 8. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/RegionContextView.ts` | +`regionReuseCounts(events)`(报告级 hash 引用计数) |
+| `src/trace/render/html.ts` | `renderHtml` 加可选 `opts.regionContent`;llm 条目渲 "Assembled by" 块 + 内容注册表 |
+| `src/trace/render/template.ts` | stability 配色 class + region 预览/复用样式 + 折叠 JS |
+| `src/cli/main.ts` | `trace report` 构造 objectStore、hydrate 内容、传入 renderHtml |
+| `src/__tests__/regionReuseCounts.test.ts` | 新建 |
+| `src/__tests__/render-html.test.ts` | Assembled-by + 去重 + 降级断言 |
+
+## 9. 验收对照(#26)
+
+- [x] 任一 llm.requested 可展开查看完整 region 来源清单 → Assembled-by 块(metadata,不需 objectStore)
+- [x] 点 region 行可看到该时刻内容(不依赖运行时副本)→ CLI hydrate 内容 → renderHtml 注册表;纯 event-log + objectStore,无运行时副本
+- [x] 长 prompt(>20 region)仍可读 → 折叠默认 + 同 hash 去重
+- 附:stability 视觉区分、复用次数标注 → §5

--- a/src/__tests__/regionReuseCounts.test.ts
+++ b/src/__tests__/regionReuseCounts.test.ts
@@ -1,0 +1,34 @@
+import { regionReuseCounts } from '../trace/RegionContextView'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+
+const regionAdded = (id: string, contentHash?: string) =>
+  ev(`add-${id}`, 'region.added', { id, target: 'message', section: 's', stability: 'volatile', reason: 'r', ...(contentHash ? { contentHash } : {}) })
+
+describe('regionReuseCounts', () => {
+  it('counts how many llm.requested active-sets reference each contentHash', () => {
+    const events: Event[] = [
+      regionAdded('h', 'HASH'),
+      ev('llm1', 'llm.requested', {}),
+      ev('llm2', 'llm.requested', {}),
+    ]
+    const counts = regionReuseCounts(events)
+    expect(counts.get('HASH')).toBe(2)
+  })
+
+  it('single reference counts as 1', () => {
+    const events: Event[] = [regionAdded('h', 'HASH'), ev('llm1', 'llm.requested', {})]
+    expect(regionReuseCounts(events).get('HASH')).toBe(1)
+  })
+
+  it('ignores regions without a contentHash and llm calls with no active regions', () => {
+    const events: Event[] = [
+      ev('llm0', 'llm.requested', {}),
+      regionAdded('h'),
+      ev('llm1', 'llm.requested', {}),
+    ]
+    expect(regionReuseCounts(events).size).toBe(0)
+  })
+})

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -193,4 +193,43 @@ describe('#26 Assembled by', () => {
     const html = renderHtml(events)
     expect(html).not.toContain('Assembled by')
   })
+
+  it('renders a region row without contentHash as metadata only (no data-hash, no preview)', () => {
+    const events: Event[] = [
+      region('eph', 'volatile'),   // no contentHash
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('eph')
+    // no data-hash attribute on the row and no region-preview element emitted
+    // (the bare substrings appear in STYLES/SCRIPT, so assert the rendered forms)
+    expect(html).not.toContain('data-hash="')
+    expect(html).not.toContain('class="region-preview"')
+  })
+
+  it('applies the stability class for each stability tier', () => {
+    const events: Event[] = [
+      region('a', 'immutable', 'HA'),
+      region('b', 'session-stable', 'HB'),
+      region('c', 'turn-stable', 'HC'),
+      region('d', 'volatile', 'HD'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    for (const cls of ['stab-immutable', 'stab-session-stable', 'stab-turn-stable', 'stab-volatile']) {
+      expect(html).toContain(cls)
+    }
+  })
+
+  it('keeps region content with a </script> sequence from breaking the document', () => {
+    const events: Event[] = [
+      region('x', 'volatile', 'HX'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['HX', '</script><b>boom</b>']]) })
+    // the raw closing tag must be neutralized in the embedded JSON registry
+    expect(html).not.toContain('</script><b>boom</b>')
+    expect(html).toContain('<\\/script>')   // close-tag-safe escaped form present
+  })
 })

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -144,3 +144,53 @@ describe('renderHtml', () => {
     expect(html).toContain('.why {')
   })
 })
+
+describe('#26 Assembled by', () => {
+  const region = (id: string, stability: string, contentHash?: string) =>
+    e({ id: `add-${id}`, runId: 'r1', type: 'region.added', timestamp: 1,
+        payload: { id, target: 'message', section: 'history', stability, reason: 'turn-archived',
+          ...(contentHash ? { contentHash } : {}) } })
+
+  it('renders an Assembled by block on llm.requested with metadata + stability class', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['H1', 'SYSTEM PROMPT TEXT']]) })
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('header')
+    expect(html).toContain('stab-immutable')
+    expect(html).toContain('data-hash="H1"')
+    expect(html).toContain('SYSTEM PROMPT TEXT')
+  })
+
+  it('dedups identical content across prompts and annotates reuse count', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm1', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+      e({ id: 'llm2', runId: 'r1', type: 'llm.requested', timestamp: 3, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['H1', 'SHARED-CONTENT-XYZ']]) })
+    expect(html.split('SHARED-CONTENT-XYZ').length - 1).toBe(1)
+    expect(html).toContain('复用 ×2')
+  })
+
+  it('degrades gracefully without region content (metadata only)', () => {
+    const events: Event[] = [
+      region('header', 'immutable', 'H1'),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('header')
+    expect(html).toContain('(内容不可用)')
+  })
+
+  it('renders no Assembled by block for an llm.requested with no active regions', () => {
+    const events: Event[] = [
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).not.toContain('Assembled by')
+  })
+})

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { Milkie } from '../runtime/Milkie.js'
 import { JsonlEventStore } from '../trace/JsonlEventStore.js'
 import { FileTraceObjectStore } from '../trace/TraceObjectStore.js'
+import { regionReuseCounts } from '../trace/RegionContextView.js'
 import { SQLiteStore } from '../store/SQLiteStore.js'
 import type { AgentCheckpoint } from '../types/store.js'
 
@@ -191,15 +192,8 @@ export async function main(argv: string[]): Promise<MainResult> {
       for (const id of runIds) events.push(...(await eventStore.readByRunId(id)))
 
       const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
-      const hashes = new Set<string>()
-      for (const ev of events) {
-        if (ev.type === 'region.added') {
-          const h = (ev.payload as { contentHash?: string }).contentHash
-          if (h) hashes.add(h)
-        }
-      }
       const regionContent = new Map<string, string>()
-      for (const h of hashes) {
+      for (const h of regionReuseCounts(events).keys()) {
         const c = await traceObjectStore.getCanonical(h)
         if (c !== undefined) regionContent.set(h, c)
       }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -189,7 +189,22 @@ export async function main(argv: string[]): Promise<MainResult> {
       const runIds = [runId, ...(await findDescendantRuns(runsDir, runId))]
       const events = []
       for (const id of runIds) events.push(...(await eventStore.readByRunId(id)))
-      stdout.push(renderHtml(events))
+
+      const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
+      const hashes = new Set<string>()
+      for (const ev of events) {
+        if (ev.type === 'region.added') {
+          const h = (ev.payload as { contentHash?: string }).contentHash
+          if (h) hashes.add(h)
+        }
+      }
+      const regionContent = new Map<string, string>()
+      for (const h of hashes) {
+        const c = await traceObjectStore.getCanonical(h)
+        if (c !== undefined) regionContent.set(h, c)
+      }
+
+      stdout.push(renderHtml(events, { regionContent }))
     })
 
   trace

--- a/src/trace/RegionContextView.ts
+++ b/src/trace/RegionContextView.ts
@@ -96,3 +96,21 @@ export async function getRegionBefore(
 ): Promise<RegionContentRef | undefined> {
   return (await contextBefore(events, eventId, objectStore)).get(regionId)
 }
+
+/**
+ * Report-wide reuse count: for every llm.requested, fold the active region set
+ * (contextRefsAt 'at') and tally each region's contentHash. The value is how
+ * many (llm.requested × region) references share that content — used by the UI
+ * to dedup identical content and annotate "复用 ×N". Pure.
+ */
+export function regionReuseCounts(events: Event[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const event of events) {
+    if (event.type !== 'llm.requested') continue
+    for (const ref of contextRefsAt(events, event.id, 'at').values()) {
+      if (!ref.contentHash) continue
+      counts.set(ref.contentHash, (counts.get(ref.contentHash) ?? 0) + 1)
+    }
+  }
+  return counts
+}

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -2,6 +2,13 @@ import type { Event } from '../types.js'
 import { buildTimelineTree, type TimelineEntry, type TimelineNode } from './tree.js'
 import { STYLES, SCRIPT } from './template.js'
 import { explainTransition, type TransitionExplanation } from '../diagnostics/explainTransition.js'
+import { contextRefsAt, regionReuseCounts, type RegionContentRef } from '../RegionContextView.js'
+
+interface RegionCtx {
+  events:        Event[]
+  reuseCounts:   Map<string, number>
+  regionContent: Map<string, string>
+}
 
 function esc(s: string): string {
   return s
@@ -64,10 +71,28 @@ function renderWhy(exp: TransitionExplanation): string {
        + `</div>`
 }
 
+function renderAssembled(requestedId: string, ctx: RegionCtx): string {
+  const refs: RegionContentRef[] = [...contextRefsAt(ctx.events, requestedId, 'at').values()]
+  if (refs.length === 0) return ''
+  const rows = refs.map(ref => {
+    const hash    = ref.contentHash
+    const reuse   = hash ? (ctx.reuseCounts.get(hash) ?? 1) : 1
+    const reuseB  = reuse > 1 ? ` <span class="reuse">复用 ×${reuse}</span>` : ''
+    const avail   = !!(hash && ctx.regionContent.has(hash))
+    const note    = hash && !avail ? ` <span class="ar-note">(内容不可用)</span>` : ''
+    const meta    = `<span class="ar-id">${esc(ref.id)}</span> · ${esc(ref.section)} · ${esc(ref.target)} · ${esc(ref.reason)}`
+    const preview = avail ? `<pre class="region-preview"></pre>` : ''
+    const dataH   = hash ? ` data-hash="${esc(hash)}"` : ''
+    return `<div class="ar-row stab-${esc(ref.stability)}"${dataH}><div class="ar-meta">${meta}${reuseB}${note}</div>${preview}</div>`
+  }).join('')
+  return `<div class="assembled"><div class="ar-head">Assembled by ${refs.length} regions</div>${rows}</div>`
+}
+
 function renderEntry(
   entry: TimelineEntry,
   eventById: Map<string, Event>,
   explanations: Map<string, TransitionExplanation>,
+  regionCtx: RegionCtx,
 ): string {
   const icon = entry.kind === 'llm' ? '◆'
              : entry.kind === 'tool' ? '▣'
@@ -82,6 +107,7 @@ function renderEntry(
   const why = entry.kind === 'fsm' && explanations.has(entry.eventId)
     ? renderWhy(explanations.get(entry.eventId)!)
     : ''
+  const assembled = entry.kind === 'llm' ? renderAssembled(entry.requestedId, regionCtx) : ''
   return `<div class="entry ${entry.kind}" data-kind="${entry.kind}" id="ev-${esc(primaryId)}">`
        + extraAnchors
        + `<div class="entry-head">`
@@ -90,6 +116,7 @@ function renderEntry(
        + `<span class="ts">${entry.timestamp}</span>`
        + `</div>`
        + why
+       + assembled
        + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
        + `</div>`
 }
@@ -98,6 +125,7 @@ function renderNode(
   node: TimelineNode,
   eventById: Map<string, Event>,
   explanations: Map<string, TransitionExplanation>,
+  regionCtx: RegionCtx,
 ): string {
   const status = node.status ?? 'in-flight'
   const badgeClass = BADGE_STATUS_CLASSES.has(status) ? ' ' + status : ''
@@ -107,9 +135,9 @@ function renderNode(
        + `<span class="run-id">${esc(node.runId)}</span>`
        + `<span class="badge${badgeClass}">${esc(status)}</span>`
        + `</div>`
-       + node.entries.map(en => renderEntry(en, eventById, explanations)).join('')
+       + node.entries.map(en => renderEntry(en, eventById, explanations, regionCtx)).join('')
        + (node.children.length > 0
-           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById, explanations)).join('')}</div>`
+           ? `<div class="child-run">${node.children.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}</div>`
            : '')
        + `</section>`
 }
@@ -125,7 +153,7 @@ function renderNode(
  * store — this is the architectural firewall behind "UI is a pure projection
  * over CLI / SDK output" (ARCHITECTURE.md `## User-facing surfaces`).
  */
-export function renderHtml(events: Event[]): string {
+export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
   const tree = buildTimelineTree(events)
   const eventById = new Map<string, Event>()
   for (const evt of events) eventById.set(evt.id, evt)
@@ -133,6 +161,12 @@ export function renderHtml(events: Event[]): string {
   for (const evt of events) {
     if (evt.type === 'fsm.transition') explanations.set(evt.id, explainTransition(events, evt.id))
   }
+
+  const regionContent = opts.regionContent ?? new Map<string, string>()
+  const regionCtx: RegionCtx = { events, reuseCounts: regionReuseCounts(events), regionContent }
+
+  const registryJson = JSON.stringify(Object.fromEntries(regionContent))
+    .replace(/<\/script/gi, '<\\/script')
   const dataJson = JSON.stringify(events)
     // close-tag-safe inlining: prevent the JSON from ending the script element.
     .replace(/<\/script/gi, '<\\/script')
@@ -152,7 +186,8 @@ export function renderHtml(events: Event[]): string {
   <span class="chip" data-kind="region">region</span>
   <span class="chip" data-kind="fsm">fsm</span>
 </div>
-${tree.map(n => renderNode(n, eventById, explanations)).join('')}
+${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
+<script type="application/json" id="region-content">${registryJson}</script>
 <script type="application/json" id="trace-data">${dataJson}</script>
 <script>${SCRIPT}</script>
 </body>

--- a/src/trace/render/template.ts
+++ b/src/trace/render/template.ts
@@ -73,16 +73,18 @@ export const SCRIPT = `
     document.addEventListener('click', function (ev) {
       if (ev.target.closest && ev.target.closest('.why a')) return;
       var arRow = ev.target.closest('.ar-row');
-      if (arRow && arRow.dataset.hash) {
+      if (arRow) {
         ev.stopPropagation();
-        arRow.classList.toggle('open');
-        var pre = arRow.querySelector('.region-preview');
-        if (pre && !pre.dataset.loaded) {
-          var reg = regOnce();
-          var c = reg[arRow.dataset.hash];
-          // region-preview only emitted when content is available
-          pre.textContent = (c != null) ? c : '';
-          pre.dataset.loaded = '1';
+        if (arRow.dataset.hash) {
+          arRow.classList.toggle('open');
+          var pre = arRow.querySelector('.region-preview');
+          if (pre && !pre.dataset.loaded) {
+            var reg = regOnce();
+            var c = reg[arRow.dataset.hash];
+            // region-preview only emitted when content is available
+            pre.textContent = (c != null) ? c : '';
+            pre.dataset.loaded = '1';
+          }
         }
         return;
       }

--- a/src/trace/render/template.ts
+++ b/src/trace/render/template.ts
@@ -42,12 +42,41 @@ export const STYLES = `
   .why a { color: #36a; text-decoration: none; }
   .why a:hover { text-decoration: underline; }
   .anchor { scroll-margin-top: 8px; }
+  .assembled { margin: 4px 0 4px 22px; padding: 6px 10px; border-left: 3px solid #b58;
+               background: rgba(0,0,0,0.03); font-size: 12px; line-height: 1.5; }
+  .ar-head { font-weight: 600; margin-bottom: 4px; }
+  .ar-row { padding: 3px 0 3px 8px; border-left: 3px solid transparent; cursor: pointer; }
+  .ar-row[data-hash]:hover { background: rgba(0,0,0,0.04); }
+  .ar-id { font-family: ui-monospace, SFMono-Regular, monospace; }
+  .ar-note { color: #a13; }
+  .reuse { color: #8a5a00; font-size: 11px; }
+  .region-preview { display: none; margin-top: 4px; background: #fafafa; padding: 8px;
+                    font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap;
+                    border-radius: 4px; max-height: 280px; overflow: auto; }
+  .ar-row.open .region-preview { display: block; }
+  .stab-immutable      { border-left-color: #2d6a2d; }
+  .stab-session-stable { border-left-color: #1a56db; }
+  .stab-turn-stable    { border-left-color: #8a5a00; }
+  .stab-volatile       { border-left-color: #a13; }
 `
 
 export const SCRIPT = `
   (function () {
     document.addEventListener('click', function (ev) {
       if (ev.target.closest && ev.target.closest('.why a')) return;
+      var arRow = ev.target.closest('.ar-row');
+      if (arRow && arRow.dataset.hash) {
+        ev.stopPropagation();
+        arRow.classList.toggle('open');
+        var pre = arRow.querySelector('.region-preview');
+        if (pre && !pre.dataset.loaded) {
+          var reg = JSON.parse((document.getElementById('region-content') || {}).textContent || '{}');
+          var c = reg[arRow.dataset.hash];
+          pre.textContent = (c != null) ? c : '(内容不可用)';
+          pre.dataset.loaded = '1';
+        }
+        return;
+      }
       var entry = ev.target.closest('.entry');
       if (entry) entry.classList.toggle('open');
       var chip = ev.target.closest('.chip');

--- a/src/trace/render/template.ts
+++ b/src/trace/render/template.ts
@@ -62,6 +62,14 @@ export const STYLES = `
 
 export const SCRIPT = `
   (function () {
+    var _regCache = null;
+    function regOnce() {
+      if (_regCache === null) {
+        var el = document.getElementById('region-content');
+        _regCache = JSON.parse((el && el.textContent) || '{}');
+      }
+      return _regCache;
+    }
     document.addEventListener('click', function (ev) {
       if (ev.target.closest && ev.target.closest('.why a')) return;
       var arRow = ev.target.closest('.ar-row');
@@ -70,9 +78,10 @@ export const SCRIPT = `
         arRow.classList.toggle('open');
         var pre = arRow.querySelector('.region-preview');
         if (pre && !pre.dataset.loaded) {
-          var reg = JSON.parse((document.getElementById('region-content') || {}).textContent || '{}');
+          var reg = regOnce();
           var c = reg[arRow.dataset.hash];
-          pre.textContent = (c != null) ? c : '(内容不可用)';
+          // region-preview only emitted when content is available
+          pre.textContent = (c != null) ? c : '';
           pre.dataset.loaded = '1';
         }
         return;


### PR DESCRIPTION
Closes #26

## Summary

核心静态报告里点 `llm.requested` 能看到 **"Assembled by N regions"**——参与 region 的 metadata + stability 配色 + 内容预览(折叠/全文)+ 同 hash 报告级去重(内联一次 + 复用 ×N)。

- `regionReuseCounts(events)`(`RegionContextView.ts`):报告级 contentHash 引用计数(纯)。
- `renderHtml(events, opts?: { regionContent })`(`html.ts`):llm 条目渲 "Assembled by" 块 + `#region-content` 注册表(内容内联一次,行按 data-hash 懒加载);**renderHtml 保持纯函数**。
- `template.ts`:stability 四档配色 + 预览样式 + 行展开 JS(memoized 注册表解析;点 region 行不误 toggle 父 entry)。
- CLI `trace report`(`cli/main.ts`):从 objectStore hydrate 被引用的 region 内容、传入 renderHtml。`render-html`(无 objectStore)降级 metadata-only。

复用 #23 的 `RegionContextView`(`contextRefsAt`/`hydrateRegionContext`),零新增事件类型、零 schema 变更。

## 范围

- **下沉核心库 + 核心静态报告**(可见效果:`milkie trace report <runId>` 浏览器打开)。
- 示例 app(`examples/agent-docs-qa`)audit panel **本次不动**(复用核心能力为 follow-up)。
- region↔transition 关联仍归 #33/#34;本 PR 只做 llm.requested 的 composition。

## Test Plan

- [x] 全量单测:49 套件 / 451 通过 / 16 skip;`tsc` + `npm run build` 干净
- [x] 单测覆盖:reuse 计数、Assembled-by metadata/stability/data-hash/内容、同 hash 去重(内容内联一次)+ 复用 ×N、无内容降级、无 region、无 contentHash 行、stability 各色、`</script>` 注入转义
- [x] **浏览器实测**:生成真实报告,确认 Assembled-by 渲染、stability 配色、复用标注、点 region 行展开内容预览(懒加载生效、不误 toggle 父 entry)、#33 Why? 块协同正常

## 设计/计划

`docs/superpowers/specs/2026-05-31-region-composition-ui-design.md`、`docs/superpowers/plans/2026-05-31-region-composition-ui.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)