### PR TITLE
feat(#60): replay emit-driven FSM transitions via tool.emitted event

### DIFF
--- a/docs/superpowers/specs/2026-05-31-emit-driven-fsm-replay-design.md
+++ b/docs/superpowers/specs/2026-05-31-emit-driven-fsm-replay-design.md
@@ -1,0 +1,125 @@
+# #60 设计:emit 驱动的 FSM 转移可 replay
+
+状态:已认可,进入实现
+关联:follow-up of #73(PR #74,`wm.mutated`);Phase 5(fork/diff/suite)前置
+
+## 背景与根因
+
+`replay()` 的本质:`ReplayingIOPort.invokeTool` 直接吐缓存输出、**不跑 handler**(忽略 `execute`
+thunk)。于是 handler 的副作用全丢。
+
+- **#73 已解的 WM 副作用**:`executeSingleTool` 每次工具调用录一条 `wm.mutated` 全量快照;replay 时
+  `replayWmSnapshots.shift()` 把快照灌回 `this.memory`(positional FIFO 对齐)。
+- **#60 剩的 emit 副作用**:handler 里 `ctx.emit` → `fsm.emitEvent` 设 `pendingEvent`。replay 不跑
+  handler → `pendingEvent` 恒为 null → `runLLMState` 的 `processPendingEvent()` 返回 null →
+  `continue` → 多发一次未录的 LLM 调用 → `ReplayDivergenceError(llm)`。所有靠 `ctx.emit` 做硬转移/
+  意图路由的 agent(如 s-011 的 classify_intent/collect_slot/confirm_action)都无法完整 replay。
+
+手法沿用 #73:把 emit 这个 handler 副作用**事件化**,replay 时按记录回灌,而非重跑 handler。
+
+## 范围与非目标
+
+**目标**:经 `executeSingleTool`(`ioPort.invokeTool`)的工具调用里 `ctx.emit` 触发的 FSM 转移,在
+`replay()` 时确定性复现。
+
+**非目标**:
+- **action-state 的 emit**:`runActionState` 里 handler 是 `tool.handler(...)` **直跑**、不经
+  `ioPort.invokeTool`,replay 时 handler 真跑、emit 自然触发,无需处理。
+- **`ctx.requestSkill` 副作用**:handler 内请求 skill 在 replay 时同样会丢(同根因),会导致后续 LLM
+  上下文缺 skill region → llm 散度。这是**相邻的同类 gap**,但不在 #60。建议作为 follow-up(#60 之于
+  #73 的关系),后续单独开票。本次不扩入(避免过度工程)。
+
+## 设计
+
+### 1. 新事件类型 `tool.emitted`
+
+`src/trace/types.ts`:`EventKind` 加 `'tool.emitted'`;新增 payload + alias 并入 `AnyEvent`。
+
+```ts
+export interface ToolEmittedPayload {
+  /** 发出该 emit 的工具调用 id(LLM 指派)。来自 cached LLM 输出 → replay 时与录制一致,故可作对齐 key。 */
+  toolCallId: string
+  /** handler 经 ctx.emit 发出、且赢得 FSM 单一 pendingEvent 槽的那个业务事件。 */
+  event: { name: string; payload?: unknown; guard?: GuardEvaluation[] }
+}
+```
+
+不进 `CacheIndex`(与 `wm.mutated` 一样不是 nondet IO),`CacheIndex.fromEvents` 与 strict
+under-consume 的四队列检查(clock/uuid/llm/tool)都自动忽略它。
+
+### 2. 记录侧:只记"赢得 pendingEvent"的那次 emit
+
+`AgentRuntime.executeSingleTool` 用**捕获式 emitFn** 判定本次调用是否真正赢得 FSM 的单一
+`pendingEvent` 槽(`emitEvent` 是 first-wins):
+
+```ts
+let capturedEmit: { name: string; payload?: unknown; guard?: GuardEvaluation[] } | undefined
+const ctx = this.buildToolContext((event, payload, guard) => {
+  const hadPending = this.fsm.hasPendingEvent()
+  this.fsm.emitEvent(event, payload, guard)
+  if (!hadPending && this.fsm.hasPendingEvent()) {
+    capturedEmit = { name: event, ...(payload !== undefined ? { payload } : {}), ...(guard ? { guard } : {}) }
+  }
+})
+```
+
+拿到 output 后(紧邻现有 `wm.mutated` 记录处),record 模式(`!this.replayEmits && this.eventStore`)
+下若 `capturedEmit` 非空,`append` 一条 `tool.emitted { toolCallId: call.id, event: capturedEmit }`。
+
+**为什么只记赢家**:并行 batch 里多个工具都可能 `ctx.emit`,但 first-wins 只有一个进 `pendingEvent`。
+JS 单线程下 `emitEvent` 同步执行,`hadPending` 前后判定可靠地识别赢家。只记赢家 → replay 注入唯一一条
+→ 转移与并发顺序无关地复现,消除并行竞态这一 record 层不确定性隐患。
+
+### 3. 回放侧:按 `toolCallId` 注入
+
+`Milkie.replay` 装配(与 `replayWmSnapshots` 平行):
+
+```ts
+replayEmits: new Map(events
+  .filter(e => e.type === 'tool.emitted')
+  .map(e => {
+    const p = e.payload as ToolEmittedPayload
+    return [p.toolCallId, p.event] as const
+  }))
+```
+
+`AgentRuntime` 新增 opt `replayEmits?: Map<string, { name: string; payload?: unknown; guard?: GuardEvaluation[] }>`。
+`executeSingleTool` replay 模式(`this.replayEmits` 存在)下,拿到 cached output 后:
+
+```ts
+const emitted = this.replayEmits.get(call.id)
+if (emitted) this.fsm.emitEvent(emitted.name, emitted.payload, emitted.guard)
+```
+
+时序正确:`executeSingleTool` 在 `runLLMState` 内,注入发生在 `processPendingEvent()` 之前 →
+`pendingEvent` 被设上 → 正常转移 → 不再多发 LLM → 不散度。replay 不传 `eventStore`,
+`setupFSMCallbacks` 的 `fsm.transition` 写入被 `if (this.eventStore)` 跳过,符合"replay 不写事件"。
+
+**对齐用 `toolCallId` 而非 positional**:`call.id` 源自 cached LLM 输出,replay 必然一致 → 稳;且
+emit 稀疏,用 map 比"每 call 录一条(含空)"更省日志、无噪音。与 `wm.mutated` 的 positional shift 不同
+是因为 WM 每 call 必变、emit 稀疏,各取所需。
+
+## 测试(TDD,先红后绿)
+
+1. **核心(升级现有绕过测试)**:`Replay.test.ts:419` 那个 `classify_intent`/`INTENT_DONE` emit-FSM,
+   录一次后 `await milkie.replay(runId)` → 实现前抛 `ReplayDivergenceError(llm)`(红)→ 实现后
+   resolves、output/最终状态一致、四队列消费干净(绿)。保留原 #31 断言不动。
+2. **guard 透传**:emit 带 `guard` 的场景,replay 后转移仍发生,且注入路径不丢 guard 入参。
+3. **不回归 #73**:不 emit 的普通 toolcall run replay 仍 OK。
+4. **并行 first-wins 边界**:batch 内两个工具都 emit,replay 复现录制时那条生效转移。
+
+## 改动文件
+
+- `src/trace/types.ts` — 事件类型/payload/alias
+- `src/runtime/AgentRuntime.ts` — 捕获式 emitFn + 记录 `tool.emitted`;`replayEmits` opt + 注入
+- `src/runtime/Milkie.ts` — `replay()` 装配 `replayEmits`
+- `src/__tests__/Replay.test.ts` — 新增真 replay 断言
+- 文档:事件清单 + roadmap 标注 #60 落地、`requestSkill` follow-up
+
+## Alternatives(已排除)
+
+- **搭车 `tool.responded.emitted`**:`tool.responded` 由 `RecordingIOPort` 写,它不持有 FSM 句柄、
+  拿不到 `pendingEvent`,记录侧塞不进(分层硬伤)。故新增独立事件。
+- **复用 `fsm.transition`**:最省存储,但 business 转移与 tool call 的对齐需绕 causedBy,较脆。
+- **方向 A(replay 重跑 handler)**:改 IOPort 语义、确定性边界复杂,且与 #73 既定模式相悖。
+- **方向 C(文档化不支持)**:阻塞 Phase 5(fork/diff/suite 依赖 emit-FSM 可 replay)。

--- a/roadmap.md
+++ b/roadmap.md
@@ -40,6 +40,14 @@ Last updated: 2026-05-30
   is archived to `.bak/store/`. This supersedes the earlier "stateStore for
   checkpoint" model and unblocks Phase 5 (fork/diff/suite need deterministic
   replay of side-effecting runs).
