### PR TITLE
feat(#68): decision attribution in agent-docs-qa audit panel

### DIFF
--- a/docs/superpowers/plans/2026-05-31-trace-attribution-web-panel.md
+++ b/docs/superpowers/plans/2026-05-31-trace-attribution-web-panel.md
@@ -1,0 +1,447 @@
+# #68 决策因果归因接进 agent-docs-qa audit panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 #64 的决策脊柱+Why+因果下钻 viewer，作为一个 iframe tab 接进 agent-docs-qa 的 live audit panel，并接通 region 内容持久化让 #26 预览可用。
+
+**Architecture:** 整块复用核心 `renderViewer`（零 `src/trace/*` 改动）。后端给 example 的 `Milkie` 接 `FileTraceObjectStore`（让 region 内容落盘），新增 `GET /run/:runId/viewer` endpoint（`readByRunId` + hydrate regionContent + `renderViewer` → 完整 HTML 文档）；前端把它作为 lazy `<iframe>` 渲染在新「Why」tab 里，#64 自带 JS 在 iframe 内自跑。
+
+**Tech Stack:** Node `http` server（vanilla，无框架）、vanilla JS 前端、Vitest + StubGateway 注入、相对路径 import 核心 `../../src/`。
+
+**Spec:** `docs/superpowers/specs/2026-05-31-trace-attribution-web-panel-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 改动 |
+|---|---|---|
+| `examples/agent-docs-qa/server.ts` | HTTP server + Milkie 装配 | 接 `FileTraceObjectStore`；新增 viewer endpoint + handler |
+| `examples/agent-docs-qa/public/index.html` | 单文件前端 | 新增「Why」tab（iframe）+ CSS；Steps→Execution |
+| `examples/agent-docs-qa/__tests__/server.test.ts` | server 测试 | objectStore 持久化测试 + viewer endpoint 测试 |
+
+不改任何 `src/trace/*`。
+
+---
+
+## Task 1: 给 example 的 Milkie 接 FileTraceObjectStore（region 内容落盘）
+
+**Files:**
+- Modify: `examples/agent-docs-qa/server.ts`（imports；`ServerState`；`startServer`）
+- Test: `examples/agent-docs-qa/__tests__/server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+加到 `describe('server — REST endpoints', …)` 内（紧跟现有 `POST /chat` 测试之后）：
+
+```typescript
+  it('persists region content to .milkie/objects after a run', async () => {
+    await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const objectsDir = path.join(exampleDir, '.milkie', 'objects')
+    expect(fs.existsSync(objectsDir)).toBe(true)
+    // A run composes context regions; their canonical content is written to
+    // the trace object store. Non-empty objects dir proves the wiring.
+    const entries = fs.readdirSync(objectsDir)
+    expect(entries.length).toBeGreaterThan(0)
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "persists region content"`
+Expected: FAIL — `objectsDir` 不存在或为空（当前 Milkie 未挂 traceObjectStore）。
+
+- [ ] **Step 3: Add imports**
+
+在 `examples/agent-docs-qa/server.ts` 顶部 import 区（现有 `import { JsonlEventStore } …` 一带）追加：
+
+```typescript
+import { FileTraceObjectStore } from '../../src/trace/TraceObjectStore.js'
+```
+
+- [ ] **Step 4: Extend ServerState**
+
+把 `interface ServerState`（现 server.ts:24-30）改为含 traceObjectStore：
+
+```typescript
+interface ServerState {
+  milkie:           Milkie
+  eventStore:       BroadcastingEventStore
+  traceObjectStore: FileTraceObjectStore
+  runsDir:          string
+  publicDir:        string
+  corpusRoot:       string
+}
+```
+
+- [ ] **Step 5: Wire it in startServer**
+
+在 `startServer` 里，把 runsDir 创建之后、`new Milkie(...)` 之前插入 objects 目录与 store；并把 traceObjectStore 传进 Milkie 和 state。替换现有 server.ts:221-243 这段为：
+
+```typescript
+  const runsDir = path.join(config.exampleDir, '.milkie', 'runs')
+  if (!existsSync(runsDir)) mkdirSync(runsDir, { recursive: true })
+
+  const objectsDir = path.join(config.exampleDir, '.milkie', 'objects')
+  if (!existsSync(objectsDir)) mkdirSync(objectsDir, { recursive: true })
+  const traceObjectStore = new FileTraceObjectStore(objectsDir)
+
+  const eventStore = new BroadcastingEventStore(new JsonlEventStore(runsDir))
+  const milkie     = new Milkie({
+    stateStore: new MemoryStore(),
+    gateway:    config.gateway,   // when omitted, Milkie falls back to createGateway(agent.model) per-invoke
+    eventStore,
+    traceObjectStore,
+  })
+
+  for (const tool of makeCorpusToolDefinitions(config.corpusRoot)) {
+    milkie.registerTool(tool)
+  }
+  milkie.loadAgentFile(config.agentFile)
+
+  // Public dir resolution: prefer co-located public/ when present (production
+  // mode using the real example dir), else fall back to this file's
+  // sibling public/ (test mode where exampleDir is a tmpDir).
+  const colocatedPublic = path.join(config.exampleDir, 'public')
+  const fallbackPublic  = path.resolve(__dirname, 'public')
+  const publicDir = existsSync(colocatedPublic) ? colocatedPublic : fallbackPublic
+
+  const state: ServerState = { milkie, eventStore, traceObjectStore, runsDir, publicDir, corpusRoot: config.corpusRoot }
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "persists region content"`
+Expected: PASS。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/agent-docs-qa/server.ts examples/agent-docs-qa/__tests__/server.test.ts
+git commit -m "feat(#68): wire FileTraceObjectStore into agent-docs-qa so region content persists"
+```
+
+---
+
+## Task 2: 新增 GET /run/:runId/viewer endpoint
+
+**Files:**
+- Modify: `examples/agent-docs-qa/server.ts`（imports；新 handler；路由）
+- Test: `examples/agent-docs-qa/__tests__/server.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+加到 server 测试 describe 内：
+
+```typescript
+  it('GET /run/:runId/viewer returns the decision viewer HTML', async () => {
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const { runId } = JSON.parse(chat.body) as { runId: string }
+
+    const r = await get(`${baseUrl}/run/${runId}/viewer`)
+    expect(r.status).toBe(200)
+    // renderViewer emits a self-contained document with the decision spine.
+    expect(r.body).toContain('<!doctype html>')
+    expect(r.body).toContain('milkie trace viewer')
+    expect(r.body).toContain('data-id=')        // spine nodes
+    expect(r.body).toContain('spine-output')     // the output node with ❓ entry
+  })
+
+  it('GET /run/:runId/viewer 404s on an unknown run', async () => {
+    const r = await get(`${baseUrl}/run/does-not-exist/viewer`)
+    expect(r.status).toBe(404)
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "viewer"`
+Expected: FAIL — 路由未命中，返回 404 给第一个测试（"返回 viewer HTML" 断言失败），404 测试可能恰好过（默认 404）但第一个必失。
+
+- [ ] **Step 3: Add imports**
+
+在 server.ts 顶部 import 区追加（接 Task 1 的 import 之后）：
+
+```typescript
+import { regionReuseCounts } from '../../src/trace/RegionContextView.js'
+import { renderViewer } from '../../src/trace/render/viewer.js'
+```
+
+- [ ] **Step 4: Add the handler**
+
+在 `handleReplay` 之后（server.ts:174 之后）新增：
+
+```typescript
+async function handleViewer(
+  res: ServerResponse, s: ServerState, runId: string,
+): Promise<void> {
+  const events = await s.eventStore.readByRunId(runId)
+  if (events.length === 0) {
+    sendJson(res, 404, { error: 'run not found' })
+    return
+  }
+  // Hydrate region content the same way `milkie trace report` does
+  // (cli/main.ts): look up each region's canonical content by hash.
+  const regionContent = new Map<string, string>()
+  for (const h of regionReuseCounts(events).keys()) {
+    const c = await s.traceObjectStore.getCanonical(h)
+    if (c !== undefined) regionContent.set(h, c)
+  }
+  const html = renderViewer(events, { regionContent })
+  res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+  res.end(html)
+}
+```
+
+- [ ] **Step 5: Add the route**
+
+在路由块里，`replayMatch` 分支之后（server.ts:268 之后）插入：
+
+```typescript
+      const viewerMatch = route.match(/^\/run\/([^/]+)\/viewer$/)
+      if (req.method === 'GET' && viewerMatch) {
+        return handleViewer(res, state, decodeURIComponent(viewerMatch[1]!))
+      }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "viewer"`
+Expected: PASS（两个）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/agent-docs-qa/server.ts examples/agent-docs-qa/__tests__/server.test.ts
+git commit -m "feat(#68): GET /run/:runId/viewer renders the #64 decision viewer (reuses renderViewer)"
+```
+
+---
+
+## Task 3: 前端「Why」tab（iframe）+ Steps 改名 Execution
+
+**Files:**
+- Modify: `examples/agent-docs-qa/public/index.html`（tab 按钮、CSS、`renderAuditBody`）
+- Test: `examples/agent-docs-qa/__tests__/server.test.ts`（GET / 回归断言新 tab）
+
+- [ ] **Step 1: Write the failing test**
+
+加到 server 测试 describe 内：
+
+```typescript
+  it('serves the audit panel with a Why tab', async () => {
+    const r = await get(`${baseUrl}/`)
+    expect(r.status).toBe(200)
+    expect(r.body).toContain('data-tab="why"')
+    expect(r.body).toContain('>Why<')
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "Why tab"`
+Expected: FAIL — index.html 尚无 `data-tab="why"`。
+
+- [ ] **Step 3: Add the tab button + rename Steps**
+
+把 index.html:460-464 的 tab 栏：
+
+```html
+    <div class="ap-tabs">
+      <div class="ap-tab active" data-tab="sources">Sources</div>
+      <div class="ap-tab" data-tab="steps">Steps</div>
+      <div class="ap-tab" data-tab="provenance">Provenance</div>
+    </div>
+```
+
+改为：
+
+```html
+    <div class="ap-tabs">
+      <div class="ap-tab active" data-tab="sources">Sources</div>
+      <div class="ap-tab" data-tab="steps">Execution</div>
+      <div class="ap-tab" data-tab="provenance">Provenance</div>
+      <div class="ap-tab" data-tab="why">Why</div>
+    </div>
+```
+
+（`data-tab="steps"` 不变 → `renderStepsTab` 逻辑零改动，只改可见文案。）
+
+- [ ] **Step 4: Add iframe CSS**
+
+在 index.html 的 `#audit-panel .ap-body { … }` 规则（约 index.html:191）之后追加：
+
+```css
+    #audit-panel .ap-body.viewer { padding: 0 }
+    #audit-panel .ap-viewer-frame { display: block; width: 100%; height: 100%; border: 0 }
+```
+
+- [ ] **Step 5: Render the iframe in renderAuditBody**
+
+把 `renderAuditBody`（index.html:1241-1261）改为：在取到 `msgEl` 后先按是否 why 切换 `.viewer` class，再加 why 分支。替换整个函数体为：
+
+```javascript
+    function renderAuditBody() {
+      if (!auditAnchorRunId) { $auditBody.innerHTML = ''; return }
+      const msgEl = $log.querySelector(`.msg.assistant[data-run-id="${auditAnchorRunId}"]`)
+      $auditBody.classList.toggle('viewer', auditActiveTab === 'why')
+      if (auditActiveTab === 'sources') {
+        $auditBody.innerHTML = renderSourcesTab(auditAnchorRunId, msgEl)
+      } else if (auditActiveTab === 'steps') {
+        $auditBody.innerHTML = renderStepsTab(auditAnchorRunId)
+      } else if (auditActiveTab === 'why') {
+        // Reuse the core #64 decision viewer wholesale: it is a self-contained
+        // HTML document (own CSS + drill-down JS), so an iframe isolates it and
+        // its "two clicks to root cause" interactions run inside the frame.
+        $auditBody.innerHTML =
+          `<iframe class="ap-viewer-frame" src="/run/${encodeURIComponent(auditAnchorRunId)}/viewer"></iframe>`
+      } else if (auditActiveTab === 'provenance') {
+        $auditBody.innerHTML = `<div class="ap-empty">Analyzing answer against sources…</div>`
+        // Async render: classifies each segment after fetching its source.
+        // Capture runId so a fast tab switch doesn't paint stale results
+        // over a panel that has since changed anchor.
+        const pendingRunId = auditAnchorRunId
+        const pendingTab   = auditActiveTab
+        renderProvenanceTab(auditAnchorRunId).then(html => {
+          if (auditAnchorRunId === pendingRunId && auditActiveTab === pendingTab) {
+            $auditBody.innerHTML = html
+          }
+        })
+      }
+    }
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd examples/agent-docs-qa && npx vitest run __tests__/server.test.ts -t "Why tab"`
+Expected: PASS。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/agent-docs-qa/public/index.html examples/agent-docs-qa/__tests__/server.test.ts
+git commit -m "feat(#68): add Why tab (iframe decision viewer) to audit panel; rename Steps→Execution"
+```
+
+---
+
+## Task 4: Live 验证（dev-browser）— 两次点击到根因 + 真实 region 预览
+
+> 这是手工/自动化浏览器验证（覆盖 #68 验收第 1、3 条），不产出 committed 单测（与 #64 的 dev-browser 验证一致）。
+
+**Files:** 无代码改动（纯验证）。如发现 bug，回到 Task 1-3 修。
+
+- [ ] **Step 1: 起 server（真实 doubao，#66 修复后）**
+
+```bash
+cd examples/agent-docs-qa && PORT=7878 npx tsx server.ts
+```
+打开 `http://localhost:7878`，发一条真实问题（如"刘备和诸葛亮的关系？"），等回答完成。
+
+- [ ] **Step 2: dev-browser 验证「两次点击到根因」（验收第 1 条）**
+
+用 dev-browser skill：
+1. 点 assistant 消息下的 "View audit ▾" 打开 panel
+2. 点 **Why** tab → 断言 `iframe.ap-viewer-frame` 出现、加载完成
+3. 进 iframe：点输出节点的 "❓ 为什么是这个结果" → 断言右侧 Why 面板渲染出"因"的解释、且该因脊柱节点高亮（`.cause`）
+4. 点面板里 "← 谁导致的" → 断言选中（`.selected`）上移一层、面板内容刷新 = **两次点击到根因**
+
+- [ ] **Step 3: 验证真实 region composition 内容预览（验收第 3 条）**
+
+在 Why tab 的 iframe 里选中一个 LLM 节点 → 断言其 composition 区出现真实 region 内容预览（非"(内容不可用)"占位）。这依赖 Task 1 的 objectStore 落盘 + doubao 真实 run。
+
+- [ ] **Step 4: 记录验证结果**
+
+把 dev-browser 的关键断言/截图结论记到 PR 描述里（这是 #68 验收证据）。
+
+---
+
+## Task 5: 收尾 — 全量测试、提交、PR、follow-up issue
+
+**Files:** 无新代码改动。
+
+- [ ] **Step 1: 全量测试 + 类型检查**
+
+Run（仓库根）:
+```bash
+npm test
+npx tsc --noEmit
+```
+Expected: 全绿（含 example 的 server.test.ts 新增 4 个用例、既有用例不破）。
+
+- [ ] **Step 2: 确认 roadmap.md 不混入**
+
+```bash
+git status --short
+```
+`roadmap.md` 若仍是用户未提交 WIP，**不要** stage 它。只确认本 PR 的 commit 都是 #68 相关。
+
+- [ ] **Step 3: Push 分支**
+
+```bash
+git push -u origin feat/68-trace-attribution-in-web-panel
+```
+
+- [ ] **Step 4: 开 PR（body 默认带 Closes #68）**
+
+```bash
+gh pr create --title "feat(#68): decision attribution in agent-docs-qa audit panel" --body "$(cat <<'EOF'
+把 #64 的决策脊柱+Why+因果下钻 viewer 接进 agent-docs-qa 的 live audit panel。
+
+## 做了什么
+- 给 example 的 Milkie 接 `FileTraceObjectStore` → region 内容落盘（#26 预览可用）
+- 新增 `GET /run/:runId/viewer`：readByRunId + hydrate regionContent + 整块复用核心 `renderViewer`（零 `src/trace/*` 改动）
+- audit panel 新增 **Why** tab（lazy iframe，#64 自带下钻 JS 在 frame 内自跑）；Steps 改名 Execution，与 Why 形成「成本/上下文」vs「因果/为什么」两个镜头
+
+## 验收（#68）
+- [x] localhost web UI 两次点击到根因 — dev-browser 验证（见下）
+- [x] 复用核心投影、前端不自带归因逻辑 — 整块 renderViewer iframe
+- [x] 真实 doubao run 能看到真实 region composition 内容预览
+
+<verification screenshots / notes>
+
+Closes #68
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: 开 follow-up issue（Steps 投影化重构，本 PR 不做）**
+
+```bash
+gh issue create --title "[diagnosable] 把 agent-docs-qa 的 Execution(原 Steps) tab 改成投影驱动" --body "$(cat <<'EOF'
+Parent: #20 ;follow-up of #68
+
+## Why
+#68 给 audit panel 加了 Why tab（整块复用核心 renderViewer），但 Execution(原 Steps) tab 仍是**前端自己解析事件重写归因**（`renderStepsTab`），违反 ARCHITECTURE.md「UI = projection over CLI/SDK，前端不自带归因逻辑」。
+
+## What
+把 Steps 的 LLM/tool/region/cache 视图从前端重写改成消费核心投影（server 出投影 JSON 或复用核心渲染），消除前端归因逻辑。保留其 cache health 分级 / region by stability 的 UX 价值。
+
+## Related
+- follow-up of #68;依赖 #26 / Phase 4a cache
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 接 FileTraceObjectStore → Task 1 ✓
+- §4.2 GET /run/:runId/viewer（readByRunId + hydrate + renderViewer + 404）→ Task 2 ✓
+- §4.3 新 tab（lazy iframe）+ Steps 重命名 + renderAuditBody → Task 3 ✓
+- §4.4 镜头分工（命名）→ Task 3 文案 ✓
+- §7 测试（200+脊柱标记、404、objectStore 落盘、live 两次点击、真实预览）→ Task 1/2/3 单测 + Task 4 dev-browser ✓
+- §9 follow-up issue → Task 5 Step 5 ✓
+- 验收三条 → Task 2/3 单测 + Task 4 验证 ✓
+
+**Placeholder scan:** 无 TBD/TODO；唯一 `<verification ...>` 占位是 PR body 里待填的人工验证证据（Task 4 Step 4 产出），非代码占位。
+
+**Type consistency:** `traceObjectStore: FileTraceObjectStore` 在 ServerState（Task 1）定义、handler（Task 2）用 `s.traceObjectStore.getCanonical`；`renderViewer(events, { regionContent })` 签名与核心一致；`regionReuseCounts(events)` 返回 `Map<string,number>`，`.keys()` 为 hash 串，与 `getCanonical(hash)` 入参一致；`data-tab="why"` 与 `renderAuditBody` 的 `auditActiveTab === 'why'` 一致。
+
+**已知偏离 spec:** tab 标签用英文（Execution/Why）而非 spec 的中文（执行·成本/决策·为什么），为与现有英文 UI 一致；功能等价，可一行调整。
+
+**作用域:** 单 PR、聚焦 example，不碰核心。

--- a/docs/superpowers/specs/2026-05-31-trace-attribution-web-panel-design.md
+++ b/docs/superpowers/specs/2026-05-31-trace-attribution-web-panel-design.md
@@ -1,0 +1,127 @@
+# #68 把决策因果归因接进 agent-docs-qa 的 web audit panel — 设计 spec
+
+**Issue:** #68（diagnosable；Parent #20；依赖 #64 决策 viewer，及 #26/#30/#31/#33/#34，均已落地于 main）
+**日期:** 2026-05-31
+**定位:** 把 #64 已聚合好的「决策脊柱 + Why 面板 + 因果下钻」搬进 `examples/agent-docs-qa` 这个**参考 web 应用**的 live audit panel——**整块复用核心 `renderViewer`，零核心代码改动**，守住 ARCHITECTURE.md「UI = projection over CLI/SDK，前端不自带归因逻辑」。
+
+经 brainstorm 定稿：集成形态 = 方案 A（复用 renderViewer，iframe 嵌入为新 tab）；Steps 处理 = 保留并重定位（分工镜头），其投影化重构踢成独立 follow-up。
+
+---
+
+## 1. 目标
+
+用户在运行的 localhost web UI 里（不再只能开独立 HTML），对一次真实对话能**因果下钻**——从输出两次点击钻到根因。把 #64 的全部归因能力（FSM 转移 / #30 因果 / #33 转移why / #34 llm-why+#26 composition / #31 guard / #64 工具why + 脊柱 + 下钻）呈现在 panel 里，和 panel 已有的「源溯源」(Sources/Provenance) 并存。
+
+## 2. 背景与现状
+
+agent-docs-qa 是 milkie 的**参考应用**——演示能力 + 示范正确架构。其右侧 audit panel 现有三个 tab：
+
+- **Sources** — 答案引用的源文档（源归因）
+- **Steps** — region 列表 + cache health（#26 + Phase 4a）；**前端自己解析事件重写**（`renderStepsTab`）
+- **Provenance** — 答案段落 → 源文档验证（源归因）
+
+缺口：决策→成因（为什么这么跳/这么调/prompt 怎么拼）= 零（grep `explainTransition`/`explainLlmCall`/`fsm.transition`/`causedBy` 全无命中）。且 Steps 的前端重写正是 ARCHITECTURE.md 不让做的反模式。
+
+核心侧 #64 的 `renderViewer(events, { regionContent })`（`src/trace/render/viewer.ts`）已把全部决策归因聚合在一个**自包含两栏 HTML 文档**里，但它是无 server 的静态 post-hoc 输出（`trace report` 的主输出）。
+
+## 3. Non-goals
+
+- **零核心改动**：不改 `src/trace/*`，整块复用 `renderViewer`。
+- **不重构 Steps**：Steps 改投影驱动（消除前端重写）= 独立 follow-up issue，不进本 PR。"加能力"与"重构旧代码"分开走，避免 PR 膨胀。
+- **MVP 不做**：viewer tab 的 live 自动刷新、descendant 子 run 合并、DAG/diff/搜索/跨 run 导航。
+
+## 4. 架构与组件
+
+```
+examples/agent-docs-qa/
+  server.ts        // 接 FileTraceObjectStore；新增 GET /run/:runId/viewer
+  public/index.html// 新增「决策·为什么」tab（iframe）；Steps 改名「执行·成本」
+  __tests__/server.test.ts // viewer endpoint 测试
+```
+
+复用（不改）：`src/trace/render/viewer.ts` 的 `renderViewer`、`src/trace/TraceObjectStore.ts` 的 `FileTraceObjectStore`。
+
+### 4.1 后端 — `FileTraceObjectStore` 装配（必须项）
+
+`server.ts:startServer` 现以 `new Milkie({ stateStore, gateway, eventStore })` 构造，**未挂 traceObjectStore** → region 内容不落盘 → #26 预览只能降级"(内容不可用)"，过不了验收第 3 条。
+
+改动：
+- `const traceObjectStore = new FileTraceObjectStore(path.join(config.exampleDir, '.milkie', 'objects'))`
+- 传进 `new Milkie({ …, traceObjectStore })`，使 region 内容在 invoke 期间落盘
+- 存进 `ServerState`，供 viewer endpoint hydrate
+
+### 4.2 后端 — `GET /run/:runId/viewer` → HTML
+
+平行现有 `POST /run/:runId/replay`（`server.ts:126` 已用 `eventStore.readByRunId(runId)`）：
+
+1. `events = await eventStore.readByRunId(runId)`；空 → 404
+2. hydrate regionContent：照搬 `cli/main.ts:195-201` 模式——遍历事件里 region 的内容 hash，`traceObjectStore.getCanonical(hash)` 命中则填入 `Map<hash, content>`
+3. `return renderViewer(events, { regionContent })`，`Content-Type: text/html`
+
+作用域 = 单 runId（MVP）。example 的 `sanguo-researcher` 是单 agent ReAct，不 spawn 子 run；descendant 合并留作扩展。
+
+### 4.3 前端 — 新 tab + 重命名（`public/index.html`）
+
+- tab 栏（现 `data-tab="sources|steps|provenance"`，行 ~460）新增 `<div class="ap-tab" data-tab="why">决策 · 为什么</div>`
+- Steps 按钮可见文案改 `执行 · 成本`（**仅改文案**；`data-tab="steps"` 与 `renderStepsTab` 不动，保留其 cache health/region 分组 UX）
+- `renderAuditBody` 对 `why` tab 渲染 `<iframe class="ap-viewer-frame" src="/run/${runId}/viewer">`，撑满 `ap-body`、border:none；**lazy 设 src**（切到该 tab 才加载）
+- #64 viewer 的脊柱/Why/下钻 vanilla JS 在 iframe 内自跑，样式/JS 天然隔离（renderViewer 出完整 `<!doctype html>` 文档）
+
+最终四 tab：`Sources` · `执行·成本` · `Provenance` · `决策·为什么`
+
+### 4.4 镜头分工（产品决策）
+
+Steps 与新 tab **非冗余，是两个镜头**，命名上明确分工：
+
+| tab | 回答 | 能力 |
+|---|---|---|
+| 执行·成本（原 Steps） | 做了什么 / 花多少 | cache 健康、region by stability（#26 + Phase 4a） |
+| 决策·为什么（新） | 为什么这么做 | 因果下钻、FSM 转移、why、guard（#30/#31/#33/#34/#64） |
+
+## 5. 数据流 / 下钻
+
+- viewer endpoint 在请求期算好全部 explanation 并内嵌（#64 既有机制，纯投影、客户端不重算）
+- "两次点击到根因" = iframe 内：点输出 ❓ → 选中其因（最近决策祖先）+ 脊柱高亮 → 点"← 谁导致的" → 再上钻一层
+- live：MVP 打开 tab 时按当前已落盘事件渲染；run 进行中可重开/刷新（#64 本就 post-hoc，验收针对已完成 run）
+
+## 6. 错误处理 / 边界
+
+- 未知 runId → endpoint 404；前端 iframe 显示错误页（沿用 server 默认）
+- region 无内容 hash / objectStore 未命中 → composition 降级"(内容不可用)"（沿用 #26/#64）
+- 无决策事件的 run → 脊柱空、面板提示（#64 既有行为）
+- 旧 run（接 objectStore 之前产生的，objects 目录无内容）→ 预览降级，不报错
+
+## 7. 测试
+
+- **`server.test.ts`**：
+  - `GET /run/:id/viewer` → 200 + `Content-Type: text/html`；body 含脊柱标记（`data-id`、`spine-output`、内嵌 spine JSON）
+  - 未知 runId → 404
+  - 真实 stub run（产生 region.added）后，viewer body 含真实 region 内容预览（覆盖**验收第 3 条**；前置 = objectStore 已接）
+  - 现有测试全绿（含 Steps tab 文案改动不破坏断言）
+- **dev-browser（live 验证，覆盖验收第 1 条）**：起 server → 发一次 chat → 开 audit panel → 点「决策·为什么」→ iframe 加载 → 点输出 ❓ → 断言 Why 面板出"因" + 该因脊柱节点高亮 → 点"← 谁导致的" → 断言选中上移、面板刷新 = **两次点击到根因**
+
+## 8. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `examples/agent-docs-qa/server.ts` | 接 `FileTraceObjectStore` 进 Milkie + ServerState；新增 `GET /run/:runId/viewer` handler（readByRunId + hydrate regionContent + renderViewer） |
+| `examples/agent-docs-qa/public/index.html` | 新增「决策·为什么」tab（lazy iframe）；Steps 文案改「执行·成本」；`renderAuditBody` 处理 `why` |
+| `examples/agent-docs-qa/__tests__/server.test.ts` | viewer endpoint 测试（200+脊柱标记、404、regionContent 预览） |
+| dev-browser 自动化 | "两次点击到根因" live 验证 |
+
+不改任何 `src/trace/*`（整块复用）。
+
+## 9. Follow-up（不进本 PR）
+
+- 新开 issue：把 Steps（`renderStepsTab`）从"前端解析事件重写归因"改成消费核心投影（即 brainstorm 中被否的方案 C，独立重构）。
+- 可选：viewer tab live 自动刷新；descendant 子 run 合并。
+
+## 10. 验收对照（#68）
+
+- [ ] localhost web UI 对一次真实对话两次点击到根因 → §4.3/§5 + dev-browser 测
+- [ ] 复用核心投影、前端不自带归因逻辑 → §3/§4（整块 renderViewer，iframe）
+- [ ] 真实 run（doubao，#66 修复后）能看到真实 region composition 内容预览 → §4.1 接 objectStore + §7 测
+
+## 11. 分支
+
+`feat/68-trace-attribution-in-web-panel`，基于 main（含 #64）。

--- a/examples/agent-docs-qa/.gitignore
+++ b/examples/agent-docs-qa/.gitignore
@@ -4,6 +4,7 @@
 .milkie/state.sqlite-wal
 .milkie/state.sqlite-shm
 .milkie/runs/
+.milkie/objects/
 
 # Browser cached state (none today; future-proofing)
 *.log

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -206,6 +206,24 @@ describe('server — REST endpoints', () => {
     const entries = fs.readdirSync(objectsDir)
     expect(entries.length).toBeGreaterThan(0)
   })
+
+  it('GET /run/:runId/viewer returns the decision viewer HTML', async () => {
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const { runId } = JSON.parse(chat.body) as { runId: string }
+
+    const r = await get(`${baseUrl}/run/${runId}/viewer`)
+    expect(r.status).toBe(200)
+    // renderViewer emits a self-contained document with the decision spine.
+    expect(r.body).toContain('<!doctype html>')
+    expect(r.body).toContain('milkie trace viewer')
+    expect(r.body).toContain('data-id=')        // spine nodes
+    expect(r.body).toContain('spine-output')     // the output node with ❓ entry
+  })
+
+  it('GET /run/:runId/viewer 404s on an unknown run', async () => {
+    const r = await get(`${baseUrl}/run/does-not-exist/viewer`)
+    expect(r.status).toBe(404)
+  })
 })
 
 describe('server — SSE stream', () => {

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -75,6 +75,16 @@ describe('server — REST endpoints', () => {
     expect(body.status).toBe('completed')
   })
 
+  it('persists region content to .milkie/objects after a run', async () => {
+    await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const objectsDir = path.join(exampleDir, '.milkie', 'objects')
+    expect(fs.existsSync(objectsDir)).toBe(true)
+    // A run composes context regions; their canonical content is written to
+    // the trace object store. Non-empty objects dir proves the wiring.
+    const entries = fs.readdirSync(objectsDir)
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
   it('POST /chat with same contextId twice continues the same conversation', async () => {
     await stopServer(server)
     server = await startServer({
@@ -185,6 +195,16 @@ describe('server — REST endpoints', () => {
     const r = await postJson(`${baseUrl}/run/00000000-0000-0000-0000-000000000000/replay`, {})
     expect(r.status).toBe(404)
     expect(JSON.parse(r.body).status).toBe('error')
+  })
+
+  it('persists region content to .milkie/objects after a run', async () => {
+    await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const objectsDir = path.join(exampleDir, '.milkie', 'objects')
+    expect(fs.existsSync(objectsDir)).toBe(true)
+    // A run composes context regions; their canonical content is written to
+    // the trace object store. Non-empty objects dir proves the wiring.
+    const entries = fs.readdirSync(objectsDir)
+    expect(entries.length).toBeGreaterThan(0)
   })
 })
 

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -224,6 +224,13 @@ describe('server — REST endpoints', () => {
     const r = await get(`${baseUrl}/run/does-not-exist/viewer`)
     expect(r.status).toBe(404)
   })
+
+  it('serves the audit panel with a Why tab', async () => {
+    const r = await get(`${baseUrl}/`)
+    expect(r.status).toBe(200)
+    expect(r.body).toContain('data-tab="why"')
+    expect(r.body).toContain('>Why<')
+  })
 })
 
 describe('server — SSE stream', () => {

--- a/examples/agent-docs-qa/public/index.html
+++ b/examples/agent-docs-qa/public/index.html
@@ -189,6 +189,8 @@
     #audit-panel .ap-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600 }
     #audit-panel .ap-tab.disabled { color: #c0c0c5; cursor: default }
     #audit-panel .ap-body { flex: 1; overflow-y: auto; padding: 14px 16px }
+    #audit-panel .ap-body.viewer { padding: 0; overflow: hidden }
+    #audit-panel .ap-viewer-frame { display: block; width: 100%; height: 100%; border: 0 }
     #audit-panel .ap-empty { color: var(--muted); font-style: italic; font-size: 12px; padding: 16px 0 }
 
     /* Sources tab */
@@ -459,8 +461,9 @@
     <div class="ap-replay-banner" role="status"></div>
     <div class="ap-tabs">
       <div class="ap-tab active" data-tab="sources">Sources</div>
-      <div class="ap-tab" data-tab="steps">Steps</div>
+      <div class="ap-tab" data-tab="steps">Execution</div>
       <div class="ap-tab" data-tab="provenance">Provenance</div>
+      <div class="ap-tab" data-tab="why">Why</div>
     </div>
     <div class="ap-body"></div>
   </aside>
@@ -1241,10 +1244,17 @@
     function renderAuditBody() {
       if (!auditAnchorRunId) { $auditBody.innerHTML = ''; return }
       const msgEl = $log.querySelector(`.msg.assistant[data-run-id="${auditAnchorRunId}"]`)
+      $auditBody.classList.toggle('viewer', auditActiveTab === 'why')
       if (auditActiveTab === 'sources') {
         $auditBody.innerHTML = renderSourcesTab(auditAnchorRunId, msgEl)
       } else if (auditActiveTab === 'steps') {
         $auditBody.innerHTML = renderStepsTab(auditAnchorRunId)
+      } else if (auditActiveTab === 'why') {
+        // Reuse the core #64 decision viewer wholesale: it is a self-contained
+        // HTML document (own CSS + drill-down JS), so an iframe isolates it and
+        // its "two clicks to root cause" interactions run inside the frame.
+        $auditBody.innerHTML =
+          `<iframe class="ap-viewer-frame" src="/run/${encodeURIComponent(auditAnchorRunId)}/viewer"></iframe>`
       } else if (auditActiveTab === 'provenance') {
         $auditBody.innerHTML = `<div class="ap-empty">Analyzing answer against sources…</div>`
         // Async render: classifies each segment after fetching its source.

--- a/examples/agent-docs-qa/public/index.html
+++ b/examples/agent-docs-qa/public/index.html
@@ -15,6 +15,7 @@
       --cite-bg: #f0eaff;
       --cite-fg: #5b3ec9;
       --skill-highlight: #fff4e0;
+      --audit-w: clamp(440px, 44vw, 720px);
     }
     * { box-sizing: border-box }
     html, body { margin: 0; padding: 0; height: 100% }
@@ -125,13 +126,17 @@
 
     /* ── Audit panel (Layer 2: per-message decision audit) ──────────── */
     #audit-panel {
-      position: fixed; top: 49px; right: 0; bottom: 0; width: 380px; z-index: 90;
+      position: fixed; top: 49px; right: 0; bottom: 0; width: var(--audit-w); z-index: 90;
       background: var(--panel); border-left: 1px solid var(--border);
       box-shadow: -8px 0 24px rgba(0,0,0,0.06);
       display: flex; flex-direction: column;
       transform: translateX(100%); transition: transform 0.18s ease-out;
     }
     #audit-panel.open { transform: translateX(0) }
+    /* When the audit panel is open, dock it: stop centering the chat, let it
+       fill the freed left space, and reserve the panel's strip on the right. */
+    body.audit-open main { justify-content: flex-start; padding-right: var(--audit-w) }
+    body.audit-open #chat { flex: 1 1 auto; max-width: 880px }
     #audit-panel .ap-header {
       display: flex; align-items: center; gap: 8px;
       padding: 12px 16px; border-bottom: 1px solid var(--border);
@@ -1281,6 +1286,7 @@
       if (auditAnchorRunId !== runId) hideReplayBanner()
       auditAnchorRunId = runId
       $audit.classList.add('open')
+      document.body.classList.add('audit-open')
       updateAuditTitle()
       // Restore last active tab across openings; never land on a disabled tab.
       setAuditTab(auditActiveTab || 'sources')
@@ -1289,6 +1295,7 @@
     function closeAudit() {
       auditAnchorRunId = null
       $audit.classList.remove('open')
+      document.body.classList.remove('audit-open')
       hideReplayBanner()
     }
 

--- a/examples/agent-docs-qa/server.ts
+++ b/examples/agent-docs-qa/server.ts
@@ -7,6 +7,8 @@ import { Milkie } from '../../src/runtime/Milkie.js'
 import { MemoryStore } from '../../src/store/MemoryStore.js'
 import { JsonlEventStore } from '../../src/trace/JsonlEventStore.js'
 import { FileTraceObjectStore } from '../../src/trace/TraceObjectStore.js'
+import { regionReuseCounts } from '../../src/trace/RegionContextView.js'
+import { renderViewer } from '../../src/trace/render/viewer.js'
 import { ReplayError } from '../../src/trace/ReplayError.js'
 import { ReplayDivergenceError } from '../../src/trace/ReplayDivergenceError.js'
 import type { IModelGateway } from '../../src/types/model.js'
@@ -175,6 +177,26 @@ async function handleReplay(
   }
 }
 
