### PR TITLE
fix(#60): disambiguate tool.emitted by (toolCallId, occurrence)

### DIFF
--- a/src/__tests__/Replay.test.ts
+++ b/src/__tests__/Replay.test.ts
@@ -511,6 +511,52 @@ describe('Milkie.replay', () => {
     expect(replayGateway.callCount).toBe(0)  // cache served everything; no live LLM
   })
 
+  it('replays two emit-driven steps that REUSE a toolCallId across FSM states (#60 dup-id)', async () => {
+    // Providers only guarantee tool_call ids are unique within ONE response, not
+    // across a run. Two states here each emit via a tool call that reuses id
+    // 'tc-1'. Keying recorded emits by toolCallId alone collapses both into one
+    // map entry → replay injects the wrong (second) event at the first call.
+    const toolA: ToolDefinition = {
+      name: 'tool_a', description: 'a', inputSchema: { type: 'object', properties: {} },
+      handler: async (_i, ctx) => { ctx.emit('A_DONE'); return {} },
+    }
+    const toolB: ToolDefinition = {
+      name: 'tool_b', description: 'b', inputSchema: { type: 'object', properties: {} },
+      handler: async (_i, ctx) => { ctx.emit('B_DONE'); return {} },
+    }
+    const config: AgentConfig = {
+      agentId: 'dup-id-agent', version: '0.0.0', systemPrompt: 'sys',
+      fsm: { states: [
+        { name: 's0', type: 'llm', tools: ['tool_a'], on: { A_DONE: 's1' } },
+        { name: 's1', type: 'llm', tools: ['tool_b'], on: { B_DONE: 'end' } },
+        { name: 'end', type: 'action', terminal: true },
+      ] },
+      model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+    }
+    const store = new MemoryEventStore()
+    const recordMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([
+        toolCallResponse('tc-1', 'tool_a', {}),  // s0 — id tc-1
+        toolCallResponse('tc-1', 'tool_b', {}),  // s1 — SAME id tc-1
+      ]),
+      eventStore: store, tools: [toolA, toolB],
+    })
+    recordMilkie.registerAgent(config)
+    const original = await recordMilkie.invoke({ agentId: 'dup-id-agent', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')  // sanity: record completes fine
+
+    const replayMilkie = new Milkie({
+      stateStore: new MemoryStore(),
+      gateway: new SequentialGateway([]), eventStore: store, tools: [toolA, toolB],
+    })
+    replayMilkie.registerAgent(config)
+
+    const replayed = await replayMilkie.replay(original.agentRunId)
+    expect(replayed.status).toBe('completed')
+    expect(replayed.output).toBe(original.output)
+  })
+
   it('records the emit with its guard and replays without divergence (#60)', async () => {
     const guard = { guardId: 'intent', result: 'INTENT_DONE', contextSlice: { confidence: 0.9 } }
     const tool = classifyIntentTool(ctx => ctx.emit('INTENT_DONE', { slot: 'x' }, guard as never))
@@ -530,6 +576,7 @@ describe('Milkie.replay', () => {
     expect(emitted).toHaveLength(1)
     expect(emitted[0]!.payload).toEqual({
       toolCallId: 'tc-1',
+      occurrence: 0,
       event: { name: 'INTENT_DONE', payload: { slot: 'x' }, guard: [guard] },
     })
 

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -101,6 +101,9 @@ export class AgentRuntime {
   private readonly traceObjectStore?: ITraceObjectStore
   private readonly replayWmSnapshots?: unknown[]  // SPIKE(#73)
   private readonly replayEmits?: Map<string, { name: string; payload?: unknown; guard?: GuardEvaluation[] }>  // #60
+  /** #60: per-run count of successful calls per toolCallId, to disambiguate a
+   *  tool_call id reused across responses when keying tool.emitted record/replay. */
+  private readonly toolEmitOccurrence = new Map<string, number>()
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly makeChildPort?: MakeChildPort
@@ -1172,10 +1175,19 @@ export class AgentRuntime {
         }
         // #60: event-source the tool's emit side-effect (FSM transition) the same
         // way. On replay the handler didn't run, so re-emit the recorded business
-        // event (keyed by toolCallId) before runLLMState calls processPendingEvent.
-        // In record mode, append tool.emitted iff this call won the pendingEvent slot.
+        // event before runLLMState calls processPendingEvent. In record mode,
+        // append tool.emitted iff this call won the pendingEvent slot.
+        //
+        // Key by (toolCallId, occurrence): providers only guarantee tool_call ids
+        // are unique within ONE response, not across a run — the same id can recur
+        // in a later FSM state. occurrence = how many times this id has been seen
+        // in this run (incremented per successful call, identically in record and
+        // replay), so duplicate ids never collapse or cross-inject. The counter
+        // ticks for EVERY call (even non-emitting ones) so the two sides stay aligned.
+        const occurrence = this.toolEmitOccurrence.get(call.id) ?? 0
+        this.toolEmitOccurrence.set(call.id, occurrence + 1)
         if (this.replayEmits) {
-          const emitted = this.replayEmits.get(call.id)
+          const emitted = this.replayEmits.get(`${call.id}#${occurrence}`)
           if (emitted) this.fsm.emitEvent(emitted.name, emitted.payload, emitted.guard)
         } else if (this.eventStore && capturedEmit) {
           await this.eventStore.append({
@@ -1184,7 +1196,7 @@ export class AgentRuntime {
             type:      'tool.emitted',
             actor:     this.config.agentId,
             timestamp: Date.now(),
-            payload:   { toolCallId: call.id, event: capturedEmit } satisfies ToolEmittedPayload,
+            payload:   { toolCallId: call.id, occurrence, event: capturedEmit } satisfies ToolEmittedPayload,
           })
         }
         const duration = this.ioPort.now() - start

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -449,13 +449,15 @@ export class Milkie {
       replayWmSnapshots: events
         .filter(e => e.type === 'wm.mutated')
         .map(e => (e.payload as { snapshot: unknown }).snapshot),
-      // #60: recorded emit-driven FSM events keyed by toolCallId → replay re-emits
-      // them so emit-driven transitions reproduce without re-running tool handlers.
+      // #60: recorded emit-driven FSM events keyed by (toolCallId, occurrence) →
+      // replay re-emits them so emit-driven transitions reproduce without re-running
+      // tool handlers. The occurrence suffix keeps a tool_call id reused across
+      // responses from collapsing in the map (provider ids are only unique per response).
       replayEmits: new Map(events
         .filter(e => e.type === 'tool.emitted')
         .map(e => {
           const p = e.payload as ToolEmittedPayload
-          return [p.toolCallId, p.event] as const
+          return [`${p.toolCallId}#${p.occurrence ?? 0}`, p.event] as const
         })),
     })
 

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -206,11 +206,14 @@ export interface GuardEvaluation {
  * replay can reproduce the emit-driven transition without re-running the
  * handler (ReplayingIOPort serves cached tool output and never runs the thunk).
  * Recorded once per tool call that WON the FSM's single pendingEvent slot
- * (first-emit-wins); keyed by toolCallId, which comes from the cached LLM
- * output and is therefore stable across replay.
+ * (first-emit-wins); keyed by (toolCallId, occurrence). toolCallId comes from
+ * the cached LLM output so it is stable across replay, but provider ids are only
+ * unique within ONE response — `occurrence` disambiguates a reused id across the run.
  */
 export interface ToolEmittedPayload {
   toolCallId: string
+  /** 0-based count of how many times toolCallId was seen in this run before this call. */
+  occurrence: number
   event: {
     name:     string
     payload?: unknown


### PR DESCRIPTION
后续修复 #60(PR #76 已合并)。审阅时发现一个 replay 确定性缺陷。

## 缺陷

`Milkie.replay` 把录制的 `tool.emitted` 按 `toolCallId` 单值装进 `Map<toolCallId, event>`。provider 只保证 tool_call id 在**单次响应内**唯一,不保证整个 run 全局唯一——同一个 id 可能在后续 FSM 状态再次出现。此时两条 `tool.emitted` 的 key 相同,后者覆盖前者:

- record 正常完成;
- replay 在第一次工具回放(本应注入事件 A)拿到的是被覆盖后的事件 B → FSM 不转移 → 多发未缓存 LLM → `ReplayDivergenceError(llm)`。

## 修复

按 `(toolCallId, occurrence)` 消歧:

- `ToolEmittedPayload` 增加 `occurrence`(该 id 在本 run 内第几次出现,0-based)。
- record/replay 都按 `\`${toolCallId}#${occurrence}\`` 作键;计数器对**每次成功调用**递增(两侧同步),故重复 id 不再覆盖。
- **per-id** 计数:不受并行 batch 内顺序影响(同一 id 一个 batch 内至多出现一次),也覆盖"同 id 多次出现、仅部分 emit"的情况(非 emit 的那次 lookup 落空、不注入)。
- 不选全局 ordinal:并行下 record/replay 完成顺序可能不同会错配;per-id occurrence 不会。

## 测试

新增复现用例 `Replay.test.ts` 的 `#60 dup-id`(两个 FSM 状态各 emit、复用 id `tc-1`):修复前 RED(`ReplayDivergenceError(llm)`)、修复后 GREEN。`Replay.test.ts` 全套 17、`src/__tests__` 388、s-011 确定性 e2e 全绿;`tsc` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)