+- **#60 landed — emit-driven FSM transitions now replay deterministically.**
+  Following #73's template, the tool handler's `ctx.emit` side-effect is
+  event-sourced: a `tool.emitted` event records the business FSM event that won
+  the single pendingEvent slot (keyed by `toolCallId`). `replay()` re-emits it
+  before `processPendingEvent`, so emit-driven hard transitions / intent routing
+  (s-011) reproduce without re-running the handler. Remaining same-root gap:
+  handler-driven `ctx.requestSkill` is still lost on replay — a follow-up for
+  Phase 5 (same event-sourced-side-effect pattern).
 - **8 of 15 stories are `active`** (have green E2E tests). The 7 `draft`
   stories all depend on Phase 5–6 capabilities that haven't shipped yet.
 - **Current active line:** finish the trace projection surface before
@@ -182,9 +190,9 @@ Last updated: 2026-05-30
   recorded events). Supersedes the Phase 2 "stateStore for checkpoint" and
   Phase 4.5 "checkpoint format" notes — checkpoint is no longer a separate
   source of truth. **Unblocks Phase 5** (deterministic replay of side-effecting
-  runs) and is the event-sourced-side-effect template for **#60** (emit-driven
-  FSM transitions in replay — same root cause: replay skips the handler; the WM
-  case is solved, the `ctx.emit` case can follow the same pattern).
+  runs) and is the event-sourced-side-effect template later reused by **#60**
+  (emit-driven FSM transitions in replay — same root cause: replay skips the
+  handler; the WM case and the `ctx.emit` case now both follow this pattern).
 
 ### Stories validated by Phase 1–4 (active)
 
