### PR TITLE
feat(#34): why-this-llm-call explainer (pure event-log projection)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-why-this-llm-call.md
+++ b/docs/superpowers/plans/2026-05-31-why-this-llm-call.md
@@ -1,0 +1,388 @@
+# why-this-llm-call explainer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 点 trace 报告里的 `llm.requested` 能读懂"这次 LLM 调用为什么发生"——触发它的 turn 终结事件 + 当时 FSM state + 因果链,纯 event-log 投影,与 #33 平行。
+
+**Architecture:** 新建 `src/trace/diagnostics/`:`fsmStateAt`(折叠 transition 求某时刻 state)+ `explainLlmCall`(核心投影,复用 #33 的 `walkCausedBy`/`summarizeEvent` + #23 的 `contextRefsAt`)。HTML 渲染层给 llm 条目加紧凑 "Why?" 块(复用 #33 的 `.why` 样式 + 事件锚点),与 #26 已有的 "Assembled by" 块并存。零 LLM、零存储、零 schema 变更。
+
+**Tech Stack:** TypeScript;Jest(`npx jest <file>`);现有 `src/trace/diagnostics/{walkCausedBy,summarizeEvent}.ts`、`src/trace/RegionContextView.ts`、`src/trace/render/html.ts`。
+
+参考 spec:`docs/superpowers/specs/2026-05-31-why-this-llm-call-design.md`。**测试运行器是 JEST。**
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `src/trace/diagnostics/fsmStateAt.ts` | 折叠 transition 求某事件时刻的 FSM state | 新建 |
+| `src/trace/diagnostics/explainLlmCall.ts` | 核心投影 + `LlmCallExplanation` 类型 | 新建 |
+| `src/trace/render/html.ts` | llm 条目渲 "Why?" 块(内联调 explainLlmCall) | 修改 |
+| `src/__tests__/fsmStateAt.test.ts` | 单测 | 新建 |
+| `src/__tests__/explainLlmCall.test.ts` | 单测 | 新建 |
+| `src/__tests__/render-html.test.ts` | llm Why? + 并存断言 | 修改 |
+
+> 测试用手工构造的 `Event[]`(纯投影,合成输入最聚焦、确定性最强、天然无 LLM 调用)。
+
+---
+
+## Task 1: fsmStateAt — 某事件时刻的 FSM state
+
+**Files:**
+- Create: `src/trace/diagnostics/fsmStateAt.ts`
+- Test: `src/__tests__/fsmStateAt.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { fsmStateAt } from '../trace/diagnostics/fsmStateAt'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+const trans = (id: string, from: string, to: string) =>
+  ev(id, 'fsm.transition', { from, to, trigger: { domain: 'business', name: 'E' } })
+
+describe('fsmStateAt', () => {
+  it('returns the last transition target before the event', () => {
+    const events: Event[] = [
+      trans('t1', 's0', 's1'),
+      ev('llm', 'llm.requested', {}),
+      trans('t2', 's1', 's2'),
+    ]
+    expect(fsmStateAt(events, 'llm')).toBe('s1')
+  })
+
+  it('returns the initial state (first transition from) when no transition precedes the event', () => {
+    const events: Event[] = [
+      ev('llm', 'llm.requested', {}),
+      trans('t1', 's0', 's1'),
+    ]
+    expect(fsmStateAt(events, 'llm')).toBe('s0')
+  })
+
+  it('returns null when there are no transitions at all', () => {
+    const events: Event[] = [ev('llm', 'llm.requested', {})]
+    expect(fsmStateAt(events, 'llm')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/fsmStateAt.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event, FsmTransitionPayload } from '../types.js'
+
+/**
+ * The FSM state in effect at `eventId`: fold fsm.transition events strictly
+ * before it and take the last `to`. If none precede it, the state is the
+ * initial state — revealed by the `from` of the run's first transition.
+ * Returns null when the run has no transitions at all. Pure.
+ */
+export function fsmStateAt(events: Event[], eventId: string): string | null {
+  const index = events.findIndex(e => e.id === eventId)
+  const cut = index < 0 ? events.length : index
+  let state: string | null = null
+  for (let i = 0; i < cut; i++) {
+    const e = events[i]!
+    if (e.type === 'fsm.transition') state = (e.payload as FsmTransitionPayload).to
+  }
+  if (state !== null) return state
+  const first = events.find(e => e.type === 'fsm.transition')
+  return first ? (first.payload as FsmTransitionPayload).from : null
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/fsmStateAt.test.ts`
+Expected: PASS（3 用例）。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/fsmStateAt.ts src/__tests__/fsmStateAt.test.ts
+git commit -m "feat(#34): fsmStateAt — FSM state in effect at a given event"
+```
+
+---
+
+## Task 2: explainLlmCall — 核心投影
+
+**Files:**
+- Create: `src/trace/diagnostics/explainLlmCall.ts`
+- Test: `src/__tests__/explainLlmCall.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { explainLlmCall } from '../trace/diagnostics/explainLlmCall'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+const region = (id: string, contentHash?: string) =>
+  ev(`add-${id}`, 'region.added', { id, target: 'message', section: 's', stability: 'volatile', reason: 'r', ...(contentHash ? { contentHash } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }),
+    region('header', 'H1'),
+    region('hist', 'H2'),
+    ev('treq', 'tool.requested', { toolName: 'search', input: {} }, 'start'),
+    ev('tres', 'tool.responded', { toolName: 'search', output: {} }, 'treq'),
+    ev('fsm', 'fsm.transition', { from: 'plan', to: 'reflect', trigger: { domain: 'business', name: 'NEXT' } }, 'tres'),
+    ev('llm', 'llm.requested', { model: 'm' }, 'tres'),
+  ]
+}
+
+describe('explainLlmCall', () => {
+  it('projects trigger, fsm state, region count, causal chain and summary (no LLM)', () => {
+    const exp = explainLlmCall(scenario(), 'llm')
+    expect(exp.trigger.causedByEventId).toBe('tres')
+    expect(exp.trigger.causedBySummary).toBe('tool.responded(search)')
+    expect(exp.fsmState).toBe('reflect')          // after fsm plan→reflect, before the llm call
+    expect(exp.regionCount).toBe(2)                // header + hist active
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['llm', 'tres', 'treq', 'start'])
+    expect(exp.summary).toContain('reflect')
+    expect(exp.summary).toContain('tool.responded(search)')
+    expect(exp.summary).toContain('2')
+  })
+
+  it('falls back when there is no upstream trigger and no transitions', () => {
+    const events: Event[] = [ev('llm', 'llm.requested', { model: 'm' })]
+    const exp = explainLlmCall(events, 'llm')
+    expect(exp.trigger.causedByEventId).toBeUndefined()
+    expect(exp.fsmState).toBeNull()
+    expect(exp.regionCount).toBe(0)
+    expect(exp.summary).toContain('(无上游)')
+  })
+
+  it('throws on a non-llm.requested event id', () => {
+    expect(() => explainLlmCall(scenario(), 'fsm')).toThrow(/llm\.requested/)
+  })
+
+  it('throws on an unknown event id', () => {
+    expect(() => explainLlmCall(scenario(), 'nope')).toThrow(/nope/)
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/explainLlmCall.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event, EventKind } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+import { fsmStateAt } from './fsmStateAt.js'
+import { contextRefsAt } from '../RegionContextView.js'
+
+export interface LlmCallExplanation {
+  llmRequestedEventId: string
+  trigger: {
+    causedByEventId?: string
+    causedBySummary?: string
+  }
+  fsmState: string | null
+  regionCount: number
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure event-log projection: explain why a given llm.requested fired — the
+ * turn-terminator that triggered it, the FSM state at the time, how many
+ * regions composed the prompt, and the causal chain. No LLM, no I/O, no
+ * stored snapshot. Returns a plain serializable object (the JSON shape the
+ * CLI explainer #36 will emit). Region details live in #26's "Assembled by".
+ */
+export function explainLlmCall(events: Event[], llmRequestedEventId: string): LlmCallExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(llmRequestedEventId)
+  if (!evt) throw new Error(`explainLlmCall: unknown event id "${llmRequestedEventId}"`)
+  if (evt.type !== 'llm.requested') {
+    throw new Error(`explainLlmCall: event "${llmRequestedEventId}" is "${evt.type}", expected "llm.requested"`)
+  }
+
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const causeSummary = causeEvt ? summarizeEvent(causeEvt) : undefined
+  const fsmState = fsmStateAt(events, llmRequestedEventId)
+  const regionCount = contextRefsAt(events, llmRequestedEventId, 'at').size
+
+  const causalChain = walkCausedBy(events, llmRequestedEventId).map(e => ({
+    eventId: e.id,
+    type:    e.type,
+    summary: summarizeEvent(e),
+  }))
+
+  const triggerSource = causeSummary ?? '(无上游)'
+  const summary = `LLM 调用 @ state ${fsmState ?? '?'},由 ${triggerSource} 触发;prompt 由 ${regionCount} 个 region 拼成`
+
+  return {
+    llmRequestedEventId,
+    trigger: {
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeSummary ? { causedBySummary: causeSummary } : {}),
+    },
+    fsmState,
+    regionCount,
+    causalChain,
+    summary,
+  }
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx jest src/__tests__/explainLlmCall.test.ts`
+Expected: PASS（4 用例）。Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/explainLlmCall.ts src/__tests__/explainLlmCall.test.ts
+git commit -m "feat(#34): explainLlmCall — pure event-log projection of why-this-llm-call"
+```
+
+---
+
+## Task 3: HTML "Why?" 块(llm 条目)
+
+**Files:**
+- Modify: `src/trace/render/html.ts`
+- Test: `src/__tests__/render-html.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`src/__tests__/render-html.test.ts`,复用文件已有 `e({...})` 助手 + `renderHtml`/`Event` 导入)
+
+```ts
+describe('#34 llm Why?', () => {
+  it('renders a Why? block on llm.requested with trigger link, state and causal chain', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 2, causedBy: 'start',
+          payload: { toolName: 'search', input: {}, requestHash: 'h' } }),
+      e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 3, causedBy: 'treq',
+          payload: { toolName: 'search', output: {}, requestHash: 'h' } }),
+      e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 4, causedBy: 'tres',
+          payload: { from: 'plan', to: 'reflect', trigger: { domain: 'business', name: 'NEXT' } } }),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 5, causedBy: 'tres', payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('reflect')                       // fsm state in the why summary
+    expect(html).toContain('tool.responded(search)')        // trigger
+    expect(html).toContain('href="#ev-tres"')               // jump link to the trigger
+  })
+
+  it('shows (未知) state when the run has no transitions', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, causedBy: 'start', payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('(未知)')
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx jest src/__tests__/render-html.test.ts -t "llm Why?"`
+Expected: FAIL。
+
+- [ ] **Step 3: html.ts — 导入 explainLlmCall**
+
+在顶部 import 区(`explainTransition` import 旁)加:
+
+```ts
+import { explainLlmCall, type LlmCallExplanation } from '../diagnostics/explainLlmCall.js'
+```
+
+- [ ] **Step 4: html.ts — renderWhyLlm 助手**
+
+在 `renderEntry` 之前(可放在 `renderWhy` 旁)加。`fsmState` 为 null 时显示 `(未知)`:
+
+```ts
+function renderWhyLlm(exp: LlmCallExplanation): string {
+  const trigger = exp.trigger.causedByEventId
+    ? `<div class="why-trigger">触发: <a href="#ev-${esc(exp.trigger.causedByEventId)}">${esc(exp.trigger.causedBySummary ?? exp.trigger.causedByEventId)}</a></div>`
+    : ''
+  const state = `<div class="why-guards">state: ${esc(exp.fsmState ?? '(未知)')}</div>`
+  const chain = `<div class="why-chain">`
+    + exp.causalChain.map(c => `<a href="#ev-${esc(c.eventId)}">${esc(c.summary)}</a>`).join(' → ')
+    + `</div>`
+  return `<div class="why">`
+       + `<div class="why-summary">${esc(exp.summary)}</div>`
+       + trigger + state + chain
+       + `</div>`
+}
+```
+
+- [ ] **Step 5: html.ts — renderEntry 内联渲染 llm Why?**
+
+在 `renderEntry` 里,`assembled` 那行之后加一行(复用 `regionCtx.events`,无需新参数):
+
+```ts
+  const assembled = entry.kind === 'llm' ? renderAssembled(entry.requestedId, regionCtx) : ''
+  const whyLlm = entry.kind === 'llm' ? renderWhyLlm(explainLlmCall(regionCtx.events, entry.requestedId)) : ''
+```
+
+并在 return 串里把 `whyLlm` 插在 `assembled` 之后、`<pre class="payload">` 之前:
+
+```ts
+       + why
+       + assembled
+       + whyLlm
+       + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
+```
+
+- [ ] **Step 6: 运行,确认通过**
+
+Run: `npx jest src/__tests__/render-html.test.ts && npx jest src/__tests__/render-tree.test.ts`
+Expected: PASS（2 新 #34 用例 + 原有 #26/#33 用例无回归)。Also `npx tsc --noEmit` clean。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add src/trace/render/html.ts src/__tests__/render-html.test.ts
+git commit -m "feat(#34): Why? block on llm.requested — trigger, fsm state, causal chain"
+```
+
+---
+
+## 收尾
+
+- [ ] **全量测试 + 构建**
+
+Run: `npx jest && npm run build`
+Expected: 全绿。
+
+- [ ] **浏览器实测(交付前必做,用户要求)**:用 dist 生成一份含 llm.requested + region + transition 的报告,浏览器打开,确认 llm 条目上 **#26 Assembled-by 与 #34 Why? 两块并存**的实际观感;**据此决定是否需要后续合并两块**(spec §1 留的问题),截图给用户看。
+
+- [ ] **开 PR**:body 带 `Closes #34`;说明与 #33/#26 的复用关系、region 详单归 #26、两块是否合并待实测决定。
+
+---
+
+## Self-Review(plan 作者已核对)
+
+**Spec 覆盖:** §4.1 fsmStateAt → Task 1 ✓ §4.2 explainLlmCall → Task 2 ✓ §5 llm Why? 渲染 → Task 3 ✓ §6 错误处理(抛错/无上游/无 transition)→ Task 2 测试二三四 + Task 3 测试二 ✓ §7 测试 → 各任务 ✓ §9 验收 → Task 2+3 ✓。region 详单复用 #26、不重复 → Task 3 只渲 trigger+state+chain ✓。
+
+**占位扫描:** 无 TBD/TODO;改代码步骤均含完整代码。
+
+**类型一致性:** `LlmCallExplanation { llmRequestedEventId, trigger:{causedByEventId?,causedBySummary?}, fsmState, regionCount, causalChain, summary }`(Task 2 定义)在 Task 3 `renderWhyLlm` 引用一致;`fsmStateAt(events,id): string|null`(Task 1)在 Task 2 调用一致;`walkCausedBy`/`summarizeEvent`/`contextRefsAt` 取自现有模块;`explainLlmCall(events,id)` 在 Task 3 内联调用一致。

--- a/docs/superpowers/specs/2026-05-31-why-this-llm-call-design.md
+++ b/docs/superpowers/specs/2026-05-31-why-this-llm-call-design.md
@@ -1,0 +1,108 @@
+# #34 why-this-llm-call explainer — 设计 spec
+
+**Issue:** #34（diagnosable P1;依赖 #26 / #30,均已落地;Parent #20;Stories s-003 平行)
+**日期:** 2026-05-31
+**定位:** 点 `llm.requested` 解释"这次 LLM 调用为什么发生"——触发它的 turn 终结事件 + 当时 FSM state + 因果链。**纯 event-log 投影,零 LLM、零存储、零 schema 变更。** 与 #33 平行、共享 explainer 层。
+
+---
+
+## 1. 目标与范围
+
+#33 解决了"为什么这次 transition";本 issue 平行解决"为什么这次 LLM 调用"。点 `llm.requested`,Why? 块展开:
+- **触发它的 turn 终结事件**(上一个 tool.responded,或 run 起点)——来自 `causedBy`(#30 edge 2);
+- **当时 FSM state**——折叠该调用之前的 `fsm.transition`;
+- **因果链**——`walkCausedBy`。
+
+**交付面**(已确认):**互补两块**——region composition 详单仍由 **#26 已有的 "Assembled by" 块**承担,本 issue 只加紧凑 Why? 块(触发 + state + 因果链 + 一句"N regions")。两块叠在同一 llm 条目上,**实现后浏览器实测,若显碎再小 follow-up 合并**。
+
+## 2. Non-goals
+
+- **不重复 region 详单**:Assembled-by(#26)已渲染;Why? 只说"prompt 由 N region 拼成",详见上方。
+- **不调 LLM、零存储、零新事件类型、零 schema 变更**:纯只读投影。
+- **不做 CLI**:`explainLlmCall` 返回可序列化对象,供 #36 复用;CLI 本身是 #36。
+- **不动 #26 的 Assembled-by 渲染**(除非实测后决定合并,届时单独 follow-up)。
+
+## 3. 数据齐备性(全部已落地)
+
+| 解释要素 | 来源 | 谁存的 |
+|---|---|---|
+| 触发的 turn 终结事件 | `llm.requested` 的 `causedBy` | #30(edge 2:`lastTerminatorId` = 上一个 tool.responded,或 seed 的 agent.run.started) |
+| 当时 FSM state | 折叠 `fsm.transition` 事件(新 helper) | #21(transition 事件) |
+| 参与 region 数 | `contextRefsAt(events, id, 'at').size` | #23/#26 |
+| 因果链 | `walkCausedBy` | #30 + #33 |
+
+## 4. 架构:`src/trace/diagnostics/`(复用 #33 层)
+
+两个纯函数,只吃内存 `Event[]`,零 I/O。
+
+### 4.1 `fsmStateAt(events, eventId): string | null`
+
+- 文件:`src/trace/diagnostics/fsmStateAt.ts`
+- 折叠 `eventId` **之前**(不含)的 `fsm.transition`,返回最后一次的 `to`(= 当时所处 state)。
+- 若之前无 transition:返回**全局第一个** `fsm.transition` 的 `from`(= 初始态,即该调用所处态);若全程无任何 transition → `null`(未知)。
+- 纯函数。可复用(#36 / 未来 swimlane #28)。
+
+### 4.2 `explainLlmCall(events, llmRequestedEventId): LlmCallExplanation`
+
+- 文件:`src/trace/diagnostics/explainLlmCall.ts`
+- 输出(普通可序列化对象,亦为 #36 CLI 的 JSON 形状):
+
+```ts
+export interface LlmCallExplanation {
+  llmRequestedEventId: string
+  trigger: {
+    causedByEventId?: string                  // = 该 llm.requested 的 causedBy
+    causedBySummary?: string                  // summarizeEvent(那条上游事件)
+  }
+  fsmState: string | null                     // fsmStateAt 结果
+  regionCount: number                         // contextRefsAt(events, id, 'at').size
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string                             // 模板拼接,无 LLM
+}
+```
+
+- **行为**:
+  - 找到 id 对应事件;不存在或 `type !== 'llm.requested'` → 抛 `Error`(消息含 id 与实际 type)。
+  - `trigger.causedByEventId` = 事件 `causedBy`;`causedBySummary` = 该上游事件经 `summarizeEvent`。
+  - `fsmState` = `fsmStateAt(events, id)`;`regionCount` = `contextRefsAt(events, id, 'at').size`。
+  - `causalChain` = `walkCausedBy(events, id).map(...)`(复用 #33)。
+  - `summary` 模板(纯数据,示例):`"LLM 调用 @ state {fsmState|'?'},由 {causedBySummary|'(无上游)'} 触发;prompt 由 {regionCount} 个 region 拼成"`。
+- 复用 `summarizeEvent`(#33);无重复造轮子。
+
+## 5. UI:llm 条目加紧凑 "Why?" 块(`src/trace/render/html.ts`)
+
+- 对 `kind:'llm'` 条目,在现有 #26 "Assembled by" 块**之后**加一个 Why? 块(由 `explainLlmCall` 投影):摘要、触发(带 `#ev-` 锚点跳转)、state、因果链(每跳一个链接)。
+- **复用 #33 的 `.why` 样式与事件锚点**(`id="ev-..."` 已由 #33 落地)。region 详单不重复(只在摘要里说 "N region",详见上方 Assembled-by)。
+- renderHtml 已持有全部 `Event[]` 与现有 explanations 机制;为 llm 条目预算 `explainLlmCall`(类比 #33 fsm 的 explanations map)。
+- `fsmState` 为 null → state 行显示 "(未知)"(不省略,保持块结构一致)。
+
+## 6. 错误处理 / 边界
+
+- `explainLlmCall`:未知 id / 非 llm.requested → 抛 `Error`。
+- 无 causedBy(理论上首个 llm 也 seed 到 run.started;防御)→ trigger 字段省略,摘要降级 "(无上游)"。
+- 无任何 transition → `fsmState: null` → UI "(未知)"。
+- 渲染层只对 `kind:'llm'` 调用,不触发抛错路径。
+
+## 7. 测试
+
+- **`fsmStateAt`**:① 之前有 transition → last `to`;② 之前无、之后有 → 初始态(首个 transition 的 `from`);③ 全程无 transition → null。
+- **`explainLlmCall`**:trigger(causedBy + summary)、fsmState、regionCount、causalChain(每 id 可解析)、summary 含关键字段正确;非 llm.requested id → 抛错;无 LLM 调用(合成事件)。
+- **渲染**:llm 条目出 Why? 块、摘要、`#ev-` 锚点链接、state 行;与 #26 Assembled-by 并存(同条目两块都在);fsmState null → "(未知)"。
+
+## 8. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/diagnostics/fsmStateAt.ts` | 新建:折叠 transition 求某时刻 state |
+| `src/trace/diagnostics/explainLlmCall.ts` | 新建:核心投影 + `LlmCallExplanation` 类型 |
+| `src/trace/render/html.ts` | llm 条目渲 Why? 块(复用 .why 样式 + 锚点);renderHtml 预算 explainLlmCall |
+| `src/__tests__/fsmStateAt.test.ts` | 新建 |
+| `src/__tests__/explainLlmCall.test.ts` | 新建 |
+| `src/__tests__/render-html.test.ts` | llm Why? 块 + 并存断言 |
+
+## 9. 验收对照(#34)
+
+- [x] 任一 llm.requested 的 "Why?" 给出 "composition + 触发上下文" → Why?(触发+state+因果链+N regions)+ 共存的 #26 Assembled-by(composition 详单)
+- [x] 不依赖运行时副本 → 纯 `Event[]` 投影,零存储
+- [x] 与 #33 风格一致 → 复用 walkCausedBy/summarizeEvent/.why 样式/锚点
+- 附:region 详单复用 #26;两块是否合并 → 实现后浏览器实测再定

--- a/src/__tests__/explainLlmCall.test.ts
+++ b/src/__tests__/explainLlmCall.test.ts
@@ -37,7 +37,16 @@ describe('explainLlmCall', () => {
     expect(exp.trigger.causedByEventId).toBeUndefined()
     expect(exp.fsmState).toBeNull()
     expect(exp.regionCount).toBe(0)
-    expect(exp.summary).toContain('(无上游)')
+    expect(exp.summary).toContain('(无上游记录)')
+  })
+
+  it('handles a dangling causedBy: keeps causedByEventId, omits causedBySummary, falls back in summary', () => {
+    const events: Event[] = [ev('llm', 'llm.requested', { model: 'm' }, 'missing')]
+    const exp = explainLlmCall(events, 'llm')
+    expect(exp.trigger.causedByEventId).toBe('missing')
+    expect(exp.trigger.causedBySummary).toBeUndefined()
+    expect(exp.summary).toContain('(无上游记录)')
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['llm'])
   })
 
   it('throws on a non-llm.requested event id', () => {

--- a/src/__tests__/explainLlmCall.test.ts
+++ b/src/__tests__/explainLlmCall.test.ts
@@ -1,0 +1,50 @@
+import { explainLlmCall } from '../trace/diagnostics/explainLlmCall'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+const region = (id: string, contentHash?: string) =>
+  ev(`add-${id}`, 'region.added', { id, target: 'message', section: 's', stability: 'volatile', reason: 'r', ...(contentHash ? { contentHash } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }),
+    region('header', 'H1'),
+    region('hist', 'H2'),
+    ev('treq', 'tool.requested', { toolName: 'search', input: {} }, 'start'),
+    ev('tres', 'tool.responded', { toolName: 'search', output: {} }, 'treq'),
+    ev('fsm', 'fsm.transition', { from: 'plan', to: 'reflect', trigger: { domain: 'business', name: 'NEXT' } }, 'tres'),
+    ev('llm', 'llm.requested', { model: 'm' }, 'tres'),
+  ]
+}
+
+describe('explainLlmCall', () => {
+  it('projects trigger, fsm state, region count, causal chain and summary (no LLM)', () => {
+    const exp = explainLlmCall(scenario(), 'llm')
+    expect(exp.trigger.causedByEventId).toBe('tres')
+    expect(exp.trigger.causedBySummary).toBe('tool.responded(search)')
+    expect(exp.fsmState).toBe('reflect')
+    expect(exp.regionCount).toBe(2)
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['llm', 'tres', 'treq', 'start'])
+    expect(exp.summary).toContain('reflect')
+    expect(exp.summary).toContain('tool.responded(search)')
+    expect(exp.summary).toContain('2')
+  })
+
+  it('falls back when there is no upstream trigger and no transitions', () => {
+    const events: Event[] = [ev('llm', 'llm.requested', { model: 'm' })]
+    const exp = explainLlmCall(events, 'llm')
+    expect(exp.trigger.causedByEventId).toBeUndefined()
+    expect(exp.fsmState).toBeNull()
+    expect(exp.regionCount).toBe(0)
+    expect(exp.summary).toContain('(无上游)')
+  })
+
+  it('throws on a non-llm.requested event id', () => {
+    expect(() => explainLlmCall(scenario(), 'fsm')).toThrow(/llm\.requested/)
+  })
+
+  it('throws on an unknown event id', () => {
+    expect(() => explainLlmCall(scenario(), 'nope')).toThrow(/nope/)
+  })
+})

--- a/src/__tests__/fsmStateAt.test.ts
+++ b/src/__tests__/fsmStateAt.test.ts
@@ -1,0 +1,31 @@
+import { fsmStateAt } from '../trace/diagnostics/fsmStateAt'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload })
+const trans = (id: string, from: string, to: string) =>
+  ev(id, 'fsm.transition', { from, to, trigger: { domain: 'business', name: 'E' } })
+
+describe('fsmStateAt', () => {
+  it('returns the last transition target before the event', () => {
+    const events: Event[] = [
+      trans('t1', 's0', 's1'),
+      ev('llm', 'llm.requested', {}),
+      trans('t2', 's1', 's2'),
+    ]
+    expect(fsmStateAt(events, 'llm')).toBe('s1')
+  })
+
+  it('returns the initial state (first transition from) when no transition precedes the event', () => {
+    const events: Event[] = [
+      ev('llm', 'llm.requested', {}),
+      trans('t1', 's0', 's1'),
+    ]
+    expect(fsmStateAt(events, 'llm')).toBe('s0')
+  })
+
+  it('returns null when there are no transitions at all', () => {
+    const events: Event[] = [ev('llm', 'llm.requested', {})]
+    expect(fsmStateAt(events, 'llm')).toBeNull()
+  })
+})

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -186,6 +186,27 @@ describe('#34 llm Why?', () => {
     expect(html).not.toContain('触发:')              // no trigger line when no causedBy
     expect(html).toContain('class="why-state"')      // state line present
   })
+
+  it('renders both the #26 Assembled-by block and the #34 Why? block on the same llm entry', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'add-header', runId: 'r1', type: 'region.added', timestamp: 2,
+          payload: { id: 'header', target: 'message', section: 'history', stability: 'immutable', reason: 'agent-set', contentHash: 'H1' } }),
+      e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 3, causedBy: 'start',
+          payload: { toolName: 'search', input: {}, requestHash: 'h' } }),
+      e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 4, causedBy: 'treq',
+          payload: { toolName: 'search', output: {}, requestHash: 'h' } }),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 5, causedBy: 'tres', payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events, { regionContent: new Map([['H1', 'SYSTEM PROMPT']]) })
+    // #26 Assembled-by present
+    expect(html).toContain('Assembled by')
+    expect(html).toContain('header')
+    // #34 Why? present on the same run/entry
+    expect(html).toContain('class="why"')
+    expect(html).toContain('tool.responded(search)')
+  })
 })
 
 describe('#26 Assembled by', () => {

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -175,6 +175,17 @@ describe('#34 llm Why?', () => {
     expect(html).toContain('class="why"')
     expect(html).toContain('(未知)')
   })
+
+  it('renders a Why? block for an llm.requested with no upstream trigger (no broken link)', () => {
+    const events: Event[] = [
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 1, payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).not.toContain('href="#ev-undefined"')
+    expect(html).not.toContain('触发:')              // no trigger line when no causedBy
+    expect(html).toContain('class="why-state"')      // state line present
+  })
 })
 
 describe('#26 Assembled by', () => {

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -145,6 +145,38 @@ describe('renderHtml', () => {
   })
 })
 
