### PR TITLE
feat(#64): causal drill-down trace viewer (decision spine + Why panel)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-trace-viewer.md
+++ b/docs/superpowers/plans/2026-05-31-trace-viewer.md
@@ -1,0 +1,635 @@
+# 因果下钻 trace viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `milkie trace report` 从平铺时间线重组成"决策脊柱 + Why 面板 + 点击下钻"的诊断 viewer,纯静态自包含 HTML,"两次点击到根因"。
+
+**Architecture:** 纯投影 `buildDecisionSpine`(events→决策脊柱,含"最近决策祖先"`causeDecisionId`)+ `explainToolCall`;复用 explainTransition/explainLlmCall/contextRefsAt/walkCausedBy。`viewer.ts` 出两栏 HTML + 内嵌全部 explanation JSON,vanilla JS 纯查表做选中/下钻/高亮;raw 全时间线作次要 tab(复用从 html.ts 抽出的 `renderTimelineSections`)。
+
+**Tech Stack:** TypeScript;Jest(`npx jest`);dev-browser(交互验收);现有 `src/trace/diagnostics/*`、`src/trace/RegionContextView.ts`、`src/trace/render/html.ts`、`src/cli/main.ts`。
+
+参考 spec:`docs/superpowers/specs/2026-05-31-trace-viewer-design.md`。**测试运行器是 JEST。**
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `src/trace/diagnostics/buildDecisionSpine.ts` | events→决策脊柱(+causeDecisionId) | 新建 |
+| `src/trace/diagnostics/explainToolCall.ts` | 工具节点投影 | 新建 |
+| `src/trace/render/html.ts` | 抽出 `renderTimelineSections`,`renderHtml` 改为薄包装 | 重构 |
+| `src/trace/render/viewer.ts` | 两栏 viewer HTML + 内嵌数据 + raw tab | 新建 |
+| `src/trace/render/viewer-template.ts` | viewer CSS + vanilla JS | 新建 |
+| `src/cli/main.ts` | `trace report` 改用 `renderViewer` | 改 |
+| `src/__tests__/buildDecisionSpine.test.ts` `explainToolCall.test.ts` `render-viewer.test.ts` | 单测 | 新建 |
+
+---
+
+## Task 1: buildDecisionSpine — 决策脊柱投影
+
+**Files:** Create `src/trace/diagnostics/buildDecisionSpine.ts`; Test `src/__tests__/buildDecisionSpine.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { buildDecisionSpine } from '../trace/diagnostics/buildDecisionSpine'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string, ts = 0): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: ts, payload, ...(causedBy ? { causedBy } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }, undefined, 1),
+    ev('llm1', 'llm.requested', { model: 'm' }, 'start', 2),
+    ev('lr1', 'llm.responded', {}, 'llm1', 3),
+    ev('treq', 'tool.requested', { toolName: 'classify_intent', input: {} }, 'lr1', 4),
+    ev('tres', 'tool.responded', { toolName: 'classify_intent', output: {} }, 'treq', 5),
+    ev('fsm', 'fsm.transition', { from: 'classify', to: 'handle', trigger: { domain: 'business', name: 'GO' } }, 'tres', 6),
+    ev('done', 'agent.run.completed', { status: 'completed', lastTextOutput: 'ok' }, 'fsm', 7),
+  ]
+}
+
+describe('buildDecisionSpine', () => {
+  it('keeps only decision nodes in timestamp order with labels', () => {
+    const spine = buildDecisionSpine(scenario())
+    expect(spine.nodes.map(n => [n.kind, n.eventId])).toEqual([
+      ['llm', 'llm1'], ['tool', 'treq'], ['transition', 'fsm'], ['output', 'done'],
+    ])
+    expect(spine.nodes.find(n => n.eventId === 'treq')!.label).toBe('tool: classify_intent')
+    expect(spine.nodes.find(n => n.eventId === 'fsm')!.label).toBe('classify → handle')
+  })
+
+  it('resolves causeDecisionId to the nearest decision ancestor (skipping non-decision causes)', () => {
+    const spine = buildDecisionSpine(scenario())
+    // fsm.causedBy = tres (tool.responded, NOT a spine node) → nearest decision ancestor = treq (tool.requested)
+    expect(spine.nodes.find(n => n.eventId === 'fsm')!.causeDecisionId).toBe('treq')
+    // done.causedBy = fsm (a decision) → causeDecisionId = fsm
+    expect(spine.nodes.find(n => n.eventId === 'done')!.causeDecisionId).toBe('fsm')
+    // llm1.causedBy = start (run.started, not a spine node, no decision ancestor) → undefined
+    expect(spine.nodes.find(n => n.eventId === 'llm1')!.causeDecisionId).toBeUndefined()
+  })
+
+  it('returns empty spine for a run with no decisions', () => {
+    expect(buildDecisionSpine([ev('s', 'agent.run.started', {})]).nodes).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败** — `npx jest src/__tests__/buildDecisionSpine.test.ts` → FAIL
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+
+export type DecisionKind = 'llm' | 'tool' | 'transition' | 'output'
+
+export interface DecisionNode {
+  eventId:          string
+  kind:             DecisionKind
+  label:            string
+  timestamp:        number
+  causedByEventId?: string
+  causeDecisionId?: string
+}
+
+export interface DecisionSpine {
+  nodes: DecisionNode[]
+}
+
+const SPINE_TYPES = new Set(['llm.requested', 'tool.requested', 'fsm.transition', 'agent.run.completed'])
+
+function kindOf(type: string): DecisionKind {
+  if (type === 'llm.requested')  return 'llm'
+  if (type === 'tool.requested') return 'tool'
+  if (type === 'fsm.transition') return 'transition'
+  return 'output'
+}
+
+function labelOf(e: Event): string {
+  if (e.type === 'llm.requested')  return 'LLM call'
+  if (e.type === 'tool.requested') return `tool: ${String((e.payload as { toolName?: unknown }).toolName ?? '?')}`
+  if (e.type === 'fsm.transition') { const p = e.payload as { from: string; to: string }; return `${p.from} → ${p.to}` }
+  return '输出'
+}
+
+/**
+ * Project the event log down to the decision spine: only LLM calls, tool
+ * calls, transitions, and the final output, in timestamp order. For each node,
+ * causeDecisionId is the nearest decision ancestor reached by walking causedBy
+ * (skipping non-decision causes like tool.responded / run.started). Pure.
+ */
+export function buildDecisionSpine(events: Event[]): DecisionSpine {
+  const spineIds = new Set(events.filter(e => SPINE_TYPES.has(e.type)).map(e => e.id))
+  const nodes: DecisionNode[] = events
+    .filter(e => SPINE_TYPES.has(e.type))
+    .map(e => {
+      // walkCausedBy returns [e, cause, ...]; the first ancestor (excluding e) that is itself a spine node.
+      const ancestor = walkCausedBy(events, e.id).slice(1).find(a => spineIds.has(a.id))
+      return {
+        eventId:   e.id,
+        kind:      kindOf(e.type),
+        label:     labelOf(e),
+        timestamp: e.timestamp,
+        ...(e.causedBy ? { causedByEventId: e.causedBy } : {}),
+        ...(ancestor ? { causeDecisionId: ancestor.id } : {}),
+      }
+    })
+    .sort((a, b) => a.timestamp - b.timestamp)
+  return { nodes }
+}
+```
+
+- [ ] **Step 4: 运行,确认通过** — `npx jest src/__tests__/buildDecisionSpine.test.ts` → PASS(3);`npx tsc --noEmit` clean
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/buildDecisionSpine.ts src/__tests__/buildDecisionSpine.test.ts
+git commit -m "feat(#64): buildDecisionSpine — project events to the decision spine with nearest-decision-ancestor"
+```
+
+---
+
+## Task 2: explainToolCall — 工具节点投影
+
+**Files:** Create `src/trace/diagnostics/explainToolCall.ts`; Test `src/__tests__/explainToolCall.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { explainToolCall } from '../trace/diagnostics/explainToolCall'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', {}),
+    ev('lr1', 'llm.responded', {}, 'start'),
+    ev('treq', 'tool.requested', { toolName: 'search', input: { q: 'x' }, requestHash: 'h' }, 'lr1'),
+    ev('tres', 'tool.responded', { toolName: 'search', output: { hits: 3 }, requestHash: 'h' }, 'treq'),
+  ]
+}
+
+describe('explainToolCall', () => {
+  it('projects toolName, input, paired output, trigger and causal chain', () => {
+    const exp = explainToolCall(scenario(), 'treq')
+    expect(exp.toolName).toBe('search')
+    expect(exp.input).toEqual({ q: 'x' })
+    expect(exp.output).toEqual({ hits: 3 })
+    expect(exp.trigger.causedByEventId).toBe('lr1')
+    expect(exp.trigger.causedBySummary).toBe('llm.responded')
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['treq', 'lr1', 'start'])
+    expect(exp.summary).toContain('search')
+  })
+
+  it('omits output when there is no paired tool.responded', () => {
+    const events: Event[] = [ev('treq', 'tool.requested', { toolName: 'search', input: {} })]
+    expect(explainToolCall(events, 'treq').output).toBeUndefined()
+  })
+
+  it('throws on a non-tool.requested event id', () => {
+    expect(() => explainToolCall(scenario(), 'tres')).toThrow(/tool\.requested/)
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败** — FAIL
+
+- [ ] **Step 3: 实现**
+
+```ts
+import type { Event, EventKind } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+
+export interface ToolCallExplanation {
+  toolRequestedEventId: string
+  toolName: string
+  input: unknown
+  output?: unknown
+  trigger: { causedByEventId?: string; causedBySummary?: string }
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure projection: explain a tool call — its name/input, the paired output,
+ * which llm.responded decided to call it, and the causal chain. No LLM/I/O.
+ * Region/CLI #36 reuse the serializable result. Parallel to explainLlmCall.
+ */
+export function explainToolCall(events: Event[], toolRequestedEventId: string): ToolCallExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(toolRequestedEventId)
+  if (!evt) throw new Error(`explainToolCall: unknown event id "${toolRequestedEventId}"`)
+  if (evt.type !== 'tool.requested') {
+    throw new Error(`explainToolCall: event "${toolRequestedEventId}" is "${evt.type}", expected "tool.requested"`)
+  }
+
+  const p = evt.payload as { toolName?: unknown; input?: unknown; requestHash?: unknown }
+  const toolName = String(p.toolName ?? '?')
+  const responded = events.find(e =>
+    e.type === 'tool.responded' && (e.payload as { requestHash?: unknown }).requestHash === p.requestHash)
+  const output = responded ? (responded.payload as { output?: unknown }).output : undefined
+
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const causeSummary = causeEvt ? summarizeEvent(causeEvt) : undefined
+
+  const causalChain = walkCausedBy(events, toolRequestedEventId).map(e => ({
+    eventId: e.id, type: e.type, summary: summarizeEvent(e),
+  }))
+
+  const summary = `工具 ${toolName} 被 ${causeSummary ?? '(无上游记录)'} 调用`
+
+  return {
+    toolRequestedEventId,
+    toolName,
+    input: p.input,
+    ...(output !== undefined ? { output } : {}),
+    trigger: {
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeSummary ? { causedBySummary: causeSummary } : {}),
+    },
+    causalChain,
+    summary,
+  }
+}
+```
+
+- [ ] **Step 4: 运行,确认通过** — PASS(3);tsc clean
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/diagnostics/explainToolCall.ts src/__tests__/explainToolCall.test.ts
+git commit -m "feat(#64): explainToolCall — pure projection of a tool call's why"
+```
+
+---
+
+## Task 3: 抽出 renderTimelineSections(为 raw tab 复用)
+
+**Files:** Modify `src/trace/render/html.ts`; Test `src/__tests__/render-html.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`render-html.test.ts` 追加)
+
+```ts
+it('exposes renderTimelineSections returning the timeline body (filters + sections, no <html>)', async () => {
+  const { renderTimelineSections } = await import('../trace/render/html')
+  const events: Event[] = [
+    e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+        payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+  ]
+  const body = renderTimelineSections(events)
+  expect(body).toContain('class="filters"')
+  expect(body).toContain('data-run-id="r1"')
+  expect(body).not.toContain('<!doctype html>')   // body fragment, not a full document
+})
+```
+
+- [ ] **Step 2: 运行,确认失败** — FAIL
+
+- [ ] **Step 3: 重构 html.ts**
+
+READ the current `renderHtml`. Extract everything from the `<div class="filters">` through the `${tree.map(...)}` sections AND the two embedded `<script type="application/json">` registries (region-content + trace-data) into a new exported function `renderTimelineSections(events, opts?)`. `renderHtml` keeps the `<!doctype html>` + `<head>`/`<style>` + `<body><h1>` + `${renderTimelineSections(events, opts)}` + `<script>${SCRIPT}</script>` wrapper. Concretely:
+
+```ts
+export function renderTimelineSections(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+  const tree = buildTimelineTree(events)
+  const eventById = new Map<string, Event>()
+  for (const evt of events) eventById.set(evt.id, evt)
+  const explanations = new Map<string, TransitionExplanation>()
+  for (const evt of events) {
+    if (evt.type === 'fsm.transition') explanations.set(evt.id, explainTransition(events, evt.id))
+  }
+  const regionContent = opts.regionContent ?? new Map<string, string>()
+  const regionCtx: RegionCtx = { events, reuseCounts: regionReuseCounts(events), regionContent }
+  const registryJson = JSON.stringify(Object.fromEntries(regionContent)).replace(/<\/script/gi, '<\\/script')
+  const dataJson = JSON.stringify(events).replace(/<\/script/gi, '<\\/script')
+  return `<div class="filters">
+  <span class="chip" data-kind="llm">LLM</span>
+  <span class="chip" data-kind="tool">tool</span>
+  <span class="chip" data-kind="lifecycle">lifecycle</span>
+  <span class="chip" data-kind="region">region</span>
+  <span class="chip" data-kind="fsm">fsm</span>
+</div>
+${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
+<script type="application/json" id="region-content">${registryJson}</script>
+<script type="application/json" id="trace-data">${dataJson}</script>`
+}
+
+export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>milkie trace report</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<h1>milkie trace report</h1>
+${renderTimelineSections(events, opts)}
+<script>${SCRIPT}</script>
+</body>
+</html>`
+}
+```
+(Match the EXACT current chip list / script ids in the file — copy them verbatim from the current renderHtml. Behavior must be identical: the new renderHtml output equals the old one.)
+
+- [ ] **Step 4: 运行,确认通过** — `npx jest src/__tests__/render-html.test.ts` → PASS（new test + ALL existing #26/#33/#34 tests, output unchanged）;tsc clean
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/trace/render/html.ts src/__tests__/render-html.test.ts
+git commit -m "refactor(#64): extract renderTimelineSections from renderHtml for viewer raw tab reuse"
+```
+
+---
+
+## Task 4: viewer.ts + viewer-template.ts — 决策 viewer
+
+**Files:** Create `src/trace/render/viewer-template.ts`, `src/trace/render/viewer.ts`; Test `src/__tests__/render-viewer.test.ts`
+
+- [ ] **Step 1: 写失败测试**(`src/__tests__/render-viewer.test.ts`)
+
+```ts
+import { renderViewer } from '../trace/render/viewer'
+import type { Event } from '../trace/types'
+
+const e = (over: Partial<Event> & { id: string; runId: string; type: Event['type'] }): Event =>
+  ({ actor: 'a', timestamp: 0, payload: {}, ...over })
+
+function scenario(): Event[] {
+  return [
+    e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1, payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    e({ id: 'llm1', runId: 'r1', type: 'llm.requested', timestamp: 2, causedBy: 'start', payload: { model: 'm' } }),
+    e({ id: 'lr1', runId: 'r1', type: 'llm.responded', timestamp: 3, causedBy: 'llm1', payload: {} }),
+    e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 4, causedBy: 'lr1', payload: { toolName: 'classify_intent', input: {}, requestHash: 'h' } }),
+    e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 5, causedBy: 'treq', payload: { toolName: 'classify_intent', output: {}, requestHash: 'h' } }),
+    e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 6, causedBy: 'tres', payload: { from: 'classify', to: 'handle', trigger: { domain: 'business', name: 'GO' }, guardEvaluations: [{ guardId: 'g1', result: 'GO', contextSlice: {} }] } }),
+    e({ id: 'done', runId: 'r1', type: 'agent.run.completed', timestamp: 7, causedBy: 'fsm', payload: { status: 'completed', lastTextOutput: 'ok' } }),
+  ]
+}
+
+describe('renderViewer', () => {
+  it('produces a self-contained document with a decision spine and embedded explanations', () => {
+    const html = renderViewer(scenario())
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    // spine has nodes with data-id for each decision
+    expect(html).toContain('data-id="llm1"')
+    expect(html).toContain('data-id="treq"')
+    expect(html).toContain('data-id="fsm"')
+    expect(html).toContain('data-id="done"')
+    // output node carries the Why entry
+    expect(html).toContain('class="spine-output"')
+    // embedded data the JS reads
+    expect(html).toContain('id="spine-data"')
+    expect(html).toContain('id="explanations-data"')
+    // why panel container + the decision/raw tabs
+    expect(html).toContain('id="why-panel"')
+    expect(html).toContain('data-tab="decision"')
+    expect(html).toContain('data-tab="raw"')
+    // raw tab reuses the timeline (filters present)
+    expect(html).toContain('class="filters"')
+  })
+
+  it('renders without crashing for a run with no decisions', () => {
+    const html = renderViewer([{ id: 's', runId: 'r1', actor: 'a', type: 'agent.run.started', timestamp: 1, payload: {} } as Event])
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(html).toContain('id="why-panel"')
+  })
+})
+```
+
+- [ ] **Step 2: 运行,确认失败** — FAIL
+
+- [ ] **Step 3: viewer-template.ts**(CSS + JS 常量)
+
+```ts
+export const VIEWER_STYLES = `
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: #f7f7f8; color: #1c1c1e; }
+  h1 { font-size: 16px; margin: 0; padding: 12px 16px; border-bottom: 1px solid #e5e5e7; background: #fff; }
+  .tabs { display: flex; gap: 8px; padding: 8px 16px; background: #fff; border-bottom: 1px solid #e5e5e7; }
+  .tab { font-size: 12px; padding: 4px 12px; border-radius: 999px; border: 1px solid #d1d1d6; cursor: pointer; background: #fff; user-select: none; }
+  .tab.active { background: #1c1c1e; color: #fff; border-color: #1c1c1e; }
+  .pane { display: none; }
+  .pane.active { display: block; }
+  #pane-decision { display: flex; height: calc(100vh - 90px); }
+  #pane-decision.active { display: flex; }
+  .spine { width: 42%; border-right: 1px solid #e5e5e7; overflow: auto; padding: 8px; background: #fafafa; }
+  .node { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; padding: 5px 8px; margin: 3px 0; border-left: 3px solid transparent; border-radius: 3px; cursor: pointer; background: #fff; }
+  .node.k-llm { border-left-color: #5b3ec9; } .node.k-tool { border-left-color: #2563eb; }
+  .node.k-transition { border-left-color: #8a5a00; } .node.k-output { border-left-color: #1c1c1e; font-weight: 600; }
+  .node.selected { outline: 2px solid #f0a; }
+  .node.cause { background: #eef6ff; }
+  .spine-output .why-entry { color: #c026a6; font-size: 11px; margin-left: 6px; }
+  #why-panel { width: 58%; overflow: auto; padding: 14px; background: #fff; font-size: 13px; line-height: 1.6; }
+  #why-panel .ph { color: #888; }
+  #why-panel h3 { font-size: 14px; margin: 0 0 8px; }
+  .why-block { background: #f7f7f8; padding: 10px; border-radius: 6px; margin-bottom: 10px; }
+  .nav-link { display: block; padding: 6px 10px; border-radius: 5px; margin: 4px 0; cursor: pointer; }
+  .nav-cause { background: #eef6ff; color: #2563eb; } .nav-effect { background: #fef0f5; color: #a13; }
+  .rawpre { font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; background: #fafafa; padding: 8px; border-radius: 4px; max-height: 240px; overflow: auto; }
+  #pane-raw { padding: 12px 16px; }
+`
+
+export const VIEWER_SCRIPT = `
+(function () {
+  var spine = JSON.parse(document.getElementById('spine-data').textContent || '{"nodes":[]}');
+  var exps  = JSON.parse(document.getElementById('explanations-data').textContent || '{}');
+  function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  function nodeEl(id){ return document.querySelector('.node[data-id="'+CSS.escape(id)+'"]'); }
+  function clearMarks(){ document.querySelectorAll('.node.selected,.node.cause').forEach(function(n){ n.classList.remove('selected','cause'); }); }
+  function chainHtml(chain){ return (chain||[]).map(function(c){ return '<a class="xlink" data-go="'+esc(c.eventId)+'">'+esc(c.summary)+'</a>'; }).join(' → '); }
+  function navHtml(causeId){
+    var out='';
+    if(causeId){ out += '<a class="nav-link nav-cause" data-go="'+esc(causeId)+'">← 谁导致的:'+esc((exps[causeId]&&exps[causeId].title)||causeId)+'</a>'; }
+    return out;
+  }
+  function panelHtml(id){
+    var x = exps[id]; if(!x){ return '<p class="ph">选一个决策节点看 why</p>'; }
+    var h = '<h3>'+esc(x.title)+'</h3>';
+    h += '<div class="why-block">'+x.bodyHtml+'</div>';
+    h += '<div class="why-block">'+navHtml(x.causeDecisionId)+'<div style="color:#888;font-size:11px;margin-top:6px">因果链: '+chainHtml(x.chain)+'</div></div>';
+    h += '<details><summary style="cursor:pointer;color:#888;font-size:11px">原始 payload</summary><pre class="rawpre">'+esc(x.rawJson)+'</pre></details>';
+    return h;
+  }
+  function selectNode(id){
+    clearMarks();
+    var n = nodeEl(id); if(n){ n.classList.add('selected'); }
+    var cid = exps[id] && exps[id].causeDecisionId;
+    if(cid){ var cn = nodeEl(cid); if(cn){ cn.classList.add('cause'); } }
+    document.getElementById('why-panel').innerHTML = panelHtml(id);
+  }
+  document.addEventListener('click', function(ev){
+    var go = ev.target.closest('[data-go]'); if(go){ selectNode(go.getAttribute('data-go')); return; }
+    var node = ev.target.closest('.node[data-id]'); if(node){ selectNode(node.getAttribute('data-id')); return; }
+    var tab = ev.target.closest('.tab[data-tab]');
+    if(tab){
+      document.querySelectorAll('.tab').forEach(function(t){ t.classList.remove('active'); });
+      tab.classList.add('active');
+      document.querySelectorAll('.pane').forEach(function(p){ p.classList.remove('active'); });
+      document.getElementById('pane-'+tab.getAttribute('data-tab')).classList.add('active');
+    }
+  });
+})();
+`
+```
+
+- [ ] **Step 4: viewer.ts**(组装 explanation 对象 + 两栏 + raw tab)
+
+```ts
+import type { Event } from '../types.js'
+import { buildDecisionSpine, type DecisionNode } from '../diagnostics/buildDecisionSpine.js'
+import { explainTransition } from '../diagnostics/explainTransition.js'
+import { explainLlmCall } from '../diagnostics/explainLlmCall.js'
+import { explainToolCall } from '../diagnostics/explainToolCall.js'
+import { regionReuseCounts } from '../RegionContextView.js'
+import { renderTimelineSections } from './html.js'
+import { VIEWER_STYLES, VIEWER_SCRIPT } from './viewer-template.js'
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+}
+
+// One panel "explanation" record per node, consumed verbatim by the client JS.
+function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>): unknown {
+  const base = {
+    causeDecisionId: node.causeDecisionId,
+    chain: [] as Array<{ eventId: string; type: string; summary: string }>,
+    rawJson: JSON.stringify(eventById.get(node.eventId)?.payload ?? {}, null, 2),
+  }
+  if (node.kind === 'transition') {
+    const x = explainTransition(events, node.eventId)
+    const guards = x.guards.map(g => `${esc(g.guardId)} 判定 ${esc(String(g.result))}`).join('、')
+    return { ...base, chain: x.causalChain, title: `为什么 ${esc(x.from)} → ${esc(x.to)}?`,
+      bodyHtml: `触发: ${esc(x.trigger.causedBySummary ?? x.trigger.name)}<br>guard: ${guards || '(无)'}` }
+  }
+  if (node.kind === 'llm') {
+    const x = explainLlmCall(events, node.eventId)
+    return { ...base, chain: x.causalChain, title: `为什么这次 LLM 调用?`,
+      bodyHtml: `state: ${esc(x.fsmState ?? '(未知)')}<br>触发: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>prompt 由 ${x.regionCount} 个 region 拼成` }
+  }
+  if (node.kind === 'tool') {
+    const x = explainToolCall(events, node.eventId)
+    return { ...base, chain: x.causalChain, title: `工具 ${esc(x.toolName)}`,
+      bodyHtml: `调用方: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>入参: ${esc(JSON.stringify(x.input))}<br>出参: ${esc(JSON.stringify(x.output ?? null))}` }
+  }
+  // output
+  const evt = eventById.get(node.eventId)
+  const out = (evt?.payload as { lastTextOutput?: string; status?: string } | undefined)
+  return { ...base, chain: [], title: '为什么是这个结果?',
+    bodyHtml: `输出: ${esc(out?.lastTextOutput ?? out?.status ?? '')}<br>由上游决策产生(点 ← 谁导致的 下钻)` }
+}
+
+/**
+ * Causal drill-down trace viewer: decision spine + Why panel + a raw timeline
+ * tab. Self-contained static HTML; all explanations precomputed and embedded,
+ * client JS only looks them up. Pure projection (region content hydration is
+ * the caller's job, passed via opts, same as renderHtml).
+ */
+export function renderViewer(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+  const spine = buildDecisionSpine(events)
+  const eventById = new Map<string, Event>()
+  for (const e of events) eventById.set(e.id, e)
+
+  const explanations: Record<string, unknown> = {}
+  for (const node of spine.nodes) explanations[node.eventId] = panelRecord(events, node, eventById)
+
+  const spineHtml = spine.nodes.map(n => {
+    const cls = `node k-${n.kind}${n.kind === 'output' ? ' spine-output' : ''}`
+    const why = n.kind === 'output' ? `<span class="why-entry">❓ 为什么是这个结果</span>` : ''
+    return `<div class="${cls}" data-id="${esc(n.eventId)}">${esc(n.label)}${why}</div>`
+  }).join('')
+
+  const spineJson = JSON.stringify(spine).replace(/<\/script/gi, '<\\/script')
+  const expsJson = JSON.stringify(explanations).replace(/<\/script/gi, '<\\/script')
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>milkie trace viewer</title>
+<style>${VIEWER_STYLES}</style>
+</head>
+<body>
+<h1>milkie trace viewer</h1>
+<div class="tabs">
+  <span class="tab active" data-tab="decision">决策视图</span>
+  <span class="tab" data-tab="raw">原始时间线</span>
+</div>
+<div id="pane-decision" class="pane active">
+  <div class="spine">${spineHtml || '<p style="color:#888;font-size:12px">无决策事件</p>'}</div>
+  <div id="why-panel"><p class="ph">从底部输出 ❓ 或任一决策点开始</p></div>
+</div>
+<div id="pane-raw" class="pane">${renderTimelineSections(events, opts)}</div>
+<script type="application/json" id="spine-data">${spineJson}</script>
+<script type="application/json" id="explanations-data">${expsJson}</script>
+<script>${VIEWER_SCRIPT}</script>
+</body>
+</html>`
+}
+```
+
+注:raw tab 复用 `renderTimelineSections`,但它内部也嵌了 `id="region-content"`/`id="trace-data"` 脚本 + `.entry` 等 class,而 viewer 自己的 CSS/JS 用 `.node`/`.tab`/`#why-panel` 等不冲突的选择器。**raw tab 的折叠/筛选交互需要 html.ts 的 SCRIPT**——本 MVP 的 raw tab 仅保证"可见全时间线 + payload 已内联",其 `.entry` 折叠 JS 暂不引入(viewer JS 不含);若实测要 raw 也能折叠,作为收尾微调把 `SCRIPT` 一并内联(class 不冲突)。
+
+- [ ] **Step 5: 运行,确认通过** — `npx jest src/__tests__/render-viewer.test.ts` → PASS(2);`npx jest`(全量)无回归;tsc clean
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/trace/render/viewer.ts src/trace/render/viewer-template.ts src/__tests__/render-viewer.test.ts
+git commit -m "feat(#64): renderViewer — decision spine + why panel + drill JS + raw tab"
+```
+
+---
+
+## Task 5: CLI `trace report` → renderViewer
+
+**Files:** Modify `src/cli/main.ts`
+
+- [ ] **Step 1: 改命令** — READ the `report <runId>` action. Change the final `stdout.push(renderHtml(events, { regionContent }))` to use the viewer, and swap the import:
+```ts
+// import line: replace renderHtml import with renderViewer
+const { renderViewer } = await import('../trace/render/viewer.js')
+// ... unchanged events + regionContent hydration ...
+stdout.push(renderViewer(events, { regionContent }))
+```
+Keep everything else (milkieDir/runsDir/findDescendantRuns/regionContent hydration) identical. Leave the `render-html` command UNCHANGED (it still emits the flat renderHtml — a no-objectStore path).
+
+- [ ] **Step 2: 验证** — `npx tsc --noEmit` clean; `npm run build` succeeds.
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/cli/main.ts
+git commit -m "feat(#64): trace report emits the decision viewer"
+```
+
+---
+
+## 收尾
+
+- [ ] **全量测试 + 构建** — `npx jest && npm run build` 全绿。
+
+- [ ] **浏览器实测(验收,用户要求)**:用 dist + 一份真实/合成 run 生成 viewer HTML,dev-browser 打开:① 点底部输出 ❓ → Why 面板出"因"的解释 + 脊柱该因节点 `.cause` 高亮;② 点"← 谁导致的" → `.selected` 上移、面板刷新(两次点击到一个决策);③ 切"原始时间线" tab 可见全事件。截图给用户。**据实测决定是否把 html.ts SCRIPT 引入让 raw tab 也可折叠(Task 4 Step 4 注)**。
+
+- [ ] **开 PR**:`Closes #64`;说明复用 #26/#30/#31/#33/#34、viewer 主输出 + raw tab、MVP 砍 DAG/diff。
+
+---
+
+## Self-Review(plan 作者已核对)
+
+**Spec 覆盖:** §3.1 buildDecisionSpine(含 causeDecisionId)→ Task 1 ✓ §3.2 explainToolCall → Task 2 ✓ §4 viewer 渲染 + raw tab → Task 3(抽 sections)+ Task 4 ✓ §5 下钻数据流(渲染期预算 + JS 查表)→ Task 4 ✓ §5 CLI → Task 5 ✓ §7 测试(投影/渲染/浏览器)→ Task 1/2/4 + 收尾浏览器 ✓ §9 验收 → 收尾浏览器 ✓。
+
+**占位扫描:** 无 TBD/TODO;每步含完整代码。Task 4 注明 raw-tab 折叠 JS 为实测后微调点(非占位,是明确的条件性收尾)。
+
+**类型一致性:** `DecisionNode`/`DecisionSpine`(Task1)在 Task4 viewer.ts 引用一致;`ToolCallExplanation`(Task2)在 Task4 引用一致;`renderTimelineSections(events,opts)`(Task3)在 Task4 viewer.ts 调用一致;`buildDecisionSpine`/`explainToolCall`/`explainTransition`/`explainLlmCall` 签名前后一致;客户端内嵌结构 `{title,bodyHtml,causeDecisionId,chain,rawJson}` 在 viewer.ts 产出与 viewer-template.ts JS 消费一致。

--- a/docs/superpowers/specs/2026-05-31-trace-viewer-design.md
+++ b/docs/superpowers/specs/2026-05-31-trace-viewer-design.md
@@ -1,0 +1,123 @@
+# #64 因果下钻 trace viewer(决策脊柱 + Why 面板)— 设计 spec
+
+**Issue:** #64（diagnosable;依赖 #26/#30/#31/#33/#34,均已落地;Parent #20）
+**日期:** 2026-05-31
+**定位:** 把 `trace report` 从"时间平铺数据堆"重组成"**决策脊柱 + Why 面板 + 点击下钻**"的诊断工具。仍是**纯静态 HTML projection**(自包含、无 server),让前几轮建的能力(causedBy / guard / explain* / composition)第一次连成"从输出钻到根因"的动作。
+
+经 brainstorm + 可视化 mockup 定稿(范式 A:决策脊柱+Why面板;时间序;viewer 主输出)。mockup 存 `.superpowers/brainstorm/51358-1780194589/content/`。
+
+---
+
+## 1. 目标
+
+诊断按**因果**进行,不按时间浏览。本 viewer:从一个输出/可疑步,**两次点击钻到"哪步决策错了、为什么"**。
+
+## 2. Non-goals
+
+- **零 LLM、零存储、零新事件类型、零 schema 变更**:纯只读 event-log 投影(+ region 内容经 objectStore hydrate,沿用 #26 CLI 模式)。
+- **无 server**:自包含静态 HTML + vanilla JS。守 ARCHITECTURE.md「UI = CLI/SDK projection,不自带查询逻辑」。
+- **MVP 不做**:DAG 图、diff、失败路径自动高亮、搜索、跨 run 导航。
+- **不重写已有投影**:复用 explainTransition/explainLlmCall/contextRefsAt/walkCausedBy。
+
+## 3. 架构与组件
+
+```
+src/trace/diagnostics/
+  buildDecisionSpine(events) → DecisionSpine     // 新:events → 决策脊柱
+  explainToolCall(events, id) → ToolCallExplanation  // 新:工具节点 why
+  (复用) explainTransition / explainLlmCall / contextRefsAt / walkCausedBy / summarizeEvent
+
+src/trace/render/
+  viewer.ts            // 新:两栏 HTML + 内嵌 explanation JSON + 节点数据
+  viewer-template.ts   // 新:viewer 的 CSS + vanilla JS(选中/下钻/高亮)
+```
+
+### 3.1 `buildDecisionSpine(events): DecisionSpine`(纯)
+
+```ts
+type DecisionKind = 'llm' | 'tool' | 'transition' | 'output'
+interface DecisionNode {
+  eventId:          string
+  kind:             DecisionKind
+  label:            string          // summarizeEvent 风格的人类标签
+  timestamp:        number
+  causedByEventId?: string          // 原始因(该事件的 causedBy,可能指向非决策事件)
+  causeDecisionId?: string          // 最近决策祖先:沿 causedBy 上溯找到的第一个脊柱节点 id(渲染期用 walkCausedBy 算)。下钻目标。
+}
+interface DecisionSpine {
+  nodes: DecisionNode[]            // 时间序(timestamp 升序)
+}
+```
+
+- **入选节点**:`llm.requested`(label "LLM call")、`tool.requested`(label `tool: <name>`)、`fsm.transition`(label `from → to`)、`agent.run.completed`(label "输出",kind `output`)。其余(clock/uuid/region.*/llm.responded/tool.responded/run.started/boundary)**不进脊柱**。
+- `causedByEventId` = 该事件的 `causedBy`(#30)。注意:它可能指向一个**非决策事件**(如 transition.causedBy → tool.responded)。脊柱节点的"下钻目标"在渲染/JS 层解析为"最近的决策祖先"(见 §5)。
+- 纯函数,可单测。
+
+### 3.2 `explainToolCall(events, toolRequestedId): ToolCallExplanation`(纯)
+
+```ts
+interface ToolCallExplanation {
+  toolRequestedEventId: string
+  toolName: string
+  input: unknown                  // tool.requested.payload.input
+  output?: unknown                // 配对 tool.responded.payload.output(若有)
+  trigger: { causedByEventId?: string; causedBySummary?: string }  // 谁调的(llm.responded)
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+```
+- 平行 explainTransition/explainLlmCall;复用 walkCausedBy/summarizeEvent。抛错语义同兄弟件(未知 id / 非 tool.requested)。
+
+## 4. 渲染(`viewer.ts` / `viewer-template.ts`)
+
+- 出**两栏自包含 HTML**:左 = 脊柱(节点列表,时间序,输出在底带 ❓ 入口);右 = Why 面板容器(初始空/提示)。
+- **内嵌数据**(`<script type="application/json">`):
+  - `spine`:`DecisionNode[]`
+  - `explanations`:`{ [eventId]: <该节点的 explanation 对象> }`——渲染期对每个脊柱节点按 kind 调对应 explain*(transition→explainTransition,llm→explainLlmCall,tool→explainToolCall,output→见下)预算好。
+  - `regionContent`:`{ [hash]: content }`——CLI hydrate(沿用 #26),供 LLM 节点 composition 内容预览。
+- **output 节点**的 explanation:`{ kind:'output', causedByEventId, causedBySummary, summary }`——指向产生它的决策(其 causedBy 的最近决策祖先)。
+- Why 面板按 explanation.kind 渲染:transition=触发/guard/链;llm=触发/state/composition(region 列表+内容预览,复用 #26 注册表机制)/链;tool=入参/出参/谁调的/链;output=由哪个决策产生 + ❓。
+- **raw 全时间线**:作为次要视图保留——顶部一个 tab 切换"决策视图 ⇄ 原始时间线",原始时间线复用现有 `renderHtml` 的 timeline 渲染(#26/#33/#34 内联块)。
+
+## 5. 下钻机制 / 数据流
+
+- **渲染期**:全部 explanation 预算 + 内嵌(纯,无客户端重算)。
+- **客户端 vanilla JS**:
+  - `selectNode(eventId)`:从内嵌 `explanations[eventId]` 渲染 Why 面板;给脊柱里 `eventId` 节点加 `.selected`;解析其"因"= `causedByEventId` 的**最近决策祖先**(沿 causedBy 上溯到第一个在 `spine` 里的事件;用内嵌的 node→causedBy + spine id 集合),给该因节点加 `.cause`。
+  - 点脊柱节点 → `selectNode`;点输出 ❓ → `selectNode(output 的因)`;点面板"← 谁导致的" → `selectNode(因 id)`。
+  - **"两次点击到根因"** = 输出❓ → 选中其因 → "← 谁导致的" → 再上钻一层。
+- **"最近决策祖先"在渲染期算好**(§3.1 的 `causeDecisionId`):`buildDecisionSpine` 对每个节点沿 `causedBy`(walkCausedBy)上溯,取第一个落在脊柱里的事件 id,内嵌备用。客户端 JS **不做图遍历,纯查表**——`selectNode` 直接读 `causeDecisionId` 定位"因"节点。
+
+## 6. 错误处理 / 边界
+
+- 无 transition 的 run(ReAct 单状态):LLM 节点 fsmState 显示"(未知)"(沿用 #34);脊柱仍有 llm/tool/output 节点。
+- 节点无 `causedBy` 或因不在脊柱:"← 谁导致的"不渲染/置灰,`causeDecisionId` 为空。
+- 空 run(无任何决策):脊柱空,面板提示"无决策事件"。
+- region 无 contentHash / objectStore 无内容:composition 降级"(内容不可用)"(沿用 #26)。
+
+## 7. 测试
+
+- **`buildDecisionSpine`**:只留 4 类决策、时间序、`causedByEventId`/`causeDecisionId` 正确(含"因是非决策事件→解析到最近决策祖先"、"因不在脊柱→空");output 节点存在。
+- **`explainToolCall`**:input/output/trigger/causalChain/summary 正确;抛错(未知/非 tool.requested)。
+- **`viewer.ts` 渲染单测**:HTML 含脊柱节点(data-id)、内嵌 spine/explanations/regionContent JSON、Why 面板容器、tab 切换;output 节点带 ❓。
+- **浏览器自动化(dev-browser)**:真实/合成 run → 点输出 ❓ → 断言面板出"因"的 why + 该因节点 `.cause` 高亮;点"← 谁导致的" → 断言 `.selected` 上移、面板内容刷新 = **"两次点击到根因"验收**;tab 切到 raw 时间线可见。
+
+## 8. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/diagnostics/buildDecisionSpine.ts` | 新建:脊柱投影 + `DecisionSpine`/`DecisionNode` 类型 |
+| `src/trace/diagnostics/explainToolCall.ts` | 新建:工具节点投影 + `ToolCallExplanation` |
+| `src/trace/render/viewer.ts` | 新建:两栏 HTML + 内嵌数据 + raw tab |
+| `src/trace/render/viewer-template.ts` | 新建:CSS + vanilla JS(select/下钻/高亮/tab) |
+| `src/cli/main.ts` | `trace report` 改用 `renderViewer`(仍 hydrate regionContent;保留 raw 复用 renderHtml) |
+| `src/__tests__/buildDecisionSpine.test.ts` | 新建 |
+| `src/__tests__/explainToolCall.test.ts` | 新建 |
+| `src/__tests__/render-viewer.test.ts` | 新建 |
+
+## 9. 验收对照(#64)
+
+- [x] 输出 ❓ → Why 面板出因的解释 + 脊柱高亮 → §4/§5 + 浏览器测
+- [x] "← 谁导致的"两次点击可达决策 → `causeDecisionId` 下钻 + 浏览器测
+- [x] 纯 projection、不调 LLM、不依赖运行时副本 → §2/§3 纯函数
+- [x] 投影 + 渲染 + 浏览器三层测 → §7

--- a/src/__tests__/buildDecisionSpine.test.ts
+++ b/src/__tests__/buildDecisionSpine.test.ts
@@ -1,0 +1,39 @@
+import { buildDecisionSpine } from '../trace/diagnostics/buildDecisionSpine'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string, ts = 0): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: ts, payload, ...(causedBy ? { causedBy } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', { agentId: 'a', goal: 'g', input: 'i', contextId: 'c' }, undefined, 1),
+    ev('llm1', 'llm.requested', { model: 'm' }, 'start', 2),
+    ev('lr1', 'llm.responded', {}, 'llm1', 3),
+    ev('treq', 'tool.requested', { toolName: 'classify_intent', input: {} }, 'lr1', 4),
+    ev('tres', 'tool.responded', { toolName: 'classify_intent', output: {} }, 'treq', 5),
+    ev('fsm', 'fsm.transition', { from: 'classify', to: 'handle', trigger: { domain: 'business', name: 'GO' } }, 'tres', 6),
+    ev('done', 'agent.run.completed', { status: 'completed', lastTextOutput: 'ok' }, 'fsm', 7),
+  ]
+}
+
+describe('buildDecisionSpine', () => {
+  it('keeps only decision nodes in timestamp order with labels', () => {
+    const spine = buildDecisionSpine(scenario())
+    expect(spine.nodes.map(n => [n.kind, n.eventId])).toEqual([
+      ['llm', 'llm1'], ['tool', 'treq'], ['transition', 'fsm'], ['output', 'done'],
+    ])
+    expect(spine.nodes.find(n => n.eventId === 'treq')!.label).toBe('tool: classify_intent')
+    expect(spine.nodes.find(n => n.eventId === 'fsm')!.label).toBe('classify → handle')
+  })
+
+  it('resolves causeDecisionId to the nearest decision ancestor (skipping non-decision causes)', () => {
+    const spine = buildDecisionSpine(scenario())
+    expect(spine.nodes.find(n => n.eventId === 'fsm')!.causeDecisionId).toBe('treq')
+    expect(spine.nodes.find(n => n.eventId === 'done')!.causeDecisionId).toBe('fsm')
+    expect(spine.nodes.find(n => n.eventId === 'llm1')!.causeDecisionId).toBeUndefined()
+  })
+
+  it('returns empty spine for a run with no decisions', () => {
+    expect(buildDecisionSpine([ev('s', 'agent.run.started', {})]).nodes).toEqual([])
+  })
+})

--- a/src/__tests__/explainToolCall.test.ts
+++ b/src/__tests__/explainToolCall.test.ts
@@ -1,0 +1,36 @@
+import { explainToolCall } from '../trace/diagnostics/explainToolCall'
+import type { Event } from '../trace/types'
+
+const ev = (id: string, type: string, payload: unknown, causedBy?: string): Event =>
+  ({ id, runId: 'r1', actor: 'a', type: type as Event['type'], timestamp: 0, payload, ...(causedBy ? { causedBy } : {}) })
+
+function scenario(): Event[] {
+  return [
+    ev('start', 'agent.run.started', {}),
+    ev('lr1', 'llm.responded', {}, 'start'),
+    ev('treq', 'tool.requested', { toolName: 'search', input: { q: 'x' }, requestHash: 'h' }, 'lr1'),
+    ev('tres', 'tool.responded', { toolName: 'search', output: { hits: 3 }, requestHash: 'h' }, 'treq'),
+  ]
+}
+
+describe('explainToolCall', () => {
+  it('projects toolName, input, paired output, trigger and causal chain', () => {
+    const exp = explainToolCall(scenario(), 'treq')
+    expect(exp.toolName).toBe('search')
+    expect(exp.input).toEqual({ q: 'x' })
+    expect(exp.output).toEqual({ hits: 3 })
+    expect(exp.trigger.causedByEventId).toBe('lr1')
+    expect(exp.trigger.causedBySummary).toBe('llm.responded')
+    expect(exp.causalChain.map(c => c.eventId)).toEqual(['treq', 'lr1', 'start'])
+    expect(exp.summary).toContain('search')
+  })
+
+  it('omits output when there is no paired tool.responded', () => {
+    const events: Event[] = [ev('treq', 'tool.requested', { toolName: 'search', input: {} })]
+    expect(explainToolCall(events, 'treq').output).toBeUndefined()
+  })
+
+  it('throws on a non-tool.requested event id', () => {
+    expect(() => explainToolCall(scenario(), 'tres')).toThrow(/tool\.requested/)
+  })
+})

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -296,4 +296,16 @@ describe('#26 Assembled by', () => {
     expect(html).not.toContain('</script><b>boom</b>')
     expect(html).toContain('<\\/script>')   // close-tag-safe escaped form present
   })
+
+  it('exposes renderTimelineSections returning the timeline body (filters + sections, no <html>)', async () => {
+    const { renderTimelineSections } = await import('../trace/render/html')
+    const events: Event[] = [
+      e({ id: 's', runId: 'r1', type: 'agent.run.started', timestamp: 1,
+          payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    ]
+    const body = renderTimelineSections(events)
+    expect(body).toContain('class="filters"')
+    expect(body).toContain('data-run-id="r1"')
+    expect(body).not.toContain('<!doctype html>')
+  })
 })

--- a/src/__tests__/render-viewer.test.ts
+++ b/src/__tests__/render-viewer.test.ts
@@ -1,0 +1,46 @@
+import { renderViewer } from '../trace/render/viewer'
+import type { Event } from '../trace/types'
+
+const e = (over: Partial<Event> & { id: string; runId: string; type: Event['type'] }): Event =>
+  ({ actor: 'a', timestamp: 0, payload: {}, ...over })
+
+function scenario(): Event[] {
+  return [
+    e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1, payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+    e({ id: 'llm1', runId: 'r1', type: 'llm.requested', timestamp: 2, causedBy: 'start', payload: { model: 'm' } }),
+    e({ id: 'lr1', runId: 'r1', type: 'llm.responded', timestamp: 3, causedBy: 'llm1', payload: {} }),
+    e({ id: 'treq', runId: 'r1', type: 'tool.requested', timestamp: 4, causedBy: 'lr1', payload: { toolName: 'classify_intent', input: {}, requestHash: 'h' } }),
+    e({ id: 'tres', runId: 'r1', type: 'tool.responded', timestamp: 5, causedBy: 'treq', payload: { toolName: 'classify_intent', output: {}, requestHash: 'h' } }),
+    e({ id: 'fsm', runId: 'r1', type: 'fsm.transition', timestamp: 6, causedBy: 'tres', payload: { from: 'classify', to: 'handle', trigger: { domain: 'business', name: 'GO' }, guardEvaluations: [{ guardId: 'g1', result: 'GO', contextSlice: {} }] } }),
+    e({ id: 'done', runId: 'r1', type: 'agent.run.completed', timestamp: 7, causedBy: 'fsm', payload: { status: 'completed', lastTextOutput: 'ok' } }),
+  ]
+}
+
+describe('renderViewer', () => {
+  it('produces a self-contained document with a decision spine and embedded explanations', () => {
+    const html = renderViewer(scenario())
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    // spine has nodes with data-id for each decision
+    expect(html).toContain('data-id="llm1"')
+    expect(html).toContain('data-id="treq"')
+    expect(html).toContain('data-id="fsm"')
+    expect(html).toContain('data-id="done"')
+    // output node carries the Why entry
+    expect(html).toContain('class="spine-output"')
+    // embedded data the JS reads
+    expect(html).toContain('id="spine-data"')
+    expect(html).toContain('id="explanations-data"')
+    // why panel container + the decision/raw tabs
+    expect(html).toContain('id="why-panel"')
+    expect(html).toContain('data-tab="decision"')
+    expect(html).toContain('data-tab="raw"')
+    // raw tab reuses the timeline (filters present)
+    expect(html).toContain('class="filters"')
+  })
+
+  it('renders without crashing for a run with no decisions', () => {
+    const html = renderViewer([{ id: 's', runId: 'r1', actor: 'a', type: 'agent.run.started', timestamp: 1, payload: {} } as Event])
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(html).toContain('id="why-panel"')
+  })
+})

--- a/src/__tests__/render-viewer.test.ts
+++ b/src/__tests__/render-viewer.test.ts
@@ -38,6 +38,18 @@ describe('renderViewer', () => {
     expect(html).toContain('class="filters"')
   })
 
+  it('embeds LLM region composition with content when regionContent is provided', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1, payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'h', runId: 'r1', type: 'region.added', timestamp: 2, payload: { id: 'header', target: 'system', section: 'header', stability: 'immutable', reason: 'agent-set', contentHash: 'H1' } }),
+      e({ id: 'llm1', runId: 'r1', type: 'llm.requested', timestamp: 3, causedBy: 'start', payload: { model: 'm' } }),
+    ]
+    const html = renderViewer(events, { regionContent: new Map([['H1', 'SYSTEM PROMPT TEXT']]) })
+    expect(html).toContain('Assembled by 1 regions')
+    expect(html).toContain('header')
+    expect(html).toContain('SYSTEM PROMPT TEXT')
+  })
+
   it('renders without crashing for a run with no decisions', () => {
     const html = renderViewer([{ id: 's', runId: 'r1', actor: 'a', type: 'agent.run.started', timestamp: 1, payload: {} } as Event])
     expect(html.startsWith('<!doctype html>')).toBe(true)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -185,7 +185,7 @@ export async function main(argv: string[]): Promise<MainResult> {
       const runsDir = path.join(milkieDir, 'runs')
       const eventStore = new JsonlEventStore(runsDir)
       const { findDescendantRuns } = await import('../trace/render/children.js')
-      const { renderHtml } = await import('../trace/render/html.js')
+      const { renderViewer } = await import('../trace/render/viewer.js')
 
       const runIds = [runId, ...(await findDescendantRuns(runsDir, runId))]
       const events = []
@@ -198,7 +198,7 @@ export async function main(argv: string[]): Promise<MainResult> {
         if (c !== undefined) regionContent.set(h, c)
       }
 
-      stdout.push(renderHtml(events, { regionContent }))
+      stdout.push(renderViewer(events, { regionContent }))
     })
 
   trace

--- a/src/trace/diagnostics/buildDecisionSpine.ts
+++ b/src/trace/diagnostics/buildDecisionSpine.ts
@@ -1,0 +1,58 @@
+import type { Event } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+
+export type DecisionKind = 'llm' | 'tool' | 'transition' | 'output'
+
+export interface DecisionNode {
+  eventId:          string
+  kind:             DecisionKind
+  label:            string
+  timestamp:        number
+  causedByEventId?: string
+  causeDecisionId?: string
+}
+
+export interface DecisionSpine {
+  nodes: DecisionNode[]
+}
+
+const SPINE_TYPES = new Set(['llm.requested', 'tool.requested', 'fsm.transition', 'agent.run.completed'])
+
+function kindOf(type: string): DecisionKind {
+  if (type === 'llm.requested')  return 'llm'
+  if (type === 'tool.requested') return 'tool'
+  if (type === 'fsm.transition') return 'transition'
+  return 'output'
+}
+
+function labelOf(e: Event): string {
+  if (e.type === 'llm.requested')  return 'LLM call'
+  if (e.type === 'tool.requested') return `tool: ${String((e.payload as { toolName?: unknown }).toolName ?? '?')}`
+  if (e.type === 'fsm.transition') { const p = e.payload as { from: string; to: string }; return `${p.from} → ${p.to}` }
+  return '输出'
+}
+
+/**
+ * Project the event log down to the decision spine: only LLM calls, tool
+ * calls, transitions, and the final output, in timestamp order. For each node,
+ * causeDecisionId is the nearest decision ancestor reached by walking causedBy
+ * (skipping non-decision causes like tool.responded / run.started). Pure.
+ */
+export function buildDecisionSpine(events: Event[]): DecisionSpine {
+  const spineIds = new Set(events.filter(e => SPINE_TYPES.has(e.type)).map(e => e.id))
+  const nodes: DecisionNode[] = events
+    .filter(e => SPINE_TYPES.has(e.type))
+    .map(e => {
+      const ancestor = walkCausedBy(events, e.id).slice(1).find(a => spineIds.has(a.id))
+      return {
+        eventId:   e.id,
+        kind:      kindOf(e.type),
+        label:     labelOf(e),
+        timestamp: e.timestamp,
+        ...(e.causedBy ? { causedByEventId: e.causedBy } : {}),
+        ...(ancestor ? { causeDecisionId: ancestor.id } : {}),
+      }
+    })
+    .sort((a, b) => a.timestamp - b.timestamp)
+  return { nodes }
+}

--- a/src/trace/diagnostics/explainToolCall.ts
+++ b/src/trace/diagnostics/explainToolCall.ts
@@ -1,0 +1,57 @@
+import type { Event, EventKind } from '../types.js'
+import { walkCausedBy } from './walkCausedBy.js'
+import { summarizeEvent } from './summarizeEvent.js'
+
+export interface ToolCallExplanation {
+  toolRequestedEventId: string
+  toolName: string
+  input: unknown
+  output?: unknown
+  trigger: { causedByEventId?: string; causedBySummary?: string }
+  causalChain: Array<{ eventId: string; type: EventKind; summary: string }>
+  summary: string
+}
+
+/**
+ * Pure projection: explain a tool call — its name/input, the paired output,
+ * which llm.responded decided to call it, and the causal chain. No LLM/I/O.
+ * Region/CLI #36 reuse the serializable result. Parallel to explainLlmCall.
+ */
+export function explainToolCall(events: Event[], toolRequestedEventId: string): ToolCallExplanation {
+  const byId = new Map<string, Event>()
+  for (const e of events) byId.set(e.id, e)
+
+  const evt = byId.get(toolRequestedEventId)
+  if (!evt) throw new Error(`explainToolCall: unknown event id "${toolRequestedEventId}"`)
+  if (evt.type !== 'tool.requested') {
+    throw new Error(`explainToolCall: event "${toolRequestedEventId}" is "${evt.type}", expected "tool.requested"`)
+  }
+
+  const p = evt.payload as { toolName?: unknown; input?: unknown; requestHash?: unknown }
+  const toolName = String(p.toolName ?? '?')
+  const responded = events.find(e =>
+    e.type === 'tool.responded' && (e.payload as { requestHash?: unknown }).requestHash === p.requestHash)
+  const output = responded ? (responded.payload as { output?: unknown }).output : undefined
+
+  const causeEvt = evt.causedBy ? byId.get(evt.causedBy) : undefined
+  const causeSummary = causeEvt ? summarizeEvent(causeEvt) : undefined
+
+  const causalChain = walkCausedBy(events, toolRequestedEventId).map(e => ({
+    eventId: e.id, type: e.type, summary: summarizeEvent(e),
+  }))
+
+  const summary = `工具 ${toolName} 被 ${causeSummary ?? '(无上游记录)'} 调用`
+
+  return {
+    toolRequestedEventId,
+    toolName,
+    input: p.input,
+    ...(output !== undefined ? { output } : {}),
+    trigger: {
+      ...(evt.causedBy ? { causedByEventId: evt.causedBy } : {}),
+      ...(causeSummary ? { causedBySummary: causeSummary } : {}),
+    },
+    causalChain,
+    summary,
+  }
+}

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -170,7 +170,16 @@ function renderNode(
  * store — this is the architectural firewall behind "UI is a pure projection
  * over CLI / SDK output" (ARCHITECTURE.md `## User-facing surfaces`).
  */
-export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+/**
+ * Builds the timeline body fragment: type filters, one section per root run
+ * (children nested), and the two embedded JSON `<script>` registries
+ * (region-content + trace-data). This is the reusable inner projection shared
+ * by `renderHtml` (full document) and the viewer's "raw timeline" tab.
+ *
+ * Returns only the inner fragment — no `<html>`/`<head>`/`<h1>` wrapper and no
+ * behavior `<script>${SCRIPT}</script>`.
+ */
+export function renderTimelineSections(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
   const tree = buildTimelineTree(events)
   const eventById = new Map<string, Event>()
   for (const evt of events) eventById.set(evt.id, evt)
@@ -187,6 +196,19 @@ export function renderHtml(events: Event[], opts: { regionContent?: Map<string, 
   const dataJson = JSON.stringify(events)
     // close-tag-safe inlining: prevent the JSON from ending the script element.
     .replace(/<\/script/gi, '<\\/script')
+  return `<div class="filters">
+  <span class="chip" data-kind="llm">LLM</span>
+  <span class="chip" data-kind="tool">tool</span>
+  <span class="chip" data-kind="lifecycle">lifecycle</span>
+  <span class="chip" data-kind="region">region</span>
+  <span class="chip" data-kind="fsm">fsm</span>
+</div>
+${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
+<script type="application/json" id="region-content">${registryJson}</script>
+<script type="application/json" id="trace-data">${dataJson}</script>`
+}
+
+export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -196,16 +218,7 @@ export function renderHtml(events: Event[], opts: { regionContent?: Map<string, 
 </head>
 <body>
 <h1>milkie trace report</h1>
-<div class="filters">
-  <span class="chip" data-kind="llm">LLM</span>
-  <span class="chip" data-kind="tool">tool</span>
-  <span class="chip" data-kind="lifecycle">lifecycle</span>
-  <span class="chip" data-kind="region">region</span>
-  <span class="chip" data-kind="fsm">fsm</span>
-</div>
-${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
-<script type="application/json" id="region-content">${registryJson}</script>
-<script type="application/json" id="trace-data">${dataJson}</script>
+${renderTimelineSections(events, opts)}
 <script>${SCRIPT}</script>
 </body>
 </html>`

--- a/src/trace/render/html.ts
+++ b/src/trace/render/html.ts
@@ -160,21 +160,9 @@ function renderNode(
 }
 
 /**
- * Pure projection: flat events → self-contained HTML report.
- *
- * The output is a single HTML document with inline CSS, vanilla JS for
- * fold/unfold + type filter, and the raw events embedded as a JSON script
- * tag so the file is its own re-renderable archive.
- *
- * No I/O, no clock, no randomness. The renderer cannot reach into the event
- * store — this is the architectural firewall behind "UI is a pure projection
- * over CLI / SDK output" (ARCHITECTURE.md `## User-facing surfaces`).
- */
-/**
- * Builds the timeline body fragment: type filters, one section per root run
- * (children nested), and the two embedded JSON `<script>` registries
- * (region-content + trace-data). This is the reusable inner projection shared
- * by `renderHtml` (full document) and the viewer's "raw timeline" tab.
+ * The timeline body fragment: type filters, one section per root run (children
+ * nested), and the two embedded JSON `<script>` registries (region-content +
+ * trace-data). Reused by `renderHtml` (full document) and the viewer's raw tab.
  *
  * Returns only the inner fragment — no `<html>`/`<head>`/`<h1>` wrapper and no
  * behavior `<script>${SCRIPT}</script>`.
@@ -208,6 +196,17 @@ ${tree.map(n => renderNode(n, eventById, explanations, regionCtx)).join('')}
 <script type="application/json" id="trace-data">${dataJson}</script>`
 }
 
+/**
+ * Pure projection: flat events → self-contained HTML report.
+ *
+ * The output is a single HTML document with inline CSS, vanilla JS for
+ * fold/unfold + type filter, and the raw events embedded as a JSON script
+ * tag so the file is its own re-renderable archive.
+ *
+ * No I/O, no clock, no randomness. The renderer cannot reach into the event
+ * store — this is the architectural firewall behind "UI is a pure projection
+ * over CLI / SDK output" (ARCHITECTURE.md `## User-facing surfaces`).
+ */
 export function renderHtml(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
   return `<!doctype html>
 <html lang="en">

--- a/src/trace/render/viewer-template.ts
+++ b/src/trace/render/viewer-template.ts
@@ -20,7 +20,9 @@ export const VIEWER_STYLES = `
   #why-panel h3 { font-size: 14px; margin: 0 0 8px; }
   .why-block { background: #f7f7f8; padding: 10px; border-radius: 6px; margin-bottom: 10px; }
   .nav-link { display: block; padding: 6px 10px; border-radius: 5px; margin: 4px 0; cursor: pointer; }
-  .nav-cause { background: #eef6ff; color: #2563eb; } .nav-effect { background: #fef0f5; color: #a13; }
+  .nav-cause { background: #eef6ff; color: #2563eb; }
+  .xlink { color: #36a; text-decoration: none; cursor: pointer; }
+  .xlink:hover { text-decoration: underline; }
   .rawpre { font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; background: #fafafa; padding: 8px; border-radius: 4px; max-height: 240px; overflow: auto; }
   #pane-raw { padding: 12px 16px; }
 `

--- a/src/trace/render/viewer-template.ts
+++ b/src/trace/render/viewer-template.ts
@@ -23,18 +23,25 @@ export const VIEWER_STYLES = `
   .nav-cause { background: #eef6ff; color: #2563eb; }
   .xlink { color: #36a; text-decoration: none; cursor: pointer; }
   .xlink:hover { text-decoration: underline; }
+  .xdim { color: #aaa; }
+  .rdetail { margin: 2px 0; font-family: ui-monospace, monospace; font-size: 11px; }
+  .rdetail summary { cursor: pointer; }
+  .rpre { white-space: pre-wrap; background: #fafafa; padding: 6px; border-radius: 4px; margin-top: 3px; }
+  .ar-na { color: #a13; }
   .rawpre { font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; background: #fafafa; padding: 8px; border-radius: 4px; max-height: 240px; overflow: auto; }
   #pane-raw { padding: 12px 16px; }
 `
 
 export const VIEWER_SCRIPT = `
 (function () {
-  var spine = JSON.parse(document.getElementById('spine-data').textContent || '{"nodes":[]}');
   var exps  = JSON.parse(document.getElementById('explanations-data').textContent || '{}');
   function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
   function nodeEl(id){ return document.querySelector('.node[data-id="'+CSS.escape(id)+'"]'); }
   function clearMarks(){ document.querySelectorAll('.node.selected,.node.cause').forEach(function(n){ n.classList.remove('selected','cause'); }); }
-  function chainHtml(chain){ return (chain||[]).map(function(c){ return '<a class="xlink" data-go="'+esc(c.eventId)+'">'+esc(c.summary)+'</a>'; }).join(' → '); }
+  function chainHtml(chain){ return (chain||[]).map(function(c){
+    if(exps[c.eventId]){ return '<a class="xlink" data-go="'+esc(c.eventId)+'">'+esc(c.summary)+'</a>'; }
+    return '<span class="xdim">'+esc(c.summary)+'</span>';
+  }).join(' → '); }
   function navHtml(causeId){
     var out='';
     if(causeId){ out += '<a class="nav-link nav-cause" data-go="'+esc(causeId)+'">← 谁导致的:'+esc((exps[causeId]&&exps[causeId].title)||causeId)+'</a>'; }

--- a/src/trace/render/viewer-template.ts
+++ b/src/trace/render/viewer-template.ts
@@ -1,0 +1,68 @@
+export const VIEWER_STYLES = `
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: #f7f7f8; color: #1c1c1e; }
+  h1 { font-size: 16px; margin: 0; padding: 12px 16px; border-bottom: 1px solid #e5e5e7; background: #fff; }
+  .tabs { display: flex; gap: 8px; padding: 8px 16px; background: #fff; border-bottom: 1px solid #e5e5e7; }
+  .tab { font-size: 12px; padding: 4px 12px; border-radius: 999px; border: 1px solid #d1d1d6; cursor: pointer; background: #fff; user-select: none; }
+  .tab.active { background: #1c1c1e; color: #fff; border-color: #1c1c1e; }
+  .pane { display: none; }
+  .pane.active { display: block; }
+  #pane-decision { display: flex; height: calc(100vh - 90px); }
+  #pane-decision.active { display: flex; }
+  .spine { width: 42%; border-right: 1px solid #e5e5e7; overflow: auto; padding: 8px; background: #fafafa; }
+  .node { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; padding: 5px 8px; margin: 3px 0; border-left: 3px solid transparent; border-radius: 3px; cursor: pointer; background: #fff; }
+  .node.k-llm { border-left-color: #5b3ec9; } .node.k-tool { border-left-color: #2563eb; }
+  .node.k-transition { border-left-color: #8a5a00; } .node.k-output { border-left-color: #1c1c1e; font-weight: 600; }
+  .node.selected { outline: 2px solid #f0a; }
+  .node.cause { background: #eef6ff; }
+  .spine-output .why-entry { color: #c026a6; font-size: 11px; margin-left: 6px; }
+  #why-panel { width: 58%; overflow: auto; padding: 14px; background: #fff; font-size: 13px; line-height: 1.6; }
+  #why-panel .ph { color: #888; }
+  #why-panel h3 { font-size: 14px; margin: 0 0 8px; }
+  .why-block { background: #f7f7f8; padding: 10px; border-radius: 6px; margin-bottom: 10px; }
+  .nav-link { display: block; padding: 6px 10px; border-radius: 5px; margin: 4px 0; cursor: pointer; }
+  .nav-cause { background: #eef6ff; color: #2563eb; } .nav-effect { background: #fef0f5; color: #a13; }
+  .rawpre { font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; background: #fafafa; padding: 8px; border-radius: 4px; max-height: 240px; overflow: auto; }
+  #pane-raw { padding: 12px 16px; }
+`
+
+export const VIEWER_SCRIPT = `
+(function () {
+  var spine = JSON.parse(document.getElementById('spine-data').textContent || '{"nodes":[]}');
+  var exps  = JSON.parse(document.getElementById('explanations-data').textContent || '{}');
+  function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  function nodeEl(id){ return document.querySelector('.node[data-id="'+CSS.escape(id)+'"]'); }
+  function clearMarks(){ document.querySelectorAll('.node.selected,.node.cause').forEach(function(n){ n.classList.remove('selected','cause'); }); }
+  function chainHtml(chain){ return (chain||[]).map(function(c){ return '<a class="xlink" data-go="'+esc(c.eventId)+'">'+esc(c.summary)+'</a>'; }).join(' → '); }
+  function navHtml(causeId){
+    var out='';
+    if(causeId){ out += '<a class="nav-link nav-cause" data-go="'+esc(causeId)+'">← 谁导致的:'+esc((exps[causeId]&&exps[causeId].title)||causeId)+'</a>'; }
+    return out;
+  }
+  function panelHtml(id){
+    var x = exps[id]; if(!x){ return '<p class="ph">选一个决策节点看 why</p>'; }
+    var h = '<h3>'+esc(x.title)+'</h3>';
+    h += '<div class="why-block">'+x.bodyHtml+'</div>';
+    h += '<div class="why-block">'+navHtml(x.causeDecisionId)+'<div style="color:#888;font-size:11px;margin-top:6px">因果链: '+chainHtml(x.chain)+'</div></div>';
+    h += '<details><summary style="cursor:pointer;color:#888;font-size:11px">原始 payload</summary><pre class="rawpre">'+esc(x.rawJson)+'</pre></details>';
+    return h;
+  }
+  function selectNode(id){
+    clearMarks();
+    var n = nodeEl(id); if(n){ n.classList.add('selected'); }
+    var cid = exps[id] && exps[id].causeDecisionId;
+    if(cid){ var cn = nodeEl(cid); if(cn){ cn.classList.add('cause'); } }
+    document.getElementById('why-panel').innerHTML = panelHtml(id);
+  }
+  document.addEventListener('click', function(ev){
+    var go = ev.target.closest('[data-go]'); if(go){ selectNode(go.getAttribute('data-go')); return; }
+    var node = ev.target.closest('.node[data-id]'); if(node){ selectNode(node.getAttribute('data-id')); return; }
+    var tab = ev.target.closest('.tab[data-tab]');
+    if(tab){
+      document.querySelectorAll('.tab').forEach(function(t){ t.classList.remove('active'); });
+      tab.classList.add('active');
+      document.querySelectorAll('.pane').forEach(function(p){ p.classList.remove('active'); });
+      document.getElementById('pane-'+tab.getAttribute('data-tab')).classList.add('active');
+    }
+  });
+})();
+`

--- a/src/trace/render/viewer.ts
+++ b/src/trace/render/viewer.ts
@@ -10,8 +10,16 @@ function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
 }
 
+interface PanelRecord {
+  title:            string
+  bodyHtml:         string
+  causeDecisionId?: string
+  chain:            Array<{ eventId: string; type: string; summary: string }>
+  rawJson:          string
+}
+
 // One panel "explanation" record per node, consumed verbatim by the client JS.
-function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>): unknown {
+function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>): PanelRecord {
   const base = {
     causeDecisionId: node.causeDecisionId,
     chain: [] as Array<{ eventId: string; type: string; summary: string }>,
@@ -51,7 +59,7 @@ export function renderViewer(events: Event[], opts: { regionContent?: Map<string
   const eventById = new Map<string, Event>()
   for (const e of events) eventById.set(e.id, e)
 
-  const explanations: Record<string, unknown> = {}
+  const explanations: Record<string, PanelRecord> = {}
   for (const node of spine.nodes) explanations[node.eventId] = panelRecord(events, node, eventById)
 
   const spineHtml = spine.nodes.map(n => {

--- a/src/trace/render/viewer.ts
+++ b/src/trace/render/viewer.ts
@@ -3,6 +3,7 @@ import { buildDecisionSpine, type DecisionNode } from '../diagnostics/buildDecis
 import { explainTransition } from '../diagnostics/explainTransition.js'
 import { explainLlmCall } from '../diagnostics/explainLlmCall.js'
 import { explainToolCall } from '../diagnostics/explainToolCall.js'
+import { contextRefsAt, type RegionContentRef } from '../RegionContextView.js'
 import { renderTimelineSections } from './html.js'
 import { VIEWER_STYLES, VIEWER_SCRIPT } from './viewer-template.js'
 
@@ -19,7 +20,7 @@ interface PanelRecord {
 }
 
 // One panel "explanation" record per node, consumed verbatim by the client JS.
-function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>): PanelRecord {
+function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>, regionContent: Map<string, string>): PanelRecord {
   const base = {
     causeDecisionId: node.causeDecisionId,
     chain: [] as Array<{ eventId: string; type: string; summary: string }>,
@@ -28,17 +29,26 @@ function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string,
   if (node.kind === 'transition') {
     const x = explainTransition(events, node.eventId)
     const guards = x.guards.map(g => `${esc(g.guardId)} 判定 ${esc(String(g.result))}`).join('、')
-    return { ...base, chain: x.causalChain, title: `为什么 ${esc(x.from)} → ${esc(x.to)}?`,
+    return { ...base, chain: x.causalChain, title: `为什么 ${x.from} → ${x.to}?`,
       bodyHtml: `触发: ${esc(x.trigger.causedBySummary ?? x.trigger.name)}<br>guard: ${guards || '(无)'}` }
   }
   if (node.kind === 'llm') {
     const x = explainLlmCall(events, node.eventId)
+    const refs: RegionContentRef[] = [...contextRefsAt(events, node.eventId, 'at').values()]
+    const comp = refs.map(r => {
+      const content = r.contentHash && regionContent.has(r.contentHash) ? regionContent.get(r.contentHash)! : undefined
+      const meta = `${esc(r.id)} · ${esc(r.section)} · ${esc(r.stability)}`
+      return content !== undefined
+        ? `<details class="rdetail"><summary>${meta}</summary><pre class="rpre">${esc(content)}</pre></details>`
+        : `<div class="rdetail">${meta} <span class="ar-na">(内容不可用)</span></div>`
+    }).join('')
     return { ...base, chain: x.causalChain, title: `为什么这次 LLM 调用?`,
-      bodyHtml: `state: ${esc(x.fsmState ?? '(未知)')}<br>触发: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>prompt 由 ${x.regionCount} 个 region 拼成` }
+      bodyHtml: `state: ${esc(x.fsmState ?? '(未知)')}<br>触发: ${esc(x.trigger.causedBySummary ?? '(无上游)')}`
+        + `<div style="margin-top:8px;font-weight:600">Assembled by ${refs.length} regions</div>${comp}` }
   }
   if (node.kind === 'tool') {
     const x = explainToolCall(events, node.eventId)
-    return { ...base, chain: x.causalChain, title: `工具 ${esc(x.toolName)}`,
+    return { ...base, chain: x.causalChain, title: `工具 ${x.toolName}`,
       bodyHtml: `调用方: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>入参: ${esc(JSON.stringify(x.input))}<br>出参: ${esc(JSON.stringify(x.output ?? null))}` }
   }
   // output
@@ -59,8 +69,9 @@ export function renderViewer(events: Event[], opts: { regionContent?: Map<string
   const eventById = new Map<string, Event>()
   for (const e of events) eventById.set(e.id, e)
 
+  const regionContent = opts.regionContent ?? new Map<string, string>()
   const explanations: Record<string, PanelRecord> = {}
-  for (const node of spine.nodes) explanations[node.eventId] = panelRecord(events, node, eventById)
+  for (const node of spine.nodes) explanations[node.eventId] = panelRecord(events, node, eventById, regionContent)
 
   const spineHtml = spine.nodes.map(n => {
     if (n.kind === 'output') {

--- a/src/trace/render/viewer.ts
+++ b/src/trace/render/viewer.ts
@@ -1,0 +1,91 @@
+import type { Event } from '../types.js'
+import { buildDecisionSpine, type DecisionNode } from '../diagnostics/buildDecisionSpine.js'
+import { explainTransition } from '../diagnostics/explainTransition.js'
+import { explainLlmCall } from '../diagnostics/explainLlmCall.js'
+import { explainToolCall } from '../diagnostics/explainToolCall.js'
+import { regionReuseCounts } from '../RegionContextView.js'
+import { renderTimelineSections } from './html.js'
+import { VIEWER_STYLES, VIEWER_SCRIPT } from './viewer-template.js'
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+}
+
+// One panel "explanation" record per node, consumed verbatim by the client JS.
+function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string, Event>): unknown {
+  const base = {
+    causeDecisionId: node.causeDecisionId,
+    chain: [] as Array<{ eventId: string; type: string; summary: string }>,
+    rawJson: JSON.stringify(eventById.get(node.eventId)?.payload ?? {}, null, 2),
+  }
+  if (node.kind === 'transition') {
+    const x = explainTransition(events, node.eventId)
+    const guards = x.guards.map(g => `${esc(g.guardId)} 判定 ${esc(String(g.result))}`).join('、')
+    return { ...base, chain: x.causalChain, title: `为什么 ${esc(x.from)} → ${esc(x.to)}?`,
+      bodyHtml: `触发: ${esc(x.trigger.causedBySummary ?? x.trigger.name)}<br>guard: ${guards || '(无)'}` }
+  }
+  if (node.kind === 'llm') {
+    const x = explainLlmCall(events, node.eventId)
+    return { ...base, chain: x.causalChain, title: `为什么这次 LLM 调用?`,
+      bodyHtml: `state: ${esc(x.fsmState ?? '(未知)')}<br>触发: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>prompt 由 ${x.regionCount} 个 region 拼成` }
+  }
+  if (node.kind === 'tool') {
+    const x = explainToolCall(events, node.eventId)
+    return { ...base, chain: x.causalChain, title: `工具 ${esc(x.toolName)}`,
+      bodyHtml: `调用方: ${esc(x.trigger.causedBySummary ?? '(无上游)')}<br>入参: ${esc(JSON.stringify(x.input))}<br>出参: ${esc(JSON.stringify(x.output ?? null))}` }
+  }
+  // output
+  const evt = eventById.get(node.eventId)
+  const out = (evt?.payload as { lastTextOutput?: string; status?: string } | undefined)
+  return { ...base, chain: [], title: '为什么是这个结果?',
+    bodyHtml: `输出: ${esc(out?.lastTextOutput ?? out?.status ?? '')}<br>由上游决策产生(点 ← 谁导致的 下钻)` }
+}
+
+/**
+ * Causal drill-down trace viewer: decision spine + Why panel + a raw timeline
+ * tab. Self-contained static HTML; all explanations precomputed and embedded,
+ * client JS only looks them up. Pure projection (region content hydration is
+ * the caller's job, passed via opts, same as renderHtml).
+ */
+export function renderViewer(events: Event[], opts: { regionContent?: Map<string, string> } = {}): string {
+  const spine = buildDecisionSpine(events)
+  const eventById = new Map<string, Event>()
+  for (const e of events) eventById.set(e.id, e)
+
+  const explanations: Record<string, unknown> = {}
+  for (const node of spine.nodes) explanations[node.eventId] = panelRecord(events, node, eventById)
+
+  const spineHtml = spine.nodes.map(n => {
+    if (n.kind === 'output') {
+      return `<div class="spine-output"><div class="node k-output" data-id="${esc(n.eventId)}">${esc(n.label)}<span class="why-entry">❓ 为什么是这个结果</span></div></div>`
+    }
+    return `<div class="node k-${n.kind}" data-id="${esc(n.eventId)}">${esc(n.label)}</div>`
+  }).join('')
+
+  const spineJson = JSON.stringify(spine).replace(/<\/script/gi, '<\\/script')
+  const expsJson = JSON.stringify(explanations).replace(/<\/script/gi, '<\\/script')
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>milkie trace viewer</title>
+<style>${VIEWER_STYLES}</style>
+</head>
+<body>
+<h1>milkie trace viewer</h1>
+<div class="tabs">
+  <span class="tab active" data-tab="decision">决策视图</span>
+  <span class="tab" data-tab="raw">原始时间线</span>
+</div>
+<div id="pane-decision" class="pane active">
+  <div class="spine">${spineHtml || '<p style="color:#888;font-size:12px">无决策事件</p>'}</div>
+  <div id="why-panel"><p class="ph">从底部输出 ❓ 或任一决策点开始</p></div>
+</div>
+<div id="pane-raw" class="pane">${renderTimelineSections(events, opts)}</div>
+<script type="application/json" id="spine-data">${spineJson}</script>
+<script type="application/json" id="explanations-data">${expsJson}</script>
+<script>${VIEWER_SCRIPT}</script>
+</body>
+</html>`
+}

--- a/src/trace/render/viewer.ts
+++ b/src/trace/render/viewer.ts
@@ -3,7 +3,6 @@ import { buildDecisionSpine, type DecisionNode } from '../diagnostics/buildDecis
 import { explainTransition } from '../diagnostics/explainTransition.js'
 import { explainLlmCall } from '../diagnostics/explainLlmCall.js'
 import { explainToolCall } from '../diagnostics/explainToolCall.js'
-import { regionReuseCounts } from '../RegionContextView.js'
 import { renderTimelineSections } from './html.js'
 import { VIEWER_STYLES, VIEWER_SCRIPT } from './viewer-template.js'
 


### PR DESCRIPTION
Closes #64

## Summary

把 `milkie trace report` 从平铺时间线重组成"**决策脊柱 + Why 面板 + 点击下钻**"的诊断 viewer——从一个输出/可疑步,**两次点击钻到"哪步决策错了、为什么"**。纯静态自包含 HTML projection,零 LLM/存储/schema 变更。

- `buildDecisionSpine(events)`(`diagnostics/`):events → 决策节点(LLM/工具/转移/输出),含"最近决策祖先"`causeDecisionId`。
- `explainToolCall(events, id)`(`diagnostics/`):工具节点 why,平行 explainTransition/explainLlmCall。
- `renderViewer` + `viewer-template`(`render/`):两栏 HTML + 内嵌 explanation JSON + vanilla JS(选中/下钻/高亮),复用 explainTransition/explainLlmCall/explainToolCall/contextRefsAt/walkCausedBy。LLM 面板含 #26 region composition + 内容预览。
- `renderTimelineSections`(从 `renderHtml` 抽出,byte-identical):raw 全时间线作次要 tab。
- CLI `trace report` → `renderViewer`(`render-html` 仍出旧平铺报告)。

## 设计/验收(brainstorm + 可视化 mockup + 浏览器实测)

- 范式 A(决策脊柱+Why面板)、时间序、viewer 主输出 + raw tab —— 经可视化 mockup 逐一定稿。
- **浏览器实测通过**:① 点输出 ❓ → 面板出因、脊柱高亮;② 点"← 谁导致的" → 选中上移、面板刷新(两次点击到决策);③ LLM 面板 Assembled-by + 可展开真实内容;④ raw tab 全事件。
- MVP 砍 DAG/diff/失败路径(future);web 面板集成(agent-docs-qa)单独 follow-up。

## Test Plan

- [x] 全量单测:54 套件 / 473 通过 / 16 skip;`tsc` + `npm run build` 干净
- [x] `buildDecisionSpine`(过滤/序/causeDecisionId)、`explainToolCall`(投影/配对/抛错)、`renderTimelineSections`(byte-identical 重构)、`renderViewer`(结构/无决策/composition)
- [x] **dev-browser 实测**"两次点击到根因" + LLM composition

## 设计/计划

`docs/superpowers/specs/2026-05-31-trace-viewer-design.md`、`docs/superpowers/plans/2026-05-31-trace-viewer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)