@@ -233,8 +241,9 @@ region snapshot/restore primitive, byte-identical replay, and **#73**
 cognitive-tool runs now replay deterministically — fork/diff/suite all build
 on deterministic replay). Phase 5 is still a multi-PR surface area tracked by
 #58 (side-effect policy), #56 (fork), #55 (diff), and #57 (suite replay).
-The remaining replay determinism gap is **#60** (emit-driven FSM transitions);
-#73's `wm.mutated` event-sourcing is the template to close it.
+Replay determinism for emit-driven FSM transitions is now closed by **#60**
+(`tool.emitted` event-sourcing, following #73's pattern); the remaining
+same-root gap is handler-driven `ctx.requestSkill` (follow-up).
 
 The cross-cutting work below stays valid in parallel — particularly the
 smaller follow-ups inherited from earlier landings: CLI surface spec update

--- a/src/__tests__/Replay.test.ts
+++ b/src/__tests__/Replay.test.ts
@@ -465,4 +465,171 @@ describe('Milkie.replay', () => {
     expect(withGuard).toEqual(without)
     expect(withGuard.length).toBeGreaterThan(0)
   })
+
+  // #60: emit-driven FSM transitions must replay deterministically.
+  // Before #60 this run diverges: replay does NOT re-run the handler, so
+  // ctx.emit never fires, the FSM never transitions, and the loop issues an
+  // uncached LLM call → ReplayDivergenceError(llm).
+  const emitAgentConfig = (): AgentConfig => ({
+    agentId: 'emit-agent', version: '0.0.0', systemPrompt: 'sys',
+    fsm: { states: [
+      { name: 's0', type: 'llm', tools: ['classify_intent'], on: { INTENT_DONE: 'end' } },
+      { name: 'end', type: 'action', terminal: true },
+    ] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  })
+
+  const classifyIntentTool = (
+    emit: (ctx: { emit: (e: string, p?: unknown, g?: unknown) => void }) => void,
+  ): ToolDefinition => ({
+    name: 'classify_intent', description: 'c', inputSchema: { type: 'object', properties: {} },
+    handler: async (_i, ctx) => { emit(ctx as never); return {} },
+  })
+
+  it('replays an emit-driven FSM transition without divergence (#60)', async () => {
+    const tool = classifyIntentTool(ctx => ctx.emit('INTENT_DONE'))
+    const store = new MemoryEventStore()
+    const recordMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([toolCallResponse('tc-1', 'classify_intent', {})]),
+      eventStore: store, tools: [tool],
+    })
+    recordMilkie.registerAgent(emitAgentConfig())
+    const original = await recordMilkie.invoke({ agentId: 'emit-agent', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')  // sanity: emit-FSM completes in record mode
+
+    const replayGateway = new SequentialGateway([])  // any live LLM call → "exhausted"
+    const replayMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: replayGateway, eventStore: store, tools: [tool],
+    })
+    replayMilkie.registerAgent(emitAgentConfig())
+
+    const replayed = await replayMilkie.replay(original.agentRunId)
+    expect(replayed.status).toBe(original.status)
+    expect(replayed.output).toBe(original.output)
+    expect(replayGateway.callCount).toBe(0)  // cache served everything; no live LLM
+  })
+
+  it('records the emit with its guard and replays without divergence (#60)', async () => {
+    const guard = { guardId: 'intent', result: 'INTENT_DONE', contextSlice: { confidence: 0.9 } }
+    const tool = classifyIntentTool(ctx => ctx.emit('INTENT_DONE', { slot: 'x' }, guard as never))
+    const store = new MemoryEventStore()
+    const recordMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([toolCallResponse('tc-1', 'classify_intent', {})]),
+      eventStore: store, tools: [tool],
+    })
+    recordMilkie.registerAgent(emitAgentConfig())
+    const original = await recordMilkie.invoke({ agentId: 'emit-agent', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')
+
+    // The recorded tool.emitted carries the toolCallId, event name, payload and guard.
+    const evs = await store.readByRunId(original.agentRunId)
+    const emitted = evs.filter(e => e.type === 'tool.emitted')
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]!.payload).toEqual({
+      toolCallId: 'tc-1',
+      event: { name: 'INTENT_DONE', payload: { slot: 'x' }, guard: [guard] },
+    })
+
+    const replayMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([]), eventStore: store, tools: [tool],
+    })
+    replayMilkie.registerAgent(emitAgentConfig())
+    const replayed = await replayMilkie.replay(original.agentRunId)
+    expect(replayed.status).toBe('completed')
+    expect(replayed.output).toBe(original.output)
+  })
+
+  it('records no tool.emitted for a tool that does not emit (#60 no-regression)', async () => {
+    // s0 uses a tool then the LLM produces text → DONE-driven transition (no ctx.emit).
+    const tool: ToolDefinition = {
+      name: 'noop', description: 'n', inputSchema: { type: 'object', properties: {} },
+      handler: async () => ({ ok: true }),
+    }
+    const config: AgentConfig = {
+      agentId: 'noemit-agent', version: '0.0.0', systemPrompt: 'sys',
+      fsm: { states: [
+        { name: 's0', type: 'llm', tools: ['noop'], on: { DONE: 'end' } },
+        { name: 'end', type: 'action', terminal: true },
+      ] },
+      model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+    }
+    const store = new MemoryEventStore()
+    const recordMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([toolCallResponse('tc-1', 'noop', {}), text('done')]),
+      eventStore: store, tools: [tool],
+    })
+    recordMilkie.registerAgent(config)
+    const original = await recordMilkie.invoke({ agentId: 'noemit-agent', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')
+
+    const evs = await store.readByRunId(original.agentRunId)
+    expect(evs.filter(e => e.type === 'tool.emitted')).toHaveLength(0)
+
+    const replayMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([]), eventStore: store, tools: [tool],
+    })
+    replayMilkie.registerAgent(config)
+    const replayed = await replayMilkie.replay(original.agentRunId)
+    expect(replayed.status).toBe('completed')
+    expect(replayed.output).toBe(original.output)
+  })
+
+  it('records only the winning emit in a parallel batch and replays it (#60 first-wins)', async () => {
+    // Two parallel-safe tools both emit; the FSM has a single pendingEvent slot
+    // (first-emit-wins), so exactly one transition happens. Replay must reproduce
+    // that same transition deterministically from the single recorded tool.emitted.
+    const mkTool = (name: string, event: string): ToolDefinition => ({
+      name, description: name, inputSchema: { type: 'object', properties: {} },
+      parallelSafe: true,
+      handler: async (_i, ctx) => { ctx.emit(event); return {} },
+    })
+    const config: AgentConfig = {
+      agentId: 'parallel-emit-agent', version: '0.0.0', systemPrompt: 'sys',
+      fsm: { states: [
+        { name: 's0', type: 'llm', tools: ['ta', 'tb'], on: { A_DONE: 'end', B_DONE: 'end' } },
+        { name: 'end', type: 'action', terminal: true },
+      ] },
+      model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+    }
+    const twoToolCalls: ModelResponse = {
+      content: [
+        { type: 'tool_use', id: 'ta-1', name: 'ta', input: {} },
+        { type: 'tool_use', id: 'tb-1', name: 'tb', input: {} },
+      ],
+      toolCalls: [
+        { id: 'ta-1', name: 'ta', input: {} },
+        { id: 'tb-1', name: 'tb', input: {} },
+      ],
+      finishReason: 'tool_use',
+    }
+    const store = new MemoryEventStore()
+    const recordMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([twoToolCalls]),
+      eventStore: store, tools: [mkTool('ta', 'A_DONE'), mkTool('tb', 'B_DONE')],
+    })
+    recordMilkie.registerAgent(config)
+    const original = await recordMilkie.invoke({ agentId: 'parallel-emit-agent', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')
+
+    // Exactly one emit won the slot → exactly one tool.emitted recorded.
+    const evs = await store.readByRunId(original.agentRunId)
+    expect(evs.filter(e => e.type === 'tool.emitted')).toHaveLength(1)
+
+    const replayMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([]),
+      eventStore: store, tools: [mkTool('ta', 'A_DONE'), mkTool('tb', 'B_DONE')],
+    })
+    replayMilkie.registerAgent(config)
+    const replayed = await replayMilkie.replay(original.agentRunId)
+    expect(replayed.status).toBe('completed')
+    expect(replayed.output).toBe(original.output)
+  })
 })

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -36,7 +36,7 @@ import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
 import type { CausalCursor } from '../trace/CausalCursor.js'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
 import type { Region } from '../context/Region.js'
