### PR TITLE
feat(#70): projection-driven Execution tab in agent-docs-qa

### DIFF
--- a/docs/superpowers/specs/2026-05-31-execution-tab-projection-design.md
+++ b/docs/superpowers/specs/2026-05-31-execution-tab-projection-design.md
@@ -1,0 +1,159 @@
+# #70 把 agent-docs-qa 的 Execution(原 Steps)tab 改成投影驱动 — 设计 spec
+
+**Issue:** #70(diagnosable;Parent #20;follow-up of #68 / PR #69)
+**日期:** 2026-05-31
+**定位:** 把 `examples/agent-docs-qa` 参考应用 audit panel 里「执行·成本」(原 Steps,`data-tab="steps"`)tab 的**前端归因逻辑**搬到核心**纯投影**,前端只渲染——守住 ARCHITECTURE.md invariant 12/13「UI = projection over CLI/SDK,前端不自带归因逻辑」。
+
+经 brainstorm 定稿:**路 A(核心出结构化 JSON,前端纯渲染)** + **本 MVP 含 CLI 入口**(守 invariant 13)。
+
+---
+
+## 1. 目标
+
+`renderStepsTab`(`public/index.html:882-1009`)目前在浏览器里手工解析事件重写归因:walk `region.added/removed` 维护 `activeRegions`、`llm.requested` 时快照、按 `requestHash` 配对 `tool/llm.responded` 取 `cacheStats`、`classifyCacheTier` 分级、`renderRegionExpander` 按 stability 分组、current-turn 内容预览。本 issue 把这套归因搬进核心纯投影函数,前端改为消费投影 JSON,**行为/外观零变化**。
+
+## 2. 背景与现状
+
+#68(PR #69)给 panel 加了「决策·为什么」tab,**整块复用核心 `renderViewer`**(iframe),前端零归因;但刻意把「执行·成本」tab 的投影化重构踢成独立 follow-up(本 issue),避免 PR 膨胀。
+
+现状关键事实:
+- 前端 `renderStepsTab` 是同步函数,从本地已 catch-up 的 `eventsByRunId` 渲染,**不经任何 endpoint**。
+- 核心已有可复用投影:`contextRefsAt(events, eventId, 'at')`(某时刻 region composition,`src/trace/RegionContextView.ts:46`)、`regionReuseCounts(events)`(同文件:106)。但**没有** cache tier 分级、没有"组装 Execution step 列表"的投影。
+- CLI `trace report <runId>` 出的是 HTML(renderViewer);**没有**出 JSON 投影的子命令。
+
+## 3. Non-goals
+
+- 不改「决策·为什么」tab(#68)、Sources、Provenance。
+- 不改 Execution tab 的视觉/交互/文案(纯搬迁,行为保真:cache 分级阈值、stability 顺序、badge 文案、展开预览全部不变)。
+- MVP 不做:Execution tab 的 live 自动刷新、descendant 子 run 合并。
+- 不引入新依赖、不改事件 schema。
+
+## 4. 架构与组件
+
+```
+src/trace/diagnostics/buildExecutionProjection.ts   // 新增:纯投影函数 + 类型
+src/__tests__/buildExecutionProjection.test.ts      // 新增:核心单测(TDD 主体)
+src/cli/main.ts                                      // 新增 `trace execution <runId>` → JSON
+examples/agent-docs-qa/server.ts                    // 新增 GET /run/:runId/execution → JSON
+examples/agent-docs-qa/public/index.html            // renderStepsTab 改 fetch + 纯渲染
+examples/agent-docs-qa/__tests__/server.test.ts     // endpoint 测试
+```
+
+### 4.1 核心 — `buildExecutionProjection`(纯函数,只读 events,无 IO)
+
+与 `buildDecisionSpine`/`explainLlmCall` 并列,风格一致(只读 events、返回可序列化 plain object)。
+
+```ts
+export interface CacheHealth {
+  tier: 'hot' | 'warm' | 'cold'
+  readTokens:       number
+  creationTokens:   number
+  totalInputTokens: number
+  hitRate:          number
+}
+
+export interface RegionGroup {
+  stability: 'immutable' | 'session-stable' | 'turn-stable' | 'volatile'
+  regions:   RegionContentRef[]   // from RegionContextView; preview filled from regionContent
+}
+
+export interface ExecutionStep {
+  kind:  'llm' | 'tool'
+  label: string
+  // llm-only:
+  messageCount?: number
+  cacheHealth?:  CacheHealth | null
+  regionGroups?: RegionGroup[]    // 已按 STABILITY_ORDER 排好,空组省略
+  prompt?:       { system?: unknown; messages: unknown[]; tools: unknown[] } | null
+  response?:     unknown
+  // tool-only:
+  tool?: { name: string; input?: unknown; output?: unknown; error?: unknown; status: 'ok' | 'pending' | 'error' }
+}
+
+export interface ExecutionProjection { steps: ExecutionStep[] }
+
+export function buildExecutionProjection(
+  events: Event[],
+  opts?: { regionContent?: Map<string, string> },
+): ExecutionProjection
+```
+
+实现要点(把前端逻辑逐项搬入,**复用核心已有**):
+- 遍历 events,遇 `llm.requested` 产出一个 llm step,遇 `tool.requested` 产出一个 tool step(顺序 = 事件顺序)。
+- **region composition**:用 `contextRefsAt(events, llmRequestedEventId, 'at')` 取该时刻 region 集合(替代前端手 walk `activeRegions`)。`opts.regionContent`(按 contentHash)命中则给 `RegionContentRef.content` 灌内容。注:前端原来只硬编码预览 `current-turn`(代码注释自承"not a general mechanism");这里用 #26 内容寻址**正确泛化**为"任何有落盘内容的 region 都可预览"(与 Why tab / renderViewer 一致),是预期内的小改进而非行为漂移;无内容则降级"(内容不可用)",不报错。
+- **cache health**:按 `requestHash` 找配对 `llm.responded.cacheStats`;tier 阈值搬自前端 `classifyCacheTier`(`hit≥0.7→hot`;`hit≥0.3 || creationTokens>0→warm`;否则 `cold`),无 cacheStats → `cacheHealth: null`。
+- **region 分组**:常量 `STABILITY_ORDER = ['immutable','session-stable','turn-stable','volatile']` 搬入核心,按序分组,空组省略;返回 `regionGroups`(前端不再自己分组)。
+- **复用计数**:`regionReuseCounts(events)`,把计数附到对应 region(前端"复用 ×N"标注的数据源)。
+- **tool 配对**:按 `requestHash` 找 `tool.responded`,有 output → `status:'ok'`,有 error → `'error'`,无 → `'pending'`。
+
+### 4.2 CLI — `trace execution <runId>`(invariant 13)
+
+`src/cli/main.ts` 新增子命令,照搬 `trace report`(:179-204)的 regionContent hydrate 模式,但输出 JSON:
+
+1. `findMilkieDir` → `JsonlEventStore(runsDir)` → `events = readByRunId(runId)`(含 descendant?MVP 单 runId,与 server 一致;descendant 留扩展)。
+2. hydrate `regionContent`:遍历 `regionReuseCounts(events).keys()`,`FileTraceObjectStore.getCanonical(h)` 命中填入 map。
+3. `stdout.push(JSON.stringify(buildExecutionProjection(events, { regionContent })) + '\n')`。
+
+### 4.3 Server — `GET /run/:runId/execution` → JSON
+
+平行 #68 `handleViewer`(`server.ts`),但出 JSON:
+1. `events = await eventStore.readByRunId(runId)`;空 → `sendJson(res, 404, { error: 'run not found' })`。
+2. hydrate `regionContent`(同 `handleViewer`)。
+3. `sendJson(res, 200, buildExecutionProjection(events, { regionContent }))`。
+
+### 4.4 前端 — `renderStepsTab` 改纯渲染(`public/index.html`)
+
+- 切到「执行·成本」tab 时 `fetch('/run/${runId}/execution')` 取 `ExecutionProjection` JSON(lazy,与 #68 viewer tab 一致);加 loading / error 态。
+- 把 `steps[]` 字段塞进**现有 DOM/CSS**(`ap-step`、cacheBadge、region expander 外壳保留,视觉不变)。
+- **删除**前端归因:`activeRegions` walk、`requestHash` 配对、`classifyCacheTier`、`STABILITY_ORDER` 分组、preview 推导(若这些 helper 仅 Execution tab 使用则一并删除)。
+- cacheBadge 文案逻辑(`{hit}% read`/`wrote {n} cache`/`no cache`)属"渲染呈现",可留前端;但 **tier 分级**(hot/warm/cold 的判定)来自投影 `cacheHealth.tier`,前端不再自己判。
+
+## 5. 数据流 / 边界
+
+- 投影在 server/CLI 请求期算好,前端不重算。
+- 未知 runId → endpoint 404 / CLI 报错;前端显错误态。
+- region 无内容 hash / objectStore 未命中 → 预览降级"(内容不可用)"(沿用 #26/#64),不报错。
+- 无 llm/tool 事件的 run → `steps: []`,前端显"No recorded steps"(沿用现状)。
+- 旧 run(objectStore 无内容)→ 预览降级,不报错。
+
+## 6. 测试
+
+- **核心单测(TDD 主体)** `buildExecutionProjection.test.ts`(纯函数,易测,先红后绿):
+  - cache tier 三档:hit≥0.7→hot;hit 0.3~0.7 或 creationTokens>0→warm;否则 cold;无 cacheStats→null。
+  - region 按 stability 分组顺序 = STABILITY_ORDER,空组省略。
+  - 复用计数附着正确(同 hash region 复用 ×N)。
+  - tool step 配对:ok / error / pending 三态。
+  - regionContent 命中 → preview 灌入;未命中 → 降级无 preview。
+  - step 顺序 = 事件顺序;llm step 带 messageCount/prompt/response。
+- **CLI** `trace execution <runId>` → stdout 合法 JSON、结构匹配(用既有 e2e 风格或集成测)。
+- **server** `server.test.ts`:`GET /run/:id/execution` → 200 + JSON 结构(steps 非空、含 cacheHealth/regionGroups);未知 runId → 404;现有测试全绿。
+- **回归断言**:`public/index.html` grep 不到 `activeRegions` / `classifyCacheTier` / `STABILITY_ORDER` 解析逻辑(证明归因已搬走)。
+- **browser 端到端(dev-browser)**:起 server → 发一次 chat → 开 audit panel → 切「执行·成本」tab → 断言:steps 列表渲染、cache badge tier class(hot/warm/cold)、region expander 按 stability 分组展开、内容预览可见 → 与重构前外观一致。
+
+## 7. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `src/trace/diagnostics/buildExecutionProjection.ts` | 新增纯投影函数 + 类型 |
+| `src/__tests__/buildExecutionProjection.test.ts` | 新增核心单测 |
+| `src/cli/main.ts` | 新增 `trace execution <runId>` → JSON |
+| `examples/agent-docs-qa/server.ts` | 新增 `GET /run/:runId/execution` handler |
+| `examples/agent-docs-qa/public/index.html` | `renderStepsTab` 改 fetch + 纯渲染,删前端归因 |
+| `examples/agent-docs-qa/__tests__/server.test.ts` | endpoint 测试 |
+| `roadmap.md` | 标注 #70 落地 |
+
+## 8. Follow-up(不进本 PR)
+
+- Execution tab live 自动刷新、descendant 子 run 合并。
+- `trace execution` 的 descendant 合并(与 `trace report` 对齐)。
+
+## 9. 验收对照(#70)
+
+- [ ] Execution tab 改投影驱动:server/CLI 出投影 JSON,前端只渲染 → §4.1-4.4
+- [ ] 保留现有 UX:cache health 分级(hot/warm/cold + token)、region 按 stability 分组 → §4.1 投影 + §4.4 渲染 + §6 测试
+- [ ] 前端不自带归因逻辑(grep 回归断言)→ §6
+- [ ] 守 invariant 13:新能力随 CLI 入口交付 → §4.2
+
+## 10. 分支
+
+`feat/70-execution-tab-projection`,基于 main(含 #68/#26)。

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -225,6 +225,41 @@ describe('server — REST endpoints', () => {
     expect(r.status).toBe(404)
   })
 
+  it('GET /run/:runId/execution returns the execution projection JSON', async () => {
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'hi' })
+    const { runId } = JSON.parse(chat.body) as { runId: string }
+
+    const r = await get(`${baseUrl}/run/${runId}/execution`)
+    expect(r.status).toBe(200)
+    const body = JSON.parse(r.body) as {
+      steps: Array<{ kind: string; regionGroups?: Array<{ stability: string; regions: unknown[] }>; cacheHealth?: unknown }>
+    }
+    expect(Array.isArray(body.steps)).toBe(true)
+    expect(body.steps.length).toBeGreaterThan(0)
+    // The stub run makes one LLM call with composed regions → an llm step
+    // whose region groups come from the core projection (not the frontend).
+    const llmStep = body.steps.find(s => s.kind === 'llm')
+    expect(llmStep).toBeDefined()
+    expect(Array.isArray(llmStep!.regionGroups)).toBe(true)
+    expect(llmStep!.regionGroups!.length).toBeGreaterThan(0)
+  })
+
+  it('GET /run/:runId/execution 404s on an unknown run', async () => {
+    const r = await get(`${baseUrl}/run/does-not-exist/execution`)
+    expect(r.status).toBe(404)
+  })
+
+  it('Execution tab frontend carries no attribution logic — it only renders the projection (invariant 12/13)', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8')
+    // #70: cache tiering, stability grouping, and event-walking attribution all
+    // moved into the core buildExecutionProjection. The frontend must NOT recompute them.
+    expect(html).not.toContain('classifyCacheTier')
+    expect(html).not.toContain('STABILITY_ORDER')
+    expect(html).not.toContain('activeRegions')
+    // It consumes the core projection endpoint instead.
+    expect(html).toContain('/execution`')
+  })
+
   it('serves the audit panel with a Why tab', async () => {
     const r = await get(`${baseUrl}/`)
     expect(r.status).toBe(200)

--- a/examples/agent-docs-qa/public/index.html
+++ b/examples/agent-docs-qa/public/index.html
@@ -705,51 +705,25 @@
     // render them as numbered cards. Internal substrate events (clock,
     // uuid, region, boundary) are intentionally hidden — those belong
     // in dev mode's substrate inspector, not in a per-turn audit.
-    // Stability buckets we group regions by in the expander. Listed in
-    // display order — most-stable first reads top-down like a layered
-    // prompt, which mirrors how the agent's working context is actually
-    // assembled (immutable system prompt at the top, volatile scratch at
-    // the bottom).
-    const STABILITY_ORDER = ['immutable', 'session-stable', 'turn-stable', 'volatile']
-
-    // Cache tiering accounts for BOTH read and creation. A call that hit
-    // 70%+ of its tokens from cache is "hot". A call that read nothing
-    // but wrote new cache entries is "warm" — the substrate is engaged,
-    // a future call sharing this prefix will benefit. A call that did
-    // neither is "cold" (cache subsystem ran but nothing matched and
-    // nothing new was written, e.g. provider didn't report stats).
-    function classifyCacheTier(cache) {
-      if (!cache) return null
-      const hit = cache.hitRate || 0
-      const created = cache.creationTokens || 0
-      if (hit >= 0.7) return 'hot'
-      if (hit >= 0.3 || created > 0) return 'warm'
-      return 'cold'
-    }
-
     function formatTokenCount(n) {
       if (n == null) return ''
       if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
       return String(n)
     }
 
-    function renderRegionExpander(regions) {
-      if (regions.length === 0) {
+    // Render the region composition the projection already grouped by stability
+    // (immutable → session-stable → turn-stable → volatile, empty groups omitted).
+    // The frontend does NOT regroup or reorder — it renders the groups as given.
+    function renderRegionExpander(groups) {
+      if (!groups || groups.length === 0) {
         return `<div class="ap-region-empty">No regions in context at this point.</div>`
       }
-      const byStability = new Map(STABILITY_ORDER.map(k => [k, []]))
-      for (const r of regions) {
-        const bucket = byStability.get(r.stability) || (byStability.set(r.stability, []), byStability.get(r.stability))
-        bucket.push(r)
-      }
       let html = ''
-      for (const stability of STABILITY_ORDER) {
-        const group = byStability.get(stability) || []
-        if (group.length === 0) continue
+      for (const group of groups) {
         html += `<div class="ap-region-group">
-          <div class="rg-title">${esc(stability)} · ${group.length}</div>
-          ${group.map(r => {
-            const preview = r.preview ? `<span class="rr-preview">${esc(r.preview)}</span>` : ''
+          <div class="rg-title">${esc(group.stability)} · ${group.regions.length}</div>
+          ${group.regions.map(r => {
+            const preview = r.content ? `<span class="rr-preview">${esc(r.content)}</span>` : ''
             return `
               <div class="ap-region-row">
                 <span class="rr-id">${esc(r.id)}</span>
@@ -879,100 +853,35 @@
       return html
     }
 
-    function renderStepsTab(runId) {
-      const events    = eventsByRunId.get(runId) || []
-      // The current-turn region's content IS the user's input for this
-      // run. Cache it once so each snapshot can attach it as a preview
-      // without re-scanning events per LLM call.
-      const userInput = userInputForRun(runId)
-      // Pair requests with their responses via requestHash — the
-      // content-addressed cache key both sides carry. Same key both for
-      // tool pairing and for fetching LLM cache stats off the response
-      // payload.
-      const toolResponses = new Map()
-      const llmResponses  = new Map()
-      for (const e of events) {
-        if (e.type === 'tool.responded' && e.payload && e.payload.requestHash) {
-          toolResponses.set(e.payload.requestHash, e)
-        }
-        if (e.type === 'llm.responded' && e.payload && e.payload.requestHash) {
-          llmResponses.set(e.payload.requestHash, e)
-        }
+    // Execution tab is a PURE PROJECTION over the core buildExecutionProjection
+    // (served at GET /run/:runId/execution). The frontend does NO event parsing
+    // or attribution: cache tiering, region grouping by stability, and tool
+    // pairing all live in the core projection (守 ARCHITECTURE.md「UI =
+    // projection over CLI/SDK,前端不自带归因逻辑」). We only render the JSON.
+    async function renderStepsTab(runId) {
+      let steps
+      try {
+        const res = await fetch(`/run/${encodeURIComponent(runId)}/execution`)
+        if (!res.ok) return `<div class="ap-empty">No recorded steps for this turn yet.</div>`
+        steps = (await res.json()).steps || []
+      } catch {
+        return `<div class="ap-empty">Failed to load execution steps.</div>`
       }
-      // Maintain a live region map as we walk events; snapshot it whenever
-      // an llm.requested fires. The snapshot is what was in the model's
-      // working context at the moment of that LLM call — the unique
-      // milkie observation the region.added/removed substrate enables.
-      const activeRegions = new Map()
-      const cards = []
-      for (const e of events) {
-        if (e.type === 'region.added' && e.payload && e.payload.id) {
-          activeRegions.set(e.payload.id, e.payload)
-        } else if (e.type === 'region.removed' && e.payload && e.payload.id) {
-          activeRegions.delete(e.payload.id)
-        } else if (e.type === 'llm.requested') {
-          const messages = e.payload && e.payload.request && countMessages(e.payload.request)
-          const resp     = e.payload && e.payload.requestHash && llmResponses.get(e.payload.requestHash)
-          const cache    = resp && resp.payload && resp.payload.cacheStats
-          // Decorate the snapshot with content previews for regions we
-          // know how to surface (just current-turn for now). Region.added
-          // events don't carry content, so this is a per-id lookup, not
-          // a general mechanism.
-          const snapshot = Array.from(activeRegions.values()).map(r =>
-            r.id === 'current-turn' && userInput
-              ? { ...r, preview: userInput }
-              : r
-          )
-          const req = e.payload && e.payload.request
-          cards.push({
-            kind:    'llm',
-            label:   'LLM call',
-            body:    messages != null
-              ? `Sent <code>${messages}</code> message${messages === 1 ? '' : 's'} to the model`
-              : 'Sent prompt to the model',
-            meta:    null,
-            cache:   cache ? { ...cache, tier: classifyCacheTier(cache) } : null,
-            regions: snapshot,
-            prompt:  req ? {
-              system:   req.system,
-              messages: req.messages || [],
-              tools:    req.tools || [],
-            } : null,
-            response: resp && resp.payload && resp.payload.response ? resp.payload.response : null,
-          })
-        } else if (e.type === 'tool.requested') {
-          const name = (e.payload && e.payload.toolName) || '?'
-          const input = e.payload && e.payload.input
-          const inputPreview = input ? truncateJson(input, 120) : ''
-          const resp = e.payload && e.payload.requestHash && toolResponses.get(e.payload.requestHash)
-          const respMeta = resp && resp.payload
-            ? `→ ok (${describeToolResult(resp.payload.output)})`
-            : '→ pending'
-          cards.push({
-            kind:   'tool',
-            label:  `Tool · ${name}`,
-            body:   inputPreview ? `<code>${esc(inputPreview)}</code>` : '',
-            meta:   respMeta,
-            input,
-            output: resp && resp.payload ? resp.payload.output : undefined,
-            error:  resp && resp.payload ? resp.payload.error  : undefined,
-          })
-        }
-      }
-      if (cards.length === 0) {
+      if (steps.length === 0) {
         return `<div class="ap-empty">No recorded steps for this turn yet.</div>`
       }
-      return cards.map((c, i) => {
-        // Badge surfaces both read AND creation so a "0% hit but cache
-        // was just written" call (substrate engaged, future calls will
-        // benefit) is visibly different from a "no cache at all" call.
+      return steps.map((s, i) => {
+        // Badge surfaces both read AND creation so a "0% hit but cache was just
+        // written" call is visibly different from a "no cache at all" call. The
+        // tier (hot/warm/cold) comes from the projection — not computed here.
         let cacheBadge = ''
-        if (c.cache) {
-          const read    = c.cache.readTokens     || 0
-          const created = c.cache.creationTokens || 0
-          const total   = c.cache.totalInputTokens || 0
-          const hitPct  = Math.round((c.cache.hitRate || 0) * 100)
-          const tierClass = c.cache.tier === 'cold' ? 'cold' : c.cache.tier === 'warm' ? 'warm' : ''
+        if (s.cacheHealth) {
+          const c = s.cacheHealth
+          const read    = c.readTokens     || 0
+          const created = c.creationTokens || 0
+          const total   = c.totalInputTokens || 0
+          const hitPct  = Math.round((c.hitRate || 0) * 100)
+          const tierClass = c.tier === 'cold' ? 'cold' : c.tier === 'warm' ? 'warm' : ''
           let text
           if (read > 0) {
             text = `${hitPct}% read · ${formatTokenCount(read)}/${formatTokenCount(total)} tok`
@@ -983,38 +892,41 @@
           }
           cacheBadge = `<span class="ap-step-cache ${tierClass}" title="read ${read} · wrote ${created} · total ${total}">${text}</span>`
         }
-        const expander = c.kind === 'llm'
-          ? `<div class="ap-step-expand" data-step-idx="${i}">${c.regions.length} region${c.regions.length === 1 ? '' : 's'} in context</div>
-             <div class="ap-step-expanded">${renderRegionExpander(c.regions)}</div>`
-          : ''
-        const details = c.kind === 'llm'
-          ? `<details class="ap-step-details"><summary>Prompt &amp; response</summary>${renderLLMDetails(c)}</details>`
-          : c.kind === 'tool'
-            ? `<details class="ap-step-details"><summary>Full input &amp; output</summary>${renderToolDetails(c)}</details>`
-            : ''
+
+        let body = '', meta = '', expander = '', details = ''
+        if (s.kind === 'llm') {
+          const n = s.messageCount
+          body = n != null
+            ? `Sent <code>${n}</code> message${n === 1 ? '' : 's'} to the model`
+            : 'Sent prompt to the model'
+          const groups = s.regionGroups || []
+          const regionCount = groups.reduce((acc, g) => acc + g.regions.length, 0)
+          expander = `<div class="ap-step-expand" data-step-idx="${i}">${regionCount} region${regionCount === 1 ? '' : 's'} in context</div>
+             <div class="ap-step-expanded">${renderRegionExpander(groups)}</div>`
+          details = `<details class="ap-step-details"><summary>Prompt &amp; response</summary>${renderLLMDetails({ prompt: s.prompt, response: s.response })}</details>`
+        } else {
+          const t = s.tool || {}
+          const inputPreview = t.input ? truncateJson(t.input, 120) : ''
+          body = inputPreview ? `<code>${esc(inputPreview)}</code>` : ''
+          meta = t.status === 'pending' ? '→ pending'
+               : t.status === 'error'   ? '→ error'
+               : `→ ok (${describeToolResult(t.output)})`
+          details = `<details class="ap-step-details"><summary>Full input &amp; output</summary>${renderToolDetails({ input: t.input, output: t.output, error: t.error })}</details>`
+        }
         return `
-          <div class="ap-step kind-${c.kind}" data-step-idx="${i}">
+          <div class="ap-step kind-${s.kind}" data-step-idx="${i}">
             <div class="ap-step-num">${i + 1}</div>
             <div class="ap-step-headerline">
-              <div class="ap-step-kind">${esc(c.label)}</div>
+              <div class="ap-step-kind">${esc(s.label)}</div>
               ${cacheBadge}
             </div>
-            <div class="ap-step-body">${c.body}</div>
-            ${c.meta ? `<div class="ap-step-meta">${esc(c.meta)}</div>` : ''}
+            <div class="ap-step-body">${body}</div>
+            ${meta ? `<div class="ap-step-meta">${esc(meta)}</div>` : ''}
             ${expander}
             ${details}
           </div>
         `
       }).join('')
-    }
-
-    function countMessages(request) {
-      // ModelRequest shape varies by provider; the common case is an
-      // OpenAI-style {messages: [...]} array. Fall back to null when
-      // we can't tell, so the caller renders a generic label.
-      if (!request) return null
-      if (Array.isArray(request.messages)) return request.messages.length
-      return null
     }
 
     function truncateJson(value, max) {
@@ -1253,7 +1165,16 @@
       if (auditActiveTab === 'sources') {
         $auditBody.innerHTML = renderSourcesTab(auditAnchorRunId, msgEl)
       } else if (auditActiveTab === 'steps') {
-        $auditBody.innerHTML = renderStepsTab(auditAnchorRunId)
+        $auditBody.innerHTML = `<div class="ap-empty">Loading execution steps…</div>`
+        // Async render: the steps come from the core projection endpoint.
+        // Capture runId/tab so a fast tab switch doesn't paint stale results.
+        const pendingRunId = auditAnchorRunId
+        const pendingTab   = auditActiveTab
+        renderStepsTab(auditAnchorRunId).then(html => {
+          if (auditAnchorRunId === pendingRunId && auditActiveTab === pendingTab) {
+            $auditBody.innerHTML = html
+          }
+        })
       } else if (auditActiveTab === 'why') {
         // Reuse the core #64 decision viewer wholesale: it is a self-contained
         // HTML document (own CSS + drill-down JS), so an iframe isolates it and

--- a/examples/agent-docs-qa/server.ts
+++ b/examples/agent-docs-qa/server.ts
@@ -9,6 +9,7 @@ import { JsonlEventStore } from '../../src/trace/JsonlEventStore.js'
 import { FileTraceObjectStore } from '../../src/trace/TraceObjectStore.js'
 import { regionReuseCounts } from '../../src/trace/RegionContextView.js'
 import { renderViewer } from '../../src/trace/render/viewer.js'
+import { buildExecutionProjection } from '../../src/trace/diagnostics/buildExecutionProjection.js'
 import { ReplayError } from '../../src/trace/ReplayError.js'
 import { ReplayDivergenceError } from '../../src/trace/ReplayDivergenceError.js'
 import type { IModelGateway } from '../../src/types/model.js'
@@ -197,6 +198,26 @@ async function handleViewer(
   res.end(html)
 }
 
+// #70: the Execution tab is a projection over the event log — the core
+// buildExecutionProjection owns all attribution (cache tiering, region
+// grouping, tool pairing); the frontend only renders this JSON.
+async function handleExecution(
+  res: ServerResponse, s: ServerState, runId: string,
+): Promise<void> {
+  const events = await s.eventStore.readByRunId(runId)
+  if (events.length === 0) {
+    sendJson(res, 404, { error: 'run not found' })
+    return
+  }
+  // Hydrate region content the same way handleViewer / `trace report` does.
+  const regionContent = new Map<string, string>()
+  for (const h of regionReuseCounts(events).keys()) {
+    const c = await s.traceObjectStore.getCanonical(h)
+    if (c !== undefined) regionContent.set(h, c)
+  }
+  sendJson(res, 200, buildExecutionProjection(events, { regionContent }))
+}
+
 async function handleSourceFetch(
   res: ServerResponse, s: ServerState, relPath: string, linesQuery: string | null,
 ): Promise<void> {
@@ -299,6 +320,11 @@ export async function startServer(config: ServerConfig): Promise<Server> {
       const viewerMatch = route.match(/^\/run\/([^/]+)\/viewer$/)
       if (req.method === 'GET' && viewerMatch) {
         return handleViewer(res, state, decodeURIComponent(viewerMatch[1]!))
+      }
+
+      const executionMatch = route.match(/^\/run\/([^/]+)\/execution$/)
+      if (req.method === 'GET' && executionMatch) {
+        return handleExecution(res, state, decodeURIComponent(executionMatch[1]!))
       }
 
       const sourceMatch = route.match(/^\/source\/(.+)$/)

--- a/roadmap.md
+++ b/roadmap.md
@@ -164,7 +164,16 @@ Last updated: 2026-05-30
   polish (#71): output answer renders markdown, the causal chain is trimmed to
   decision hops, `summarizeEvent` disambiguates repeated tool calls by input,
   and `agent.run.completed.causedBy = final llm.responded` so the output ❓
-  drills. Follow-up #70 (make the Execution/Steps tab projection-driven) open.
+  drills.
+- **#70 landed — the Execution tab is projection-driven.** The example's
+  Execution (formerly Steps) tab no longer re-derives attribution in the
+  browser: a new core pure projection `buildExecutionProjection` owns cache
+  tiering (hot/warm/cold), region grouping by stability, and tool pairing.
+  It ships with a CLI entry point (`milkie trace execution <runId>` → JSON,
+  invariant 13) and a server endpoint (`GET /run/:runId/execution`); the
+  frontend only renders the JSON (no `classifyCacheTier` / `STABILITY_ORDER` /
+  event-walking left in `index.html`). Closes the #68 follow-up so the whole
+  audit panel now honors「UI = projection over CLI/SDK」.
 - **Phase 4.7 — Events as the single source of truth for resume (#73, PR #74).**
   Tool side-effects on working memory are now event-sourced: each tool call
   emits a frozen `wm.mutated` WM snapshot, so `replay()` — which does NOT re-run
@@ -223,8 +232,9 @@ agent-consumable projections before adding richer UI:
   functions as CLI. They are reference projections over Trace, not a
   separate observability product. **Landed:** the #64 causal drill-down viewer
   (decision spine + Why panel) and its embedding into the agent-docs-qa audit
-  panel (#68 / #71). **Open:** #70 (make the example's Execution tab
-  projection-driven instead of re-parsing events in the frontend).
+  panel (#68 / #71), plus #70 (the Execution tab is now projection-driven via
+  `buildExecutionProjection` + `trace execution` CLI + `/run/:id/execution`
+  endpoint; the frontend only renders).
 
 **Phase 5 — fork / structural diff / suite replay** remains the next big
 capability rock. Substrate prerequisites are now stronger thanks to the

--- a/src/__tests__/CliTraceExecution.test.ts
+++ b/src/__tests__/CliTraceExecution.test.ts
@@ -1,0 +1,49 @@
+import { main } from '../cli/main'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+describe('CLI: trace execution', () => {
+  let tmpDir: string
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-execution-'))
+  })
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  it('trace execution <runId> emits the execution projection as JSON to stdout', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.milkie', 'runs'), { recursive: true })
+    const runId = 'demo-run'
+    const events = [
+      { id: 's', runId, type: 'agent.run.started', actor: 'runtime', timestamp: 1,
+        payload: { agentId: 'echo', goal: 'g', input: 'i', contextId: runId } },
+      { id: 'ra', runId, type: 'region.added', actor: 'echo', timestamp: 2,
+        payload: { id: 'header', target: 'system', section: 'sys', stability: 'immutable', reason: 'agent-set' } },
+      { id: 'q', runId, type: 'llm.requested', actor: 'echo', timestamp: 3,
+        payload: { request: { model: 'm', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }, requestHash: 'h1' } },
+      { id: 'a', runId, type: 'llm.responded', actor: 'echo', timestamp: 4, causedBy: 'q',
+        payload: { response: { content: [{ type: 'text', text: 'hi' }], toolCalls: [], finishReason: 'end_turn' },
+          requestHash: 'h1', cacheStats: { readTokens: 90, creationTokens: 0, totalInputTokens: 100, hitRate: 0.9 } } },
+      { id: 'c', runId, type: 'agent.run.completed', actor: 'runtime', timestamp: 9,
+        payload: { status: 'completed', lastTextOutput: 'hi' } },
+    ]
+    fs.writeFileSync(
+      path.join(tmpDir, '.milkie', 'runs', `${runId}.jsonl`),
+      events.map(e => JSON.stringify(e)).join('\n') + '\n',
+    )
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir)
+    try {
+      const result = await main(['trace', 'execution', runId])
+      expect(result.exitCode).toBe(0)
+      const proj = JSON.parse(result.stdout) as {
+        steps: Array<{ kind: string; cacheHealth?: { tier: string }; regionGroups?: Array<{ stability: string }> }>
+      }
+      const llm = proj.steps.find(s => s.kind === 'llm')
+      expect(llm).toBeDefined()
+      expect(llm!.cacheHealth?.tier).toBe('hot')
+      expect(llm!.regionGroups?.[0]?.stability).toBe('immutable')
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
+})

--- a/src/__tests__/buildExecutionProjection.test.ts
+++ b/src/__tests__/buildExecutionProjection.test.ts
@@ -1,0 +1,138 @@
+import { buildExecutionProjection } from '../trace/diagnostics/buildExecutionProjection'
+import type { Event } from '../trace/types'
+
+// Minimal event builders — these are the recorded-log shapes the projection reads.
+function llmRequested(id: string, hash: string, messages: unknown[] = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]): Event {
+  return { id, runId: 'r', type: 'llm.requested', actor: 'a', timestamp: 1,
+    payload: { request: { model: 'm', messages }, requestHash: hash } }
+}
+function llmResponded(id: string, hash: string, cacheStats?: unknown): Event {
+  return { id, runId: 'r', type: 'llm.responded', actor: 'a', timestamp: 2, causedBy: hash,
+    payload: { response: { content: [], toolCalls: [], finishReason: 'end_turn' }, requestHash: hash,
+      ...(cacheStats ? { cacheStats } : {}) } }
+}
+function regionAdded(id: string, stability: string, contentHash?: string): Event {
+  return { id: `ra-${id}`, runId: 'r', type: 'region.added', actor: 'a', timestamp: 0,
+    payload: { id, target: 'message', section: 'sec', stability, reason: 'agent-set',
+      ...(contentHash ? { contentHash } : {}) } }
+}
+function toolRequested(id: string, hash: string, name: string, input: unknown = {}): Event {
+  return { id, runId: 'r', type: 'tool.requested', actor: 'a', timestamp: 3,
+    payload: { toolName: name, input, requestHash: hash } }
+}
+function toolResponded(id: string, hash: string, name: string, body: { output?: unknown; error?: unknown }): Event {
+  return { id, runId: 'r', type: 'tool.responded', actor: 'a', timestamp: 4, causedBy: hash,
+    payload: { toolName: name, requestHash: hash, ...body } }
+}
+
+describe('buildExecutionProjection', () => {
+  it('classifies a high-hit-rate llm call as a hot cache tier', () => {
+    const events: Event[] = [
+      llmRequested('llm-req', 'h1'),
+      llmResponded('llm-resp', 'h1', { readTokens: 90, creationTokens: 0, totalInputTokens: 100, hitRate: 0.9 }),
+    ]
+    const proj = buildExecutionProjection(events)
+    expect(proj.steps).toHaveLength(1)
+    expect(proj.steps[0]!.kind).toBe('llm')
+    expect(proj.steps[0]!.cacheHealth?.tier).toBe('hot')
+  })
+
+  it('classifies partial reuse or a fresh cache write as warm', () => {
+    const partialRead = buildExecutionProjection([
+      llmRequested('q1', 'h1'),
+      llmResponded('r1', 'h1', { readTokens: 40, creationTokens: 0, totalInputTokens: 100, hitRate: 0.4 }),
+    ])
+    expect(partialRead.steps[0]!.cacheHealth?.tier).toBe('warm')
+
+    const freshWrite = buildExecutionProjection([
+      llmRequested('q2', 'h2'),
+      llmResponded('r2', 'h2', { readTokens: 0, creationTokens: 80, totalInputTokens: 100, hitRate: 0 }),
+    ])
+    expect(freshWrite.steps[0]!.cacheHealth?.tier).toBe('warm')
+  })
+
+  it('classifies no-read no-write as cold', () => {
+    const proj = buildExecutionProjection([
+      llmRequested('q', 'h'),
+      llmResponded('r', 'h', { readTokens: 0, creationTokens: 0, totalInputTokens: 100, hitRate: 0 }),
+    ])
+    expect(proj.steps[0]!.cacheHealth?.tier).toBe('cold')
+  })
+
+  it('reports null cacheHealth when the response carries no cacheStats', () => {
+    const proj = buildExecutionProjection([llmRequested('q', 'h'), llmResponded('r', 'h')])
+    expect(proj.steps[0]!.cacheHealth).toBeNull()
+  })
+
+  it('groups regions in context by stability in canonical order, omitting empty groups', () => {
+    const events: Event[] = [
+      regionAdded('header', 'immutable'),
+      regionAdded('scratch', 'volatile'),
+      regionAdded('skill', 'session-stable'),
+      llmRequested('llm-req', 'h1'),
+      llmResponded('llm-resp', 'h1'),
+    ]
+    const groups = buildExecutionProjection(events).steps[0]!.regionGroups!
+    // immutable → session-stable → turn-stable → volatile; turn-stable absent → omitted
+    expect(groups.map(g => g.stability)).toEqual(['immutable', 'session-stable', 'volatile'])
+    expect(groups[0]!.regions.map(r => r.id)).toEqual(['header'])
+  })
+
+  it('emits tool steps with ok / error / pending status, in event order', () => {
+    const events: Event[] = [
+      toolRequested('t1', 'ha', 'search', { q: 'x' }),
+      toolResponded('t1r', 'ha', 'search', { output: { hits: 3 } }),
+      toolRequested('t2', 'hb', 'fetch'),
+      toolResponded('t2r', 'hb', 'fetch', { error: { message: 'boom' } }),
+      toolRequested('t3', 'hc', 'slow'),  // no response → pending
+    ]
+    const steps = buildExecutionProjection(events).steps
+    expect(steps.map(s => s.kind)).toEqual(['tool', 'tool', 'tool'])
+    expect(steps.map(s => s.tool?.status)).toEqual(['ok', 'error', 'pending'])
+    expect(steps[0]!.tool).toMatchObject({ name: 'search', input: { q: 'x' }, output: { hits: 3 } })
+    expect(steps[0]!.label).toBe('Tool · search')
+    expect(steps[1]!.tool?.error).toMatchObject({ message: 'boom' })
+  })
+
+  it('preserves event order across interleaved llm and tool steps', () => {
+    const events: Event[] = [
+      llmRequested('q1', 'h1'),
+      llmResponded('r1', 'h1'),
+      toolRequested('t1', 'ha', 'search'),
+      toolResponded('t1r', 'ha', 'search', { output: {} }),
+      llmRequested('q2', 'h2'),
+      llmResponded('r2', 'h2'),
+    ]
+    expect(buildExecutionProjection(events).steps.map(s => s.kind)).toEqual(['llm', 'tool', 'llm'])
+  })
+
+  it('fills region content from the regionContent map by contentHash, degrading when absent', () => {
+    const events: Event[] = [
+      regionAdded('header', 'immutable', 'ch1'),
+      regionAdded('scratch', 'volatile'),  // no contentHash → no content
+      llmRequested('q', 'h1'),
+      llmResponded('r', 'h1'),
+    ]
+    const proj = buildExecutionProjection(events, { regionContent: new Map([['ch1', 'SYSTEM PROMPT TEXT']]) })
+    const regions = proj.steps[0]!.regionGroups!.flatMap(g => g.regions)
+    expect(regions.find(r => r.id === 'header')!.content).toBe('SYSTEM PROMPT TEXT')
+    expect(regions.find(r => r.id === 'scratch')!.content).toBeUndefined()
+  })
+
+  it('carries message count, prompt, and response on the llm step', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'yo' }] },
+    ]
+    const events: Event[] = [
+      { id: 'q', runId: 'r', type: 'llm.requested', actor: 'a', timestamp: 1,
+        payload: { request: { model: 'm', system: 'SYS', messages, tools: [{ name: 'search' }] }, requestHash: 'h1' } },
+      { id: 'resp', runId: 'r', type: 'llm.responded', actor: 'a', timestamp: 2, causedBy: 'h1',
+        payload: { response: { content: [{ type: 'text', text: 'hello' }], toolCalls: [], finishReason: 'end_turn' }, requestHash: 'h1' } },
+    ]
+    const step = buildExecutionProjection(events).steps[0]!
+    expect(step.messageCount).toBe(2)
+    expect(step.prompt).toMatchObject({ system: 'SYS', messages, tools: [{ name: 'search' }] })
+    expect(step.response).toMatchObject({ content: [{ type: 'text', text: 'hello' }] })
+  })
+})

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -204,6 +204,30 @@ export async function main(argv: string[]): Promise<MainResult> {
     })
 
   trace
+    .command('execution <runId>')
+    .description('Project <runId> into execution-timeline JSON (steps with cache health + region composition) to stdout')
+    .action(async (runId: string) => {
+      const milkieDir = findMilkieDir(process.cwd())
+      if (!milkieDir) {
+        throw new Error('no .milkie/ directory found upward from cwd')
+      }
+      const runsDir = path.join(milkieDir, 'runs')
+      const eventStore = new JsonlEventStore(runsDir)
+      const { buildExecutionProjection } = await import('../trace/diagnostics/buildExecutionProjection.js')
+
+      const events = await eventStore.readByRunId(runId)
+
+      const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
+      const regionContent = new Map<string, string>()
+      for (const h of regionReuseCounts(events).keys()) {
+        const c = await traceObjectStore.getCanonical(h)
+        if (c !== undefined) regionContent.set(h, c)
+      }
+
+      stdout.push(JSON.stringify(buildExecutionProjection(events, { regionContent })) + '\n')
+    })
+
+  trace
     .command('replay <runId>')
     .description('Replay a recorded run from .milkie/runs/<runId>.jsonl')
     .action(async (runId: string) => {

--- a/src/trace/diagnostics/buildExecutionProjection.ts
+++ b/src/trace/diagnostics/buildExecutionProjection.ts
@@ -1,0 +1,135 @@
+import type { Event, LlmRequestedPayload, LlmRespondedPayload, ToolRequestedPayload, ToolRespondedPayload } from '../types.js'
+import { contextRefsAt, type RegionContentRef } from '../RegionContextView.js'
+
+export interface CacheHealth {
+  tier:             'hot' | 'warm' | 'cold'
+  readTokens:       number
+  creationTokens:   number
+  totalInputTokens: number
+  hitRate:          number
+}
+
+export interface RegionGroup {
+  stability: string
+  regions:   RegionContentRef[]
+}
+
+export interface ToolStep {
+  name:    string
+  input?:  unknown
+  output?: unknown
+  error?:  unknown
+  status:  'ok' | 'error' | 'pending'
+}
+
+export interface ExecutionStep {
+  kind:          'llm' | 'tool'
+  label:         string
+  messageCount?: number
+  cacheHealth?:  CacheHealth | null
+  regionGroups?: RegionGroup[]
+  prompt?:       { system?: unknown; messages: unknown[]; tools: unknown[] } | null
+  response?:     unknown
+  tool?:         ToolStep
+}
+
+export interface ExecutionProjection {
+  steps: ExecutionStep[]
+}
+
+// Canonical prompt-assembly order: most stable on top, volatile scratch last.
+// Lifted from the frontend's STABILITY_ORDER so the projection owns the rule.
+const STABILITY_ORDER = ['immutable', 'session-stable', 'turn-stable', 'volatile'] as const
+
+function groupRegionsByStability(refs: RegionContentRef[]): RegionGroup[] {
+  const groups: RegionGroup[] = []
+  for (const stability of STABILITY_ORDER) {
+    const regions = refs.filter(r => r.stability === stability)
+    if (regions.length > 0) groups.push({ stability, regions })
+  }
+  return groups
+}
+
+/**
+ * Cache-health tiering — lifted verbatim from the agent-docs-qa frontend's
+ * classifyCacheTier so the projection owns the rule, not the UI.
+ *   hot  — read-dominated (hit ≥ 0.7)
+ *   warm — some reuse OR a fresh cache entry was written (substrate engaged)
+ *   cold — cache ran but neither read nor wrote
+ */
+function classifyCacheTier(c: { hitRate?: number; creationTokens?: number }): CacheHealth['tier'] {
+  const hit = c.hitRate ?? 0
+  const created = c.creationTokens ?? 0
+  if (hit >= 0.7) return 'hot'
+  if (hit >= 0.3 || created > 0) return 'warm'
+  return 'cold'
+}
+
+/**
+ * Pure event-log projection of a run's execution timeline: one step per
+ * llm.requested / tool.requested, carrying the cache-health tier and (later)
+ * region composition the frontend used to recompute itself. No I/O.
+ */
+export function buildExecutionProjection(
+  events: Event[],
+  opts: { regionContent?: Map<string, string> } = {},
+): ExecutionProjection {
+  const regionContent = opts.regionContent
+  const llmResponses = new Map<string, Event>()
+  const toolResponses = new Map<string, Event>()
+  for (const e of events) {
+    if (e.type === 'llm.responded') {
+      const p = e.payload as LlmRespondedPayload
+      if (p.requestHash) llmResponses.set(p.requestHash, e)
+    } else if (e.type === 'tool.responded') {
+      const p = e.payload as ToolRespondedPayload
+      if (p.requestHash) toolResponses.set(p.requestHash, e)
+    }
+  }
+
+  const steps: ExecutionStep[] = []
+  for (const e of events) {
+    if (e.type === 'llm.requested') {
+      const p = e.payload as LlmRequestedPayload
+      const resp = p.requestHash ? llmResponses.get(p.requestHash) : undefined
+      const cacheStats = resp && (resp.payload as LlmRespondedPayload).cacheStats
+      const refs = Array.from(contextRefsAt(events, e.id, 'at').values()).map(r =>
+        r.contentHash && regionContent?.has(r.contentHash)
+          ? { ...r, content: regionContent.get(r.contentHash) }
+          : r,
+      )
+      const req = (p.request ?? {}) as { system?: unknown; messages?: unknown[]; tools?: unknown[] }
+      const messages = Array.isArray(req.messages) ? req.messages : []
+      steps.push({
+        kind:         'llm',
+        label:        'LLM call',
+        messageCount: messages.length,
+        cacheHealth:  cacheStats
+          ? { tier: classifyCacheTier(cacheStats), ...cacheStats }
+          : null,
+        regionGroups: groupRegionsByStability(refs),
+        prompt:       { ...(req.system !== undefined ? { system: req.system } : {}), messages, tools: Array.isArray(req.tools) ? req.tools : [] },
+        response:     (resp?.payload as LlmRespondedPayload | undefined)?.response,
+      })
+    } else if (e.type === 'tool.requested') {
+      const p = e.payload as ToolRequestedPayload
+      const resp = p.requestHash ? toolResponses.get(p.requestHash) : undefined
+      const respPayload = resp?.payload as ToolRespondedPayload | undefined
+      const status: ToolStep['status'] = !respPayload
+        ? 'pending'
+        : respPayload.error !== undefined ? 'error' : 'ok'
+      steps.push({
+        kind:  'tool',
+        label: `Tool · ${p.toolName}`,
+        tool:  {
+          name:   p.toolName,
+          input:  p.input,
+          ...(respPayload?.output !== undefined ? { output: respPayload.output } : {}),
+          ...(respPayload?.error  !== undefined ? { error:  respPayload.error  } : {}),
+          status,
+        },
+      })
+    }
+  }
+  return { steps }
+}


### PR DESCRIPTION
## 背景

`examples/agent-docs-qa` audit panel 的 `Execution`(原 Steps)tab 在**前端**自己解析事件重写归因——walk `region.added/removed` 维护 `activeRegions`、按 `requestHash` 配对、`classifyCacheTier` 分级、`STABILITY_ORDER` 分组——违反 ARCHITECTURE.md invariant 12/13「UI = projection over CLI/SDK,前端不自带归因逻辑」。#68(PR #69)刻意把这块重构拆成独立 follow-up,本 PR 收口。

## 方案(路 A:核心出 JSON,前端纯渲染)

- **核心纯投影** `src/trace/diagnostics/buildExecutionProjection.ts`:每个 `llm.requested`/`tool.requested` 一个 step,携带 cache health 分级(hot/warm/cold,逻辑原样搬自前端 `classifyCacheTier`)、region 按 stability 分组(复用 `contextRefsAt` + `STABILITY_ORDER`)、tool 配对(ok/error/pending)、region 内容预览(按 `contentHash` 从 objectStore 灌入,用 #26 内容寻址**泛化**了前端原来只对 current-turn 的临时特例)。与 `buildDecisionSpine`/`explainLlmCall` 同风格,纯函数、只读 events。
- **CLI 入口(invariant 13)**:`milkie trace execution <runId>` → 投影 JSON 到 stdout。
- **Server endpoint**:`GET /run/:runId/execution` → 投影 JSON(平行 #68 viewer endpoint,同样 hydrate regionContent)。
- **前端** `renderStepsTab` 改为 fetch endpoint + 纯渲染;删除 `classifyCacheTier`/`STABILITY_ORDER`/`activeRegions`/`countMessages`。

**为什么新增独立投影函数而非搭车 renderViewer**:Execution 是改造现有 tab(与 panel 视觉/交互一体),JSON+前端渲染能保留现有 UX 外壳同时把归因搬走;#68 的 HTML/iframe 整块塞那套适合 Why tab 那种独立新视图。详见 spec。

## 测试(TDD,逐个 watched RED→GREEN)

- **核心** 9 个单测:cache 三档分级 + null、region 按 stability 分组与顺序(空组省略)、tool 三态、事件顺序、region content 填充与降级、messageCount/prompt/response。
- **CLI**:`trace execution <runId>` 输出 JSON 结构。
- **server**:`GET /run/:id/execution` 200 + 结构;未知 runId → 404。
- **回归守护**:断言 `index.html` 不含 `classifyCacheTier`/`STABILITY_ORDER`/`activeRegions`(防前端归因复活)。
- **浏览器端到端(dev-browser)**:真实浏览器发问 → 打开 audit panel → 切 Execution tab,断言 steps 渲染、region 按 stability 分组(immutable·1 → session-stable·4 → turn-stable·1 → volatile·1)+ 内容预览,数据全部来自核心投影。

验证:`tsc --noEmit` 干净;`src/__tests__` + 示例套件 **52 suites / 445 tests** 全绿。

## 改动文件

- `src/trace/diagnostics/buildExecutionProjection.ts`(新增)+ `src/__tests__/buildExecutionProjection.test.ts`
- `src/cli/main.ts` — `trace execution` 子命令 + `src/__tests__/CliTraceExecution.test.ts`
- `examples/agent-docs-qa/server.ts` — `/run/:runId/execution` endpoint
- `examples/agent-docs-qa/public/index.html` — `renderStepsTab` 改纯渲染
- `examples/agent-docs-qa/__tests__/server.test.ts` — endpoint + 回归守护
- `roadmap.md`、`docs/superpowers/specs/2026-05-31-execution-tab-projection-design.md`

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)