+describe('#34 llm Why?', () => {
+  it('renders a Why? block on llm.requested with trigger link, state and causal chain', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 2, causedBy: 'start',
+          payload: { toolName: 'search', input: {}, requestHash: 'h' } }),
+      e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 3, causedBy: 'treq',
+          payload: { toolName: 'search', output: {}, requestHash: 'h' } }),
+      e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 4, causedBy: 'tres',
+          payload: { from: 'plan', to: 'reflect', trigger: { domain: 'business', name: 'NEXT' } } }),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 5, causedBy: 'tres', payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('reflect')
+    expect(html).toContain('tool.responded(search)')
+    expect(html).toContain('href="#ev-tres"')
+  })
+
+  it('shows (未知) state when the run has no transitions', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'llm', runId: 'r1', type: 'llm.requested', timestamp: 2, causedBy: 'start', payload: { model: 'm' } }),
+    ]
+    const html = renderHtml(events)
+    expect(html).toContain('class="why"')
+    expect(html).toContain('(未知)')
+  })
+})
+
 describe('#26 Assembled by', () => {
   const region = (id: string, stability: string, contentHash?: string) =>
     e({ id: `add-${id}`, runId: 'r1', type: 'region.added', timestamp: 1,

--- a/src/trace/diagnostics/explainLlmCall.ts
+++ b/src/trace/diagnostics/explainLlmCall.ts
@@ -1,0 +1,61 @@
+import type { Event, EventKind } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+import { fsmStateAt } from './fsmStateAt.js'
+import { contextRefsAt } from '../RegionContextView.js'
+
+export interface LlmCallExplanation {
+  llmRequestedEventId: string
+  trigger: {
+    causedByEventId?: string
+    causedBySummary?: string
+  }
+  fsmState: string | null
+  regionCount: number
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure event-log projection: explain why a given llm.requested fired — the
+ * turn-terminator that triggered it, the FSM state at the time, how many
+ * regions composed the prompt, and the causal chain. No LLM, no I/O, no
+ * stored snapshot. Returns a plain serializable object (the JSON shape the
+ * CLI explainer #36 will emit). Region details live in #26's "Assembled by".
+ */
+export function explainLlmCall(events: Event[], llmRequestedEventId: string): LlmCallExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(llmRequestedEventId)
+  if (!evt) throw new Error(`explainLlmCall: unknown event id "${llmRequestedEventId}"`)
+  if (evt.type !== 'llm.requested') {
+    throw new Error(`explainLlmCall: event "${llmRequestedEventId}" is "${evt.type}", expected "llm.requested"`)
+  }
+
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const causeSummary = causeEvt ? summarizeEvent(causeEvt) : undefined
+  const fsmState = fsmStateAt(events, llmRequestedEventId)
+  const regionCount = contextRefsAt(events, llmRequestedEventId, 'at').size
+
+  const causalChain = walkCausedBy(events, llmRequestedEventId).map(e => ({
+    eventId: e.id,
+    type:    e.type,
+    summary: summarizeEvent(e),
+  }))
+
+  const triggerSource = causeSummary ?? '(无上游)'
+  const summary = `LLM 调用 @ state ${fsmState ?? '?'},由 ${triggerSource} 触发;prompt 由 ${regionCount} 个 region 拼成`
+
+  return {
+    llmRequestedEventId,
+    trigger: {
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeSummary ? { causedBySummary: causeSummary } : {}),
+    },
+    fsmState,
+    regionCount,
+    causalChain,
+    summary,
+  }
+}

--- a/src/trace/diagnostics/explainLlmCall.ts
+++ b/src/trace/diagnostics/explainLlmCall.ts
@@ -44,7 +44,7 @@ export function explainLlmCall(events: Event[], llmRequestedEventId: string): Ll
     summary: summarizeEvent(e),
   }))
 
-  const triggerSource = causeSummary ?? '(无上游)'
+  const triggerSource = causeSummary ?? '(无上游记录)'
   const summary = `LLM 调用 @ state ${fsmState ?? '?'},由 ${triggerSource} 触发;prompt 由 ${regionCount} 个 region 拼成`
 
   return {

--- a/src/trace/diagnostics/fsmStateAt.ts
+++ b/src/trace/diagnostics/fsmStateAt.ts
@@ -1,0 +1,20 @@
+import type { Event, FsmTransitionPayload } from '../types.js'
+
+/**
+ * The FSM state in effect at `eventId`: fold fsm.transition events strictly
+ * before it and take the last `to`. If none precede it, the state is the
+ * initial state — revealed by the `from` of the run's first transition.
+ * Returns null when the run has no transitions at all. Pure.
+ */
+export function fsmStateAt(events: Event[], eventId: string): string | null {
+  const index = events.findIndex(e => e.id === eventId)
+  const cut = index < 0 ? events.length : index
+  let state: string | null = null
+  for (let i = 0; i < cut; i++) {
+    const e = events[i]!
+    if (e.type === 'fsm.transition') state = (e.payload as FsmTransitionPayload).to
+  }
+  if (state !== null) return state
+  const first = events.find(e => e.type === 'fsm.transition')
+  return first ? (first.payload as FsmTransitionPayload).from : null
+}

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -76,7 +76,7 @@ function renderWhyLlm(exp: LlmCallExplanation): string {
   const trigger = exp.trigger.causedByEventId
     ? `<div class="why-trigger">触发: <a href="#ev-${esc(exp.trigger.causedByEventId)}">${esc(exp.trigger.causedBySummary ?? exp.trigger.causedByEventId)}</a></div>`
     : ''
-  const state = `<div class="why-guards">state: ${esc(exp.fsmState ?? '(未知)')}</div>`
+  const state = `<div class="why-state">state: ${esc(exp.fsmState ?? '(未知)')}</div>`
   const chain = `<div class="why-chain">`
     + exp.causalChain.map(c => `<a href="#ev-${esc(c.eventId)}">${esc(c.summary)}</a>`).join(' → ')
     + `</div>`

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -2,6 +2,7 @@ import type { Event } from '../types.js'
 import { buildTimelineTree, type TimelineEntry, type TimelineNode } from './tree.js'
 import { STYLES, SCRIPT } from './template.js'
 import { explainTransition, type TransitionExplanation } from '../diagnostics/explainTransition.js'
+import { explainLlmCall, type LlmCallExplanation } from '../diagnostics/explainLlmCall.js'
 import { contextRefsAt, regionReuseCounts, type RegionContentRef } from '../RegionContextView.js'
 
 interface RegionCtx {
@@ -71,6 +72,20 @@ function renderWhy(exp: TransitionExplanation): string {
        + `</div>`
 }
 
+function renderWhyLlm(exp: LlmCallExplanation): string {
+  const trigger = exp.trigger.causedByEventId
+    ? `<div class="why-trigger">触发: <a href="#ev-${esc(exp.trigger.causedByEventId)}">${esc(exp.trigger.causedBySummary ?? exp.trigger.causedByEventId)}</a></div>`
+    : ''
+  const state = `<div class="why-guards">state: ${esc(exp.fsmState ?? '(未知)')}</div>`
+  const chain = `<div class="why-chain">`
+    + exp.causalChain.map(c => `<a href="#ev-${esc(c.eventId)}">${esc(c.summary)}</a>`).join(' → ')
+    + `</div>`
+  return `<div class="why">`
+       + `<div class="why-summary">${esc(exp.summary)}</div>`
+       + trigger + state + chain
+       + `</div>`
+}
+
 function renderAssembled(requestedId: string, ctx: RegionCtx): string {
   const refs: RegionContentRef[] = [...contextRefsAt(ctx.events, requestedId, 'at').values()]
   if (refs.length === 0) return ''
@@ -108,6 +123,7 @@ function renderEntry(
     ? renderWhy(explanations.get(entry.eventId)!)
     : ''
   const assembled = entry.kind === 'llm' ? renderAssembled(entry.requestedId, regionCtx) : ''
+  const whyLlm = entry.kind === 'llm' ? renderWhyLlm(explainLlmCall(regionCtx.events, entry.requestedId)) : ''
   return `<div class="entry ${entry.kind}" data-kind="${entry.kind}" id="ev-${esc(primaryId)}">`
        + extraAnchors
        + `<div class="entry-head">`
@@ -117,6 +133,7 @@ function renderEntry(
        + `</div>`
        + why
        + assembled
+       + whyLlm
        + `<pre class="payload">${payloadFor(entry, eventById)}</pre>`
        + `</div>`
 }

--- a/src/trace/render/template.ts
+++ b/src/trace/render/template.ts
@@ -37,7 +37,7 @@ export const STYLES = `
   .why { margin: 4px 0 4px 22px; padding: 6px 10px; border-left: 3px solid #6b8;
          background: rgba(0,0,0,0.03); font-size: 12px; line-height: 1.5; }
   .why-summary { font-weight: 600; margin-bottom: 2px; }
-  .why-trigger, .why-guards { color: #444; }
+  .why-trigger, .why-guards, .why-state { color: #444; }
   .why-chain { margin-top: 3px; color: #666; word-break: break-word; }
   .why a { color: #36a; text-decoration: none; }
   .why a:hover { text-decoration: underline; }


### PR DESCRIPTION
Closes #34

## Summary

点 trace 报告里的 `llm.requested` 能读懂"这次 LLM 调用为什么发生"——触发它的 turn 终结事件 + 当时 FSM state + 因果链。**纯 event-log 投影:零 LLM、零存储、零 schema 变更**。与 #33 平行、共享 explainer 层。

- `fsmStateAt(events, id)`(`diagnostics/`):折叠 `fsm.transition` 求某时刻 FSM state(纯,#36/#28 也可复用)。
- `explainLlmCall(events, id)`(`diagnostics/`):核心投影,返回可序列化 `LlmCallExplanation`(也是 #36 CLI 的 JSON 形状);复用 #33 的 `walkCausedBy`/`summarizeEvent` + #23 的 `contextRefsAt`。
- `html.ts`:llm 条目加紧凑 "Why?" 块(触发链接 + state + 因果链),复用 #33 `.why` 样式 + 锚点,与 #26 "Assembled by" 块并存。

## 设计决策(浏览器实测后定)

- **互补两块,保持分离**:实测确认 Assembled-by(prompt 里有什么)与 Why?(为什么来 + state + 链)视觉清晰、互补可读,**不合并**。
- region 详单归 #26;Why? 只述 region 数(该数同时是 #36 CLI 契约)。

## Test Plan

- [x] 全量单测:51 套件 / 462 通过 / 16 skip;`tsc` + `npm run build` 干净
- [x] `fsmStateAt`(前有 transition/初始态/无 transition)、`explainLlmCall`(投影/dangling causedBy/无 transition/抛错)、render(触发链接+state+链、(未知)、无 trigger 不断链、**#26+#34 并存**)
- [x] **浏览器实测**:生成真实报告,确认 llm 条目 Assembled-by + Why? 两块并存观感、state/触发/因果链正确、#33 fsm Why? 协同

## 设计/计划

`docs/superpowers/specs/2026-05-31-why-this-llm-call-design.md`、`docs/superpowers/plans/2026-05-31-why-this-llm-call.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)