-import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation } from '../trace/types.js'
+import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation, ToolEmittedPayload } from '../trace/types.js'
 
 export type MakeChildPort = (
   childRunId:  string,
@@ -74,6 +74,11 @@ export interface AgentRuntimeOptions {
    *  Present → replay-restore mode: after each tool call, restore WM from the next
    *  snapshot instead of trusting the (non-re-run) handler. Absent → record mode. */
   replayWmSnapshots?: unknown[]
+  /** #60: recorded business FSM events keyed by toolCallId, for replay. Present →
+   *  replay mode: after each tool call, re-emit the recorded event (the handler is
+   *  not re-run, so ctx.emit never fires) so the emit-driven transition reproduces.
+   *  Absent → record mode (capture & append tool.emitted instead). */
+  replayEmits?: Map<string, { name: string; payload?: unknown; guard?: GuardEvaluation[] }>
 }
 
 type SkillLoadRequest = {
@@ -95,6 +100,7 @@ export class AgentRuntime {
   private readonly eventStore?:      import('../trace/EventStore.js').IEventStore
   private readonly traceObjectStore?: ITraceObjectStore
   private readonly replayWmSnapshots?: unknown[]  // SPIKE(#73)
+  private readonly replayEmits?: Map<string, { name: string; payload?: unknown; guard?: GuardEvaluation[] }>  // #60
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly makeChildPort?: MakeChildPort
@@ -135,6 +141,7 @@ export class AgentRuntime {
     this.recorder        = opts.recorder
     this.eventStore      = opts.eventStore
     this.replayWmSnapshots = opts.replayWmSnapshots
+    this.replayEmits     = opts.replayEmits
     this.traceObjectStore = opts.traceObjectStore
     this.subAgentConfigs = opts.subAgentConfigs
     this.childRecorderFactory = opts.childRecorderFactory
@@ -1109,8 +1116,21 @@ export class AgentRuntime {
     call: { id: string; name: string; input: unknown },
     batchId: string | null,
   ): Promise<ToolResult> {
+    // #60: capture the emit that WON the FSM's single pendingEvent slot
+    // (first-emit-wins). Only the winner drives a transition, so recording just
+    // the winner makes replay reproduce one transition regardless of how a
+    // parallel batch's emits race.
+    let capturedEmit: { name: string; payload?: unknown; guard?: GuardEvaluation[] } | undefined
     const ctx = this.buildToolContext((event, payload, guard) => {
+      const hadPending = this.fsm.hasPendingEvent()
       this.fsm.emitEvent(event, payload, guard)
+      if (!hadPending && this.fsm.hasPendingEvent()) {
+        capturedEmit = {
+          name: event,
+          ...(payload !== undefined ? { payload } : {}),
+          ...(guard ? { guard: Array.isArray(guard) ? guard : [guard] } : {}),
+        }
+      }
     })
 
     const maxRetries = 3
@@ -1148,6 +1168,23 @@ export class AgentRuntime {
             actor:     this.config.agentId,
             timestamp: Date.now(),
             payload:   { snapshot: this.memory.toJSON() },  // toJSON() deep-clones (frozen)
+          })
+        }
+        // #60: event-source the tool's emit side-effect (FSM transition) the same
+        // way. On replay the handler didn't run, so re-emit the recorded business
+        // event (keyed by toolCallId) before runLLMState calls processPendingEvent.
+        // In record mode, append tool.emitted iff this call won the pendingEvent slot.
+        if (this.replayEmits) {
+          const emitted = this.replayEmits.get(call.id)
+          if (emitted) this.fsm.emitEvent(emitted.name, emitted.payload, emitted.guard)
+        } else if (this.eventStore && capturedEmit) {
+          await this.eventStore.append({
+            id:        uuidv4(),
+            runId:     this.agentRunId,
+            type:      'tool.emitted',
+            actor:     this.config.agentId,
+            timestamp: Date.now(),
+            payload:   { toolCallId: call.id, event: capturedEmit } satisfies ToolEmittedPayload,
           })
         }
         const duration = this.ioPort.now() - start

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -24,6 +24,7 @@ import { ReplayingIOPort } from '../trace/ReplayingIOPort.js'
 import { ReplayError } from '../trace/ReplayError.js'
 import { ReplayDivergenceError } from '../trace/ReplayDivergenceError.js'
 import { extractRunSnapshot } from '../trace/RunSnapshot.js'
+import type { ToolEmittedPayload } from '../trace/types.js'
 
 export interface MilkieOptions {
   stateStore?:      IStateStore
@@ -448,6 +449,14 @@ export class Milkie {
       replayWmSnapshots: events
         .filter(e => e.type === 'wm.mutated')
         .map(e => (e.payload as { snapshot: unknown }).snapshot),
+      // #60: recorded emit-driven FSM events keyed by toolCallId → replay re-emits
+      // them so emit-driven transitions reproduce without re-running tool handlers.
+      replayEmits: new Map(events
+        .filter(e => e.type === 'tool.emitted')
+        .map(e => {
+          const p = e.payload as ToolEmittedPayload
+          return [p.toolCallId, p.event] as const
+        })),
     })
 
     const result = await runtime.run(snapshot.input)

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -24,6 +24,7 @@ export type EventKind =
   | 'agent.spawned'
   | 'agent.returned'
   | 'wm.mutated'
+  | 'tool.emitted'
   | 'agent.checkpoint'
 
 export interface Event<P = unknown> {
@@ -200,6 +201,23 @@ export interface GuardEvaluation {
   contextSlice: unknown
 }
 
+/**
+ * #60: a business FSM event a tool handler emitted via ctx.emit, captured so
+ * replay can reproduce the emit-driven transition without re-running the
+ * handler (ReplayingIOPort serves cached tool output and never runs the thunk).
+ * Recorded once per tool call that WON the FSM's single pendingEvent slot
+ * (first-emit-wins); keyed by toolCallId, which comes from the cached LLM
+ * output and is therefore stable across replay.
+ */
+export interface ToolEmittedPayload {
+  toolCallId: string
+  event: {
+    name:     string
+    payload?: unknown
+    guard?:   GuardEvaluation[]
+  }
+}
+
 export interface FsmTransitionPayload {
   from: string
   to:   string
@@ -229,6 +247,7 @@ export type RegionAddedEvent        = Event<RegionAddedPayload>        & { type:
 export type RegionRemovedEvent      = Event<RegionRemovedPayload>      & { type: 'region.removed' }
 export type ContextBoundaryAppliedEvent = Event<ContextBoundaryAppliedPayload> & { type: 'context.boundary.applied' }
 export type FsmTransitionEvent     = Event<FsmTransitionPayload>     & { type: 'fsm.transition' }
+export type ToolEmittedEvent       = Event<ToolEmittedPayload>       & { type: 'tool.emitted' }
 export type SkillLoadedEvent       = Event<SkillLifecyclePayload>    & { type: 'skill.loaded' }
 export type SkillUnloadedEvent     = Event<SkillLifecyclePayload>    & { type: 'skill.unloaded' }
 
@@ -247,5 +266,6 @@ export type AnyEvent =
   | RegionRemovedEvent
   | ContextBoundaryAppliedEvent
   | FsmTransitionEvent
+  | ToolEmittedEvent
   | SkillLoadedEvent
   | SkillUnloadedEvent

--- a/tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts
+++ b/tests/e2e/s-011-multi-state-fsm-intent-routing-and-slot-filling.e2e.test.ts
@@ -573,6 +573,7 @@ describe('Case 6 Path D: 多轮槽填充（确定性）', () => {
   let trajectoryStore: TrajectoryStore
   let stateStore: MemoryStore
   let eventStore: MemoryEventStore
+  let run1: AgentResult
   let run4: AgentResult
   let trajectory: Trajectory
 
@@ -594,7 +595,7 @@ describe('Case 6 Path D: 多轮槽填充（确定性）', () => {
     milkie.registerAgent(billingSpecialistConfig)
     milkie.registerAgent(customerServiceConfig)
 
-    await milkie.invoke({
+    run1 = await milkie.invoke({
       agentId: 'customer-service',
       goal,
       input: '我想取消订单',
@@ -671,5 +672,14 @@ describe('Case 6 Path D: 多轮槽填充（确定性）', () => {
       .filter(s => s.name === 'tool.call' && s.attributes['toolName'] === 'collect_slot')
       .map(s => (s.attributes['input'] as { name?: string }).name)
     expect(slotNames).toEqual(['orderId', 'reason', 'preferRefund'])
+  })
+
+  // #60: turn-1 is emit-driven (classify_intent → ctx.emit routes the intent
+  // hard-transition into collecting_slots). Before #60 replaying it diverged,
+  // because the handler is not re-run on replay so ctx.emit never fired.
+  it('replays the emit-driven turn-1 run without divergence (#60)', async () => {
+    const replayed = await milkie.replay(run1.agentRunId)
+    expect(replayed.status).toBe(run1.status)
+    expect(replayed.output).toBe(run1.output)
   })
 })


### PR DESCRIPTION
## 背景与根因

`replay()` 由 `ReplayingIOPort.invokeTool` 直接吐缓存输出、**不跑 handler**(忽略 `execute` thunk)。于是 handler 里 `ctx.emit` 永远不触发 → FSM 不转移 → run loop 多发一次未缓存的 LLM 调用 → `ReplayDivergenceError(llm)`。所有靠 `ctx.emit` 做硬转移/意图路由的 agent(如 s-011)都无法完整 replay。这是 #73 解决兄弟问题(工具对 working memory 的副作用)后,replay 确定性的最后一个缺口。

## 方案(沿用 #73 的副作用事件化模板)

- 新增 `tool.emitted` 事件:记录 handler 经 `ctx.emit` 发出、且**赢得 FSM 单一 `pendingEvent` 槽**(first-emit-wins)的那个业务事件,按 `toolCallId` 作 key(`toolCallId` 来自 cached LLM 输出 → replay 时必然一致,故对齐稳)。
- replay 时在 `executeSingleTool` 拿到缓存输出后据 `toolCallId` re-emit,注入发生在 `processPendingEvent` 之前 → emit 驱动的转移确定性复现,无需重跑 handler。
- `tool.emitted` 不是 IO nondet 事件 → 绕过 `CacheIndex` 与 under-consume 四队列检查。

**为什么新增独立事件而非搭车 `tool.responded`**:后者由 `RecordingIOPort` 写,它不持有 FSM 句柄、拿不到 `pendingEvent`,记录侧塞不进(分层硬伤)。详见设计文档。

## 范围

- 覆盖经 `executeSingleTool`(`ioPort.invokeTool`)的工具调用 emit。
- action-state handler 在 replay 直跑、emit 自然复现,无需处理。
- handler 内 `ctx.requestSkill` 是同根因的相邻 gap,作为 follow-up(roadmap 已标注)。

## 测试(TDD)

核心测试先 watched RED(`ReplayDivergenceError(llm)`,正是 #60 根因)→ 最小实现转 GREEN,再补齐:

1. emit-FSM replay 无散度(核心)
2. guard 透传 + 录制 payload 形状精确断言
3. 无 emit → 不产生 `tool.emitted`(不回归 #73)
4. 并行 batch first-wins:只录赢家一条,replay 确定性复现
5. **s-011 turn-1**(#60 原始动机用例)真实多 handler emit-FSM 的 replay 断言

验证:`tsc --noEmit` 干净;`src/__tests__` 全量 387 通过;canonical `npm test`(单测 + 确定性 e2e 含 s-011)全绿。

## 改动文件

- `src/trace/types.ts` — `tool.emitted` 类型/payload/alias
- `src/runtime/AgentRuntime.ts` — 捕获式 emitFn + 记录/注入
- `src/runtime/Milkie.ts` — `replay()` 装配 `replayEmits`
- `src/__tests__/Replay.test.ts`、s-011 e2e — 测试
- `roadmap.md`、`docs/superpowers/specs/2026-05-31-emit-driven-fsm-replay-design.md` — 文档

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)