+async function handleViewer(
+  res: ServerResponse, s: ServerState, runId: string,
+): Promise<void> {
+  const events = await s.eventStore.readByRunId(runId)
+  if (events.length === 0) {
+    sendJson(res, 404, { error: 'run not found' })
+    return
+  }
+  // Hydrate region content the same way `milkie trace report` does
+  // (cli/main.ts): look up each region's canonical content by hash.
+  const regionContent = new Map<string, string>()
+  for (const h of regionReuseCounts(events).keys()) {
+    const c = await s.traceObjectStore.getCanonical(h)
+    if (c !== undefined) regionContent.set(h, c)
+  }
+  const html = renderViewer(events, { regionContent })
+  res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+  res.end(html)
+}
+
 async function handleSourceFetch(
   res: ServerResponse, s: ServerState, relPath: string, linesQuery: string | null,
 ): Promise<void> {
@@ -272,6 +294,11 @@ export async function startServer(config: ServerConfig): Promise<Server> {
       const replayMatch = route.match(/^\/run\/([^/]+)\/replay$/)
       if (req.method === 'POST' && replayMatch) {
         return handleReplay(res, state, decodeURIComponent(replayMatch[1]!))
+      }
+
+      const viewerMatch = route.match(/^\/run\/([^/]+)\/viewer$/)
+      if (req.method === 'GET' && viewerMatch) {
+        return handleViewer(res, state, decodeURIComponent(viewerMatch[1]!))
       }
 
       const sourceMatch = route.match(/^\/source\/(.+)$/)

--- a/examples/agent-docs-qa/server.ts
+++ b/examples/agent-docs-qa/server.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { Milkie } from '../../src/runtime/Milkie.js'
 import { MemoryStore } from '../../src/store/MemoryStore.js'
 import { JsonlEventStore } from '../../src/trace/JsonlEventStore.js'
+import { FileTraceObjectStore } from '../../src/trace/TraceObjectStore.js'
 import { ReplayError } from '../../src/trace/ReplayError.js'
 import { ReplayDivergenceError } from '../../src/trace/ReplayDivergenceError.js'
 import type { IModelGateway } from '../../src/types/model.js'
@@ -22,11 +23,12 @@ export interface ServerConfig {
 }
 
 interface ServerState {
-  milkie:      Milkie
-  eventStore:  BroadcastingEventStore
-  runsDir:     string
-  publicDir:   string
-  corpusRoot:  string
+  milkie:           Milkie
+  eventStore:       BroadcastingEventStore
+  traceObjectStore: FileTraceObjectStore
+  runsDir:          string
+  publicDir:        string
+  corpusRoot:       string
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {
@@ -221,11 +223,16 @@ export async function startServer(config: ServerConfig): Promise<Server> {
   const runsDir = path.join(config.exampleDir, '.milkie', 'runs')
   if (!existsSync(runsDir)) mkdirSync(runsDir, { recursive: true })
 
+  const objectsDir = path.join(config.exampleDir, '.milkie', 'objects')
+  if (!existsSync(objectsDir)) mkdirSync(objectsDir, { recursive: true })
+  const traceObjectStore = new FileTraceObjectStore(objectsDir)
+
   const eventStore = new BroadcastingEventStore(new JsonlEventStore(runsDir))
   const milkie     = new Milkie({
     stateStore: new MemoryStore(),
     gateway:    config.gateway,   // when omitted, Milkie falls back to createGateway(agent.model) per-invoke
     eventStore,
+    traceObjectStore,
   })
 
   for (const tool of makeCorpusToolDefinitions(config.corpusRoot)) {
@@ -240,7 +247,7 @@ export async function startServer(config: ServerConfig): Promise<Server> {
   const fallbackPublic  = path.resolve(__dirname, 'public')
   const publicDir = existsSync(colocatedPublic) ? colocatedPublic : fallbackPublic
 
-  const state: ServerState = { milkie, eventStore, runsDir, publicDir, corpusRoot: config.corpusRoot }
+  const state: ServerState = { milkie, eventStore, traceObjectStore, runsDir, publicDir, corpusRoot: config.corpusRoot }
 
   const server = http.createServer(async (req, res) => {
     try {

--- a/src/__tests__/render-viewer.test.ts
+++ b/src/__tests__/render-viewer.test.ts
@@ -50,6 +50,17 @@ describe('renderViewer', () => {
     expect(html).toContain('SYSTEM PROMPT TEXT')
   })
 
+  it('keeps the inactive decision pane hidden so the decision/raw toggle works', () => {
+    const html = renderViewer(scenario())
+    // The decision pane must hide when it loses `.active`. A bare
+    // `#pane-decision { ... display ... }` rule (id selector, specificity 100)
+    // would override `.pane { display: none }` (specificity 10) and keep the
+    // spine permanently visible — breaking the 决策视图/原始时间线 toggle.
+    // Only `#pane-decision.active` may set its display.
+    expect(html).not.toMatch(/#pane-decision\s*\{[^}]*display/)
+    expect(html).toMatch(/#pane-decision\.active\s*\{[^}]*display:\s*flex/)
+  })
+
   it('renders without crashing for a run with no decisions', () => {
     const html = renderViewer([{ id: 's', runId: 'r1', actor: 'a', type: 'agent.run.started', timestamp: 1, payload: {} } as Event])
     expect(html.startsWith('<!doctype html>')).toBe(true)

--- a/src/trace/render/viewer-template.ts
+++ b/src/trace/render/viewer-template.ts
@@ -6,8 +6,7 @@ export const VIEWER_STYLES = `
   .tab.active { background: #1c1c1e; color: #fff; border-color: #1c1c1e; }
   .pane { display: none; }
   .pane.active { display: block; }
-  #pane-decision { display: flex; height: calc(100vh - 90px); }
-  #pane-decision.active { display: flex; }
+  #pane-decision.active { display: flex; height: calc(100vh - 90px); }
   .spine { width: 42%; border-right: 1px solid #e5e5e7; overflow: auto; padding: 8px; background: #fafafa; }
   .node { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; padding: 5px 8px; margin: 3px 0; border-left: 3px solid transparent; border-radius: 3px; cursor: pointer; background: #fff; }
   .node.k-llm { border-left-color: #5b3ec9; } .node.k-tool { border-left-color: #2563eb; }


### PR DESCRIPTION
把 #64 的决策脊柱 + Why 面板 + 因果下钻 viewer 接进 agent-docs-qa 的 live audit panel。**整块复用核心 `renderViewer`**，守住 ARCHITECTURE.md「UI = projection over CLI/SDK，前端不自带归因逻辑」。

## 做了什么

**集成（#68 主体）**
- **接 `FileTraceObjectStore`**：example 的 `Milkie` 原先未挂 traceObjectStore → region 内容不落盘。现指向 `.milkie/objects`，让 #26 内容预览可 hydrate。
- **`GET /run/:runId/viewer`**：`readByRunId` + 按 `regionReuseCounts` hydrate regionContent（照搬 `cli/main.ts` 的 `trace report` 模式）+ 整块 `renderViewer` → 自包含 HTML。
- **audit panel 新增 `Why` tab**：lazy `<iframe>` 嵌入 viewer，#64 自带的脊柱/Why/下钻 JS 在 frame 内自跑。`Steps` 改名 `Execution`，与 `Why` 形成两个镜头——**Execution = 成本/上下文（cache 健康、region by stability）**，**Why = 因果/为什么（#30/#31/#33/#34/#64）**。

**审查中发现并一并修复**
- **`fix(#64)` tab 切换**：`#pane-decision { display:flex }`（id 选择器，特异性 100）无条件压过 `.pane { display:none }`，导致「决策视图/原始时间线」切换时决策 pane 永不隐藏、看似无反应。把 flex/height 收进 `.active` 修复（独立 viewer 的 `trace report` 也受此 bug 影响）。
- **`feat(#68)` 布局**：审计打开时由"固定 380px 悬浮层盖在居中对话上"（左留白、面板挤）改为 **dock 双栏**——对话左对齐铺满、面板宽度自适应 `clamp(440px,44vw,720px)`；面板关闭仍居中 760px。

## 验收（#68）— 真实 doubao run + dev-browser live 验证
- [x] **localhost web UI 两次点击到根因**：点 LLM 节点 → Why 面板出「触发:tool.responded(grep)·Assembled by 13 regions」+ 高亮其因「tool: grep」+「← 谁导致的」→ 点回溯 → 选中上移到 grep（入参 `{pattern:孔明}`）→ 再点上钻一层。每点一步往根因走。
- [x] **复用核心投影、前端不自带归因逻辑**：整块 renderViewer iframe。
- [x] **真实 region composition 内容预览**：0 个「内容不可用」降级；regionContent 13 条真实内容。

## 测试
- `examples/agent-docs-qa/__tests__/server.test.ts`：viewer endpoint 200+脊柱标记、404、objectStore 落盘、Why tab 存在 — 24/24。
- `src/__tests__/render-viewer.test.ts`：tab 切换 CSS 回归（断言无裸 `#pane-decision` display 规则）。
- `tsc --noEmit` 通过；dev-browser live 验证（两次点击到根因 + 真实预览 + tab 切换 + 布局）。

## Follow-up（不在本 PR）
- **#70**：Execution(原 Steps) tab 改投影驱动（消除前端重写归因）。
- **#71**：#64 viewer UX polish —— output ❓ 下钻（runtime 补 `agent.run.completed.causedBy`）、输出渲染 markdown、因果链精简 + 标签带入参。

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)