### PR TITLE
fix(example): agent-docs-qa 用 doubao 模型(修 gpt-4o-mini coding 端点被拒)

### DIFF
--- a/examples/agent-docs-qa/agents/sanguo-researcher.md
+++ b/examples/agent-docs-qa/agents/sanguo-researcher.md
@@ -31,8 +31,8 @@ fsm:
         再次怀疑、且 verifier 已加载,直接以严格模式重新验证即可。
       tools: [list_dir, read_file, grep, skill_request]
 model:
-  provider: openai
-  model: gpt-4o-mini
+  provider: volcengine
+  model: doubao-seed-2-0-pro-260215
   adapter: openai-compatible
 skills:
   verifier: "0.1.0"


### PR DESCRIPTION
Closes #66

## Summary

`examples/agent-docs-qa` 的 agent 配了 `gpt-4o-mini`,但 `createGateway` 走 `VOLCENGINE_API_BASE`(Volcengine Ark **coding 端点**),该端点只认 doubao 系模型 → `404 ... does not support the coding plan feature`,示例 web playground 不可用。

改 `agents/sanguo-researcher.md`:`gpt-4o-mini` → `doubao-seed-2-0-pro-260215`,`provider: openai` → `volcengine`(参考 alfred `config/dolphin.yaml` 同端点配法)。baseUrl/apiKey 走 env 不变。

## Test Plan

- [x] `npx tsx server.ts` 起 playground,POST /chat `{"input":"曹操是谁"}` → status completed、返回带语料引用的真实回答(已实测)

🤖 Generated with [Claude Code](https://claude.com/claude-code)