### PR TITLE
feat(#88): 答案错因诊断 — 专职 diagnoser agent over Trace 投影(PoC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.log*
 yarn.lock
 pnpm-lock.yaml
 bun.lockb
+
+# git worktrees (isolated workspaces)
+.worktrees/

--- a/docs/superpowers/plans/2026-06-01-diagnoser-agent.md
+++ b/docs/superpowers/plans/2026-06-01-diagnoser-agent.md
@@ -1,0 +1,393 @@
+# diagnoser agent 实现计划(#88)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `examples/agent-docs-qa` 内做一个专职 `diagnoser` agent,读被诊断 run 的 Trace 投影,沿「问题→工具query→证据→答案」定位第一个相关性断点。
+
+**Architecture:** 确定性的读-Trace 工具(包装核心 `buildExecutionProjection`,可纯单测)+ 一个 LLM diagnoser agent(方法论写在 systemPrompt,输出约定 JSON 契约)。PoC 借住 example,归宿见 #89。
+
+**Tech Stack:** TypeScript、jest、milkie SDK(`Milkie` / `ToolDefinition` / `MemoryEventStore` / `MemoryTraceObjectStore` / `buildExecutionProjection`)。
+
+**测试策略(关键)**:读-Trace 工具是确定性的 → 严格 TDD。diagnoser 的**判断质量**依赖真实 LLM,stub 下只能验"管道通 + 输出契约成立",判断质量归 live e2e(手动,不进 CI)。
+
+---
+
+### Task 1: 读-Trace 工具骨架 + `get_run_io`
+
+**Files:**
+- Create: `examples/agent-docs-qa/tools/trace-tools.ts`
+- Test: `examples/agent-docs-qa/__tests__/trace-tools.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```typescript
+// examples/agent-docs-qa/__tests__/trace-tools.test.ts
+import { makeTraceTools } from '../tools/trace-tools'
+import { MemoryEventStore } from '../../../src/trace/MemoryEventStore'
+import { MemoryTraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import type { ToolContext } from '../../../src/types/tool'
+
+const CTX = {} as ToolContext  // 这些工具不使用 ctx
+
+async function seedRun(store: MemoryEventStore, runId: string) {
+  await store.append({ id: 's', runId, type: 'agent.run.started', actor: 'a', timestamp: 1,
+    payload: { agentId: 'x', goal: 'g', input: '曹操爸爸是谁', contextId: runId } })
+  await store.append({ id: 'c', runId, type: 'agent.run.completed', actor: 'a', timestamp: 9,
+    payload: { status: 'completed', lastTextOutput: '赤壁之战发生在公元208年。' } })
+}
+
+describe('makeTraceTools: get_run_io', () => {
+  it('returns the user question and final answer of a run', async () => {
+    const store = new MemoryEventStore()
+    await seedRun(store, 'target-1')
+    const tools = makeTraceTools(store, new MemoryTraceObjectStore())
+    const getRunIo = tools.find(t => t.name === 'get_run_io')!
+    const out = await getRunIo.handler({ runId: 'target-1' }, CTX)
+    expect(out).toEqual({ question: '曹操爸爸是谁', finalAnswer: '赤壁之战发生在公元208年。' })
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试,确认失败**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/trace-tools.test.ts`
+Expected: FAIL — `Cannot find module '../tools/trace-tools'`.
+
+- [ ] **Step 3: 写最小实现**
+
+```typescript
+// examples/agent-docs-qa/tools/trace-tools.ts
+import type { IEventStore } from '../../../src/trace/EventStore'
+import type { ITraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import type { ToolDefinition } from '../../../src/types/tool'
+import type { AgentRunStartedPayload, AgentRunCompletedPayload } from '../../../src/trace/types'
+
+/**
+ * Read-Trace tools for the diagnoser agent: deterministic projections over a
+ * recorded run's event log. Wrap core projections; never parse raw events in
+ * the agent. `runId` is the run being DIAGNOSED (distinct from the diagnoser's
+ * own run).
+ */
+export function makeTraceTools(
+  eventStore: IEventStore,
+  _objectStore: ITraceObjectStore,
+): ToolDefinition[] {
+  const get_run_io: ToolDefinition = {
+    name: 'get_run_io',
+    description: '取被诊断 run 的用户问题与最终答案。入参 { runId }。',
+    inputSchema: { type: 'object', properties: { runId: { type: 'string' } }, required: ['runId'] },
+    handler: async (input) => {
+      const { runId } = input as { runId: string }
+      const events = await eventStore.readByRunId(runId)
+      let question = ''
+      let finalAnswer = ''
+      for (const e of events) {
+        if (e.type === 'agent.run.started') question = String((e.payload as AgentRunStartedPayload).input ?? '')
+        if (e.type === 'agent.run.completed') finalAnswer = String((e.payload as AgentRunCompletedPayload).lastTextOutput ?? '')
+      }
+      return { question, finalAnswer }
+    },
+  }
+
+  return [get_run_io]
+}
+```
+
+- [ ] **Step 4: 跑测试,确认通过**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/trace-tools.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add examples/agent-docs-qa/tools/trace-tools.ts examples/agent-docs-qa/__tests__/trace-tools.test.ts
+git commit -m "feat(#88): get_run_io read-Trace tool"
+```
+
+---
+
+### Task 2: `get_execution` 工具(包装 buildExecutionProjection)
+
+**Files:**
+- Modify: `examples/agent-docs-qa/tools/trace-tools.ts`
+- Test: `examples/agent-docs-qa/__tests__/trace-tools.test.ts`
+
+- [ ] **Step 1: 写失败测试**(追加到 trace-tools.test.ts)
+
+```typescript
+describe('makeTraceTools: get_execution', () => {
+  it('returns the execution projection (steps with tool query) of a run', async () => {
+    const store = new MemoryEventStore()
+    const runId = 'target-2'
+    await store.append({ id: 's', runId, type: 'agent.run.started', actor: 'a', timestamp: 1,
+      payload: { agentId: 'x', goal: 'g', input: '曹操爸爸是谁', contextId: runId } })
+    await store.append({ id: 'lq', runId, type: 'llm.requested', actor: 'a', timestamp: 2,
+      payload: { request: { model: 'm', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }, requestHash: 'h1' } })
+    await store.append({ id: 'lr', runId, type: 'llm.responded', actor: 'a', timestamp: 3, causedBy: 'lq',
+      payload: { response: { content: [], toolCalls: [], finishReason: 'tool_use' }, requestHash: 'h1' } })
+    await store.append({ id: 'tq', runId, type: 'tool.requested', actor: 'a', timestamp: 4,
+      payload: { toolName: 'grep', input: { pattern: '赤壁' }, requestHash: 'h2' } })
+    await store.append({ id: 'tr', runId, type: 'tool.responded', actor: 'a', timestamp: 5, causedBy: 'tq',
+      payload: { toolName: 'grep', output: { matches: [] }, requestHash: 'h2' } })
+
+    const tools = makeTraceTools(store, new MemoryTraceObjectStore())
+    const getExec = tools.find(t => t.name === 'get_execution')!
+    const proj = await getExec.handler({ runId }, CTX) as { steps: Array<{ kind: string; tool?: { name: string; input: unknown } }> }
+    const toolStep = proj.steps.find(s => s.kind === 'tool')
+    expect(toolStep?.tool).toMatchObject({ name: 'grep', input: { pattern: '赤壁' } })
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试,确认失败**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/trace-tools.test.ts -t get_execution`
+Expected: FAIL — `getExec` is undefined (`get_execution` not in the tool list).
+
+- [ ] **Step 3: 写最小实现**(在 trace-tools.ts 顶部加 import,新增工具并加入返回数组)
+
+```typescript
+// 顶部 imports 追加:
+import { regionReuseCounts } from '../../../src/trace/RegionContextView'
+import { buildExecutionProjection } from '../../../src/trace/diagnostics/buildExecutionProjection'
+```
+
+```typescript
+// 在 get_run_io 之后、return 之前新增:
+const get_execution: ToolDefinition = {
+  name: 'get_execution',
+  description: '取被诊断 run 的执行投影:步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。入参 { runId }。',
+  inputSchema: { type: 'object', properties: { runId: { type: 'string' } }, required: ['runId'] },
+  handler: async (input) => {
+    const { runId } = input as { runId: string }
+    const events = await eventStore.readByRunId(runId)
+    // Hydrate region content the same way `trace report` / #70 endpoint does.
+    const regionContent = new Map<string, string>()
+    for (const h of regionReuseCounts(events).keys()) {
+      const c = await _objectStore.getCanonical(h)
+      if (c !== undefined) regionContent.set(h, c)
+    }
+    return buildExecutionProjection(events, { regionContent })
+  },
+}
+```
+
+```typescript
+// 把 return 改成:
+return [get_run_io, get_execution]
+```
+
+(注:`_objectStore` 现在被使用,可把参数名从 `_objectStore` 改为 `objectStore`。)
+
+- [ ] **Step 4: 跑测试,确认全部通过**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/trace-tools.test.ts`
+Expected: PASS（get_run_io + get_execution 两组）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add examples/agent-docs-qa/tools/trace-tools.ts examples/agent-docs-qa/__tests__/trace-tools.test.ts
+git commit -m "feat(#88): get_execution read-Trace tool wrapping buildExecutionProjection"
+```
+
+---
+
+### Task 3: diagnoser agent 定义
+
+**Files:**
+- Create: `examples/agent-docs-qa/agents/diagnoser.md`
+
+- [ ] **Step 1: 写 agent 定义**(prompt 工程,无单测;由 Task 4 的管道测覆盖)
+
+```markdown
+---
+agentId: diagnoser
+version: 0.0.1
+fsm:
+  states:
+    - name: diagnose
+      type: llm
+      instructions: |
+        你是一个诊断 agent。你的输入是一个被诊断 run 的 runId（一个字符串 id）。
+        你的任务:判断那次 run 的最终答案是否答到了用户的问题上;若没有,沿
+        「用户问题 → 工具 query → 命中证据 → 最终答案」定位第一个与问题失配的步骤。
+
+        步骤:
+        1. 调 get_run_io({ runId }) 拿到用户问题(question)和最终答案(finalAnswer)。
+        2. 调 get_execution({ runId }) 拿到执行链(steps:每步 LLM/工具调用、工具的
+           query、命中证据、region 组成)。
+        3. 逐跳评估相关性:每个工具 query 是否针对 question?命中证据是否相关?最终
+           答案是否回答了 question?
+        4. 找出第一个与问题失配的跳(firstBreak)。
+
+        最后**只输出一段 JSON**(不要任何额外文字、不要 markdown 代码围栏):
+        {
+          "verdict": "ok" | "suspect",
+          "firstBreak": { "step": "<eventId 或步序>", "what": "<这一步做了什么>", "why": "<为什么与问题失配>" } | null,
+          "explanation": "<简短中文解释>"
+        }
+        verdict=ok 时 firstBreak 为 null。严格只输出 JSON。
+      tools: [get_run_io, get_execution]
+model:
+  provider: volcengine
+  model: doubao-seed-2-0-pro-260215
+  adapter: openai-compatible
+---
+诊断 agent:读被诊断 run 的 Trace 投影,定位答案与问题之间的相关性断点。
+```
+
+- [ ] **Step 2: 提交**
+
+```bash
+git add examples/agent-docs-qa/agents/diagnoser.md
+git commit -m "feat(#88): diagnoser agent definition (methodology + JSON output contract)"
+```
+
+---
+
+### Task 4: server 接入 + stub 管道/契约测
+
+**Files:**
+- Modify: `examples/agent-docs-qa/server.ts:281-284`
+- Test: `examples/agent-docs-qa/__tests__/server.test.ts`
+
+- [ ] **Step 1: 写失败测试**(追加到 server.test.ts 的 "server — REST endpoints" describe 之外,新 describe)
+
+```typescript
+describe('diagnoser agent (stub pipeline + output contract)', () => {
+  it('diagnoser reads the target run via tools and returns a JSON verdict', async () => {
+    const fs = require('fs'), os = require('os'), path = require('path')
+    const exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-docs-qa-diag-'))
+    fs.mkdirSync(path.join(exampleDir, '.milkie', 'runs'), { recursive: true })
+
+    // Stub: 1) diagnoser calls get_execution, 2) emits the JSON verdict.
+    const toolCall = (id: string, name: string, input: unknown) => ({
+      content: [{ type: 'tool_use', id, name, input }], toolCalls: [{ id, name, input }], finishReason: 'tool_use',
+    })
+    const text = (s: string) => ({ content: [{ type: 'text', text: s }], toolCalls: [], finishReason: 'end_turn' })
+
+    // First record a target run with sanguo-researcher (a normal chat).
+    let server = await startServer({
+      port: 0, exampleDir,
+      gateway: new StubGateway([text('赤壁之战发生在公元208年。')]),
+      agentFile: path.join(__dirname, '..', 'agents', 'sanguo-researcher.md'),
+      corpusRoot: path.join(__dirname, '..', 'corpus'),
+    })
+    let addr = server.address() as { port: number }
+    let baseUrl = `http://localhost:${addr.port}`
+    const chat = JSON.parse((await postJson(`${baseUrl}/chat`, { input: '曹操爸爸是谁' })).body) as { runId: string }
+    await stopServer(server)
+
+    // Now run the diagnoser against that runId via the SDK directly.
+    const { Milkie } = require('../../../src/runtime/Milkie')
+    const { JsonlEventStore } = require('../../../src/trace/JsonlEventStore')
+    const { FileTraceObjectStore } = require('../../../src/trace/TraceObjectStore')
+    const { makeTraceTools } = require('../tools/trace-tools')
+    const verdict = { verdict: 'suspect', firstBreak: { step: '2', what: 'grep 赤壁', why: '与问题(曹操爸爸)不相关' }, explanation: '工具查询跑偏' }
+    const milkie = new Milkie({
+      eventStore: new JsonlEventStore(path.join(exampleDir, '.milkie', 'runs')),
+      traceObjectStore: new FileTraceObjectStore(path.join(exampleDir, '.milkie', 'objects')),
+      gateway: new StubGateway([toolCall('d1', 'get_execution', { runId: chat.runId }), text(JSON.stringify(verdict))]),
+    })
+    for (const t of makeTraceTools((milkie as any).eventStore ?? new JsonlEventStore(path.join(exampleDir, '.milkie', 'runs')),
+                                   new FileTraceObjectStore(path.join(exampleDir, '.milkie', 'objects')))) {
+      milkie.registerTool(t)
+    }
+    milkie.loadAgentFile(path.join(__dirname, '..', 'agents', 'diagnoser.md'))
+
+    const result = await milkie.invoke({ agentId: 'diagnoser', goal: 'diagnose', input: chat.runId })
+    expect(result.status).toBe('completed')
+    const parsed = JSON.parse(result.output)
+    expect(parsed).toHaveProperty('verdict')
+    expect(parsed).toHaveProperty('firstBreak')
+    expect(parsed).toHaveProperty('explanation')
+
+    fs.rmSync(exampleDir, { recursive: true, force: true })
+  }, 15_000)
+})
+```
+
+- [ ] **Step 2: 跑测试,确认失败**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/server.test.ts -t "diagnoser agent"`
+Expected: FAIL — diagnoser agentId 未注册 / 工具未注册(取决于 stub 路径)。
+（若失败信息提示 `makeTraceTools` 的 eventStore 取值方式不稳,改为显式 `const es = new JsonlEventStore(path.join(exampleDir,'.milkie','runs'))` 复用同一实例。）
+
+- [ ] **Step 3: 让 server 默认也注册 trace 工具 + 加载 diagnoser**(生产路径,使 panel 集成 issue 后续可直接用)
+
+修改 `examples/agent-docs-qa/server.ts`,在 `for (const tool of makeCorpusToolDefinitions(...))` 之后追加:
+
+```typescript
+import { makeTraceTools } from './tools/trace-tools.js'   // 顶部 import 区追加
+
+// ...在 milkie.loadAgentFile(config.agentFile) 之前:
+for (const tool of makeTraceTools(eventStore, traceObjectStore)) {
+  milkie.registerTool(tool)
+}
+// 同目录的 diagnoser(若存在则加载,使其与领域 agent 并存)
+const diagnoserPath = path.join(path.dirname(config.agentFile), 'diagnoser.md')
+if (existsSync(diagnoserPath)) milkie.loadAgentFile(diagnoserPath)
+```
+
+- [ ] **Step 4: 跑测试,确认通过**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/server.test.ts -t "diagnoser agent"`
+Expected: PASS — diagnoser 跑通、output 可 `JSON.parse` 成契约(verdict/firstBreak/explanation)。
+
+- [ ] **Step 5: 跑整套 server 测,确认无回归**
+
+Run: `npx jest examples/agent-docs-qa/__tests__/server.test.ts`
+Expected: 全绿(现有 + 新增 diagnoser 用例)。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add examples/agent-docs-qa/server.ts examples/agent-docs-qa/__tests__/server.test.ts
+git commit -m "feat(#88): wire trace tools + diagnoser into server; stub pipeline/contract test"
+```
+
+---
+
+### Task 5: README 标注 + live e2e 说明
+
+**Files:**
+- Modify: `examples/agent-docs-qa/README.md`
+
+- [ ] **Step 1: 在 README 加一节**
+
+```markdown
+## diagnoser agent(#88,借住)
+
+`agents/diagnoser.md` 是一个**横切诊断 agent**(答案错因诊断):读被诊断 run 的 Trace
+投影(`tools/trace-tools.ts`),沿「问题→工具query→证据→答案」定位第一个相关性断点。
+
+- 它**借住**于本 example;归宿是 milkie 的内置/标准 agent 层(见 issue #89),不属于"三国问答"领域。
+- 编程入口:`milkie.invoke({ agentId: 'diagnoser', input: <被诊断的 runId> })`,输出为
+  JSON `{ verdict, firstBreak, explanation }`。
+- 确定性测试覆盖读-Trace 工具 + 管道/契约;**诊断判断质量**需真实 LLM,见下方 live 验证。
+
+### live 验证(手动,需 VOLCENGINE_TOKEN/API_BASE)
+
+启动 server,问一个会跑偏的问题(stub 或真实),拿到 runId 后:
+`milkie.invoke({ agentId: 'diagnoser', input: '<runId>' })` —— 人工核对 `firstBreak`
+是否指向真正跑偏的那一步(例:问"曹操爸爸"却 grep"赤壁")。
+```
+
+- [ ] **Step 2: 提交**
+
+```bash
+git add examples/agent-docs-qa/README.md
+git commit -m "docs(#88): README — diagnoser agent (borrowed; home #89) + live verification"
+```
+
+---
+
+## 完成标准
+
+- 读-Trace 工具(`get_run_io` / `get_execution`)有确定性单测,全绿。
+- diagnoser agent 经 stub 管道测:被 invoke、调工具拿到被诊断 run 投影、输出能 `JSON.parse` 成契约。
+- 整套 example 测试无回归。
+- README 标注借住 + 归宿 #89 + live 验证步骤。
+- (手动,非 CI)真实 doubao 对"曹操爸爸→grep赤壁"诊断,`firstBreak` 指向工具 query 跑偏。

--- a/docs/superpowers/specs/2026-06-01-diagnoser-agent-design.md
+++ b/docs/superpowers/specs/2026-06-01-diagnoser-agent-design.md
@@ -1,0 +1,81 @@
+# #88 答案错因诊断 — 专职 diagnoser agent over Trace 投影(实现 spec)
+
+**Issue:** #88(diagnosable;Parent #20);设计层定稿见 #88 正文,本 doc 补**实现约束 + 测试策略**。
+**日期:** 2026-06-01
+**分支:** `feat/88-diagnoser-agent`(基于 main)
+
+## 1. 目标(承 #88)
+
+现有诊断答"机制"(Why)与"源支撑"(Provenance),答不了"答案对不对 / 错在哪"。补一个**相关性链路断点**诊断:沿 `用户问题 → 工具 query → 命中证据 → 最终答案`,定位第一个与问题失配的跳。封装为**专职 diagnoser agent**(读 Trace 的旁观者),PoC 借住 `examples/agent-docs-qa`(归宿是 #89 的内置 agent 层,PoC 不阻塞于它)。
+
+## 2. 组件与实现约束
+
+```
+examples/agent-docs-qa/
+  agents/diagnoser.md       # diagnoser agent:方法论 systemPrompt + 声明 trace 工具
+  tools/trace-tools.ts      # makeTraceTools(eventStore, objectStore) → 读-Trace 工具集
+  server.ts                 # 多加载 diagnoser.md(再调一次 loadAgentFile)
+  README.md                 # 标注 diagnoser 借住、归宿 #89
+```
+
+### 2.1 读-Trace 工具(确定性,可纯 TDD)
+
+`makeTraceTools(eventStore, traceObjectStore)` 闭包返回(范式同 `makeCorpusTools`):
+- `get_run_io({ runId })` → `{ question, finalAnswer }`(从 `agent.run.started.input` + `agent.run.completed.lastTextOutput`)。
+- `get_execution({ runId })` → `ExecutionProjection`:`readByRunId(runId)` + hydrate regionContent(同 `trace report`/#70 endpoint 的方式)→ `buildExecutionProjection(events, { regionContent })`。给出步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。
+- (可选,后置)`explain_step({ runId, eventId })` → 单步决策因果。
+
+工具**只读、确定性**(包装核心投影,不解析原始事件)。这是诊断能力里**唯一能脱离 LLM 单测**的部分 —— 优先 TDD 它。
+
+### 2.2 diagnoser agent(`diagnoser.md`)
+
+- frontmatter 同 `sanguo-researcher.md`:`agentId: diagnoser`、单 llm state、`tools: [get_run_io, get_execution]`、model。
+- systemPrompt = **诊断方法论**:拿 `targetRunId` → 调工具取 问题/答案/执行链 → 逐跳评估 relevance → 报告第一个 break + 理由。
+- **输入** = `targetRunId`(`milkie.invoke('diagnoser', { input: targetRunId })`)。
+
+### 2.3 输出契约(靠 prompt 约定 + parse,非强 schema)
+
+milkie 无强结构化输出(只有 `responseFormat?` 透传)。故 systemPrompt **约定 diagnoser 的最终文本输出为 JSON**:
+```json
+{ "verdict": "ok" | "suspect",
+  "firstBreak": { "step": "<eventId 或步序>", "what": "...", "why": "..." } | null,
+  "explanation": "..." }
+```
+消费方 `JSON.parse`。PoC 接受"模型偶发不合格式"的脆性(prompt 里给严格格式要求 + 例子);强 schema enforcement 留后续(也可能推动核心加结构化输出能力)。
+
+### 2.4 server 多 agent 加载
+
+`server.ts:startServer` 现 `loadAgentFile(sanguo-researcher.md)` 单个 → 增加 `loadAgentFile(diagnoser.md)`(或遍历 `agents/`)。同一 milkie 实例两个 agent,靠 agentId 区分。
+
+## 3. 测试策略(关键:诚实区分两层)
+
+diagnoser 是 LLM agent,**测试分两层**:
+
+- **确定性层(本 PoC 必做,TDD)**:
+  - **读-Trace 工具单测**(纯函数级,易测):喂构造的 fixture run(events 数组),断言 `get_run_io` / `get_execution` 返回的投影正确(question/answer、步骤序列、工具 query、region 分组)。这是核心可确定性验证的部分。
+  - **管道 + 输出契约集成测(stub LLM)**:stub gateway 让 diagnoser 调一次工具、输出一段预设 JSON;断言 (a) 工具被调用、拿到 targetRun 投影,(b) 最终输出能 `JSON.parse` 成契约结构。**stub 只证"管道通 + 契约成立",不证"判断对错"。**
+- **真实 LLM 层(手动 / 可选 e2e,不进 CI 确定性套件)**:
+  - 用真实 doubao,对"曹操爸爸 → grep 赤壁"这条真实 run 跑 diagnoser,**人工验证** `firstBreak` 指向"工具 query 与问题不相关"。这一层才验证诊断**质量**,但非确定,归 live e2e。
+
+> 明确写下:stub 测不了诊断判断质量(那需要真实 LLM 推理)。PoC 的确定性保证落在"读-Trace 工具正确 + 管道通 + 输出契约成立";判断质量靠 live e2e 人工/抽样验证。
+
+## 4. 边界
+
+- 被诊断 run 与诊断 run 是**两个 runId**;diagnoser 自己跑也产生 Trace,别与被诊断 run 混。
+- 判断逻辑在核心之外(diagnoser 是 example agent + LLM),核心只提供确定性投影。
+- 不碰 event log 语义;读-Trace 工具只读。
+
+## 5. 非目标(承 #88)
+
+UI/panel 集成(endpoint + 按钮 + 渲染)、多轴诊断、grounding 复核(verifier 已有)、可注入 skill 形态、内置 agent 层机制(#89)。
+
+## 6. 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `examples/agent-docs-qa/tools/trace-tools.ts` | 新增 `makeTraceTools`(读-Trace 工具集) |
+| `examples/agent-docs-qa/agents/diagnoser.md` | 新增 diagnoser agent(方法论 + 工具声明) |
+| `examples/agent-docs-qa/server.ts` | 多加载 diagnoser.md |
+| `examples/agent-docs-qa/__tests__/` | 读-Trace 工具单测 + stub 管道/契约测 |
+| `examples/agent-docs-qa/README.md` | 标注 diagnoser 借住 / 归宿 #89 |
+| (可选)live e2e | 真实 doubao 诊断"曹操爸爸→grep赤壁",人工验证 |

--- a/examples/agent-docs-qa/README.md
+++ b/examples/agent-docs-qa/README.md
@@ -205,3 +205,19 @@ Full spec: **`docs/superpowers/specs/2026-05-25-context-region-substrate-design.
 - Spec: [Context Region Substrate](../../docs/superpowers/specs/2026-05-25-context-region-substrate-design.md)
   (the design that addresses the limitations listed above)
 - Architecture: [ARCHITECTURE.md](../../ARCHITECTURE.md) — "Reference UI projection"
+
+## diagnoser agent(#88,借住)
+
+`agents/diagnoser.md` 是一个**横切诊断 agent**(答案错因诊断):读被诊断 run 的 Trace
+投影(`tools/trace-tools.ts`),沿「问题→工具query→证据→答案」定位第一个相关性断点。
+
+- 它**借住**于本 example;归宿是 milkie 的内置/标准 agent 层(见 issue #89),不属于"三国问答"领域。
+- 编程入口:`milkie.invoke({ agentId: 'diagnoser', input: <被诊断的 runId> })`,输出为
+  JSON `{ verdict, firstBreak, explanation }`。
+- 确定性测试覆盖读-Trace 工具 + 管道/契约;**诊断判断质量**需真实 LLM,见下方 live 验证。
+
+### live 验证(手动,需 VOLCENGINE_TOKEN/API_BASE)
+
+启动 server,问一个会跑偏的问题(stub 或真实),拿到 runId 后:
+`milkie.invoke({ agentId: 'diagnoser', input: '<runId>' })` —— 人工核对 `firstBreak`
+是否指向真正跑偏的那一步(例:问"曹操爸爸"却 grep"赤壁")。

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -4,6 +4,10 @@ import type { IModelGateway, ModelRequest, ModelResponse } from '../../../src/ty
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { Milkie } from '../../../src/runtime/Milkie'
+import { JsonlEventStore } from '../../../src/trace/JsonlEventStore'
+import { FileTraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import { makeTraceTools } from '../tools/trace-tools'
 
 class StubGateway implements IModelGateway {
   constructor(private readonly responses: ModelResponse[]) {}
@@ -450,11 +454,6 @@ describe('e2e: skill loading through full chat flow', () => {
   }, 10_000)
 })
 
-import { Milkie } from '../../../src/runtime/Milkie'
-import { JsonlEventStore } from '../../../src/trace/JsonlEventStore'
-import { FileTraceObjectStore } from '../../../src/trace/TraceObjectStore'
-import { makeTraceTools } from '../tools/trace-tools'
-
 describe('diagnoser agent (stub pipeline + output contract)', () => {
   it('reads the target run via tools and returns a JSON verdict', async () => {
     const exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-docs-qa-diag-'))
@@ -503,6 +502,18 @@ describe('diagnoser agent (stub pipeline + output contract)', () => {
     expect(parsed).toHaveProperty('verdict')
     expect(parsed).toHaveProperty('firstBreak')
     expect(parsed).toHaveProperty('explanation')
+
+    // Non-hollow assertion: verify get_execution actually executed successfully
+    // and produced a real ExecutionProjection over the target run.
+    const diagEvents = await es.readByRunId(result.agentRunId)
+    const execResp = diagEvents.find(
+      e => e.type === 'tool.responded' && (e.payload as { toolName?: string }).toolName === 'get_execution'
+    )
+    expect(execResp).toBeDefined()                                                              // get_execution actually ran
+    const execPayload = execResp!.payload as { error?: unknown; output?: { steps?: unknown[] } }
+    expect(execPayload.error).toBeUndefined()                                                   // ran successfully, not swallowed error
+    expect(Array.isArray(execPayload.output?.steps)).toBe(true)                                 // produced a real ExecutionProjection
+    expect(execPayload.output!.steps!.length).toBeGreaterThan(0)                                // over the (non-empty) target run
 
     fs.rmSync(exampleDir, { recursive: true, force: true })
   }, 15_000)

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -455,10 +455,18 @@ describe('e2e: skill loading through full chat flow', () => {
 })
 
 describe('diagnoser agent (stub pipeline + output contract)', () => {
-  it('reads the target run via tools and returns a JSON verdict', async () => {
-    const exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-docs-qa-diag-'))
-    fs.mkdirSync(path.join(exampleDir, '.milkie', 'runs'), { recursive: true })
+  let exampleDir: string
 
+  beforeEach(() => {
+    exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-docs-qa-diag-'))
+    fs.mkdirSync(path.join(exampleDir, '.milkie', 'runs'), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(exampleDir, { recursive: true, force: true })
+  })
+
+  it('reads the target run via tools and returns a JSON verdict', async () => {
     const toolCall = (id: string, name: string, input: unknown) => ({
       content: [{ type: 'tool_use' as const, id, name, input }],
       toolCalls: [{ id, name, input }],
@@ -483,17 +491,18 @@ describe('diagnoser agent (stub pipeline + output contract)', () => {
     const runsDir = path.join(exampleDir, '.milkie', 'runs')
     const objsDir = path.join(exampleDir, '.milkie', 'objects')
     const es = new JsonlEventStore(runsDir)
-    const os2 = new FileTraceObjectStore(objsDir)
+    const traceObjStore = new FileTraceObjectStore(objsDir)
     const verdict = { verdict: 'suspect', firstBreak: { step: '2', what: 'grep 赤壁', why: '与问题(曹操爸爸)不相关' }, explanation: '工具查询跑偏' }
     const milkie = new Milkie({
       eventStore: es,
-      traceObjectStore: os2,
+      traceObjectStore: traceObjStore,
+      // Stub drives only get_execution (real execution); get_run_io is covered by trace-tools.test.ts.
       gateway: new StubGateway([
         toolCall('d1', 'get_execution', { runId: chat.runId }),
         text(JSON.stringify(verdict)),
       ]),
     })
-    for (const t of makeTraceTools(es, os2)) milkie.registerTool(t)
+    for (const t of makeTraceTools(es, traceObjStore)) milkie.registerTool(t)
     milkie.loadAgentFile(path.join(__dirname, '..', 'agents', 'diagnoser.md'))
 
     const result = await milkie.invoke({ agentId: 'diagnoser', goal: 'diagnose', input: chat.runId })
@@ -514,7 +523,5 @@ describe('diagnoser agent (stub pipeline + output contract)', () => {
     expect(execPayload.error).toBeUndefined()                                                   // ran successfully, not swallowed error
     expect(Array.isArray(execPayload.output?.steps)).toBe(true)                                 // produced a real ExecutionProjection
     expect(execPayload.output!.steps!.length).toBeGreaterThan(0)                                // over the (non-empty) target run
-
-    fs.rmSync(exampleDir, { recursive: true, force: true })
   }, 15_000)
 })

--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -449,3 +449,61 @@ describe('e2e: skill loading through full chat flow', () => {
     expect(systemText).not.toContain('你已进入 verifier 模式')
   }, 10_000)
 })
+
+import { Milkie } from '../../../src/runtime/Milkie'
+import { JsonlEventStore } from '../../../src/trace/JsonlEventStore'
+import { FileTraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import { makeTraceTools } from '../tools/trace-tools'
+
+describe('diagnoser agent (stub pipeline + output contract)', () => {
+  it('reads the target run via tools and returns a JSON verdict', async () => {
+    const exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-docs-qa-diag-'))
+    fs.mkdirSync(path.join(exampleDir, '.milkie', 'runs'), { recursive: true })
+
+    const toolCall = (id: string, name: string, input: unknown) => ({
+      content: [{ type: 'tool_use' as const, id, name, input }],
+      toolCalls: [{ id, name, input }],
+      finishReason: 'tool_use' as const,
+    })
+
+    // 1) Record a target run (a normal sanguo-researcher chat) that goes off-topic.
+    let server = await startServer({
+      port: 0, exampleDir,
+      gateway: new StubGateway([text('赤壁之战发生在公元208年。')]),
+      agentFile: path.join(__dirname, '..', 'agents', 'sanguo-researcher.md'),
+      corpusRoot: path.join(__dirname, '..', 'corpus'),
+    })
+    const addr = server.address() as { port: number }
+    const baseUrl = `http://localhost:${addr.port}`
+    const chat = JSON.parse((await postJson(`${baseUrl}/chat`, { input: '曹操爸爸是谁' })).body) as { runId: string }
+    await stopServer(server)
+
+    // 2) Run the diagnoser against that runId.
+    //    Share ONE explicit JsonlEventStore over the same runsDir so both the
+    //    trace tools and the diagnoser Milkie read the same recorded events.
+    const runsDir = path.join(exampleDir, '.milkie', 'runs')
+    const objsDir = path.join(exampleDir, '.milkie', 'objects')
+    const es = new JsonlEventStore(runsDir)
+    const os2 = new FileTraceObjectStore(objsDir)
+    const verdict = { verdict: 'suspect', firstBreak: { step: '2', what: 'grep 赤壁', why: '与问题(曹操爸爸)不相关' }, explanation: '工具查询跑偏' }
+    const milkie = new Milkie({
+      eventStore: es,
+      traceObjectStore: os2,
+      gateway: new StubGateway([
+        toolCall('d1', 'get_execution', { runId: chat.runId }),
+        text(JSON.stringify(verdict)),
+      ]),
+    })
+    for (const t of makeTraceTools(es, os2)) milkie.registerTool(t)
+    milkie.loadAgentFile(path.join(__dirname, '..', 'agents', 'diagnoser.md'))
+
+    const result = await milkie.invoke({ agentId: 'diagnoser', goal: 'diagnose', input: chat.runId })
+    expect(result.status).toBe('completed')
+    const parsed = JSON.parse(result.output)
+    expect(parsed).toHaveProperty('verdict')
+    expect(parsed).toHaveProperty('firstBreak')
+    expect(parsed).toHaveProperty('explanation')
+
+    fs.rmSync(exampleDir, { recursive: true, force: true })
+  }, 15_000)
+})

--- a/examples/agent-docs-qa/__tests__/trace-tools.test.ts
+++ b/examples/agent-docs-qa/__tests__/trace-tools.test.ts
@@ -1,0 +1,24 @@
+import { makeTraceTools } from '../tools/trace-tools'
+import { MemoryEventStore } from '../../../src/trace/MemoryEventStore'
+import { MemoryTraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import type { ToolContext } from '../../../src/types/tool'
+
+const CTX = {} as ToolContext  // these tools do not use ctx
+
+async function seedRun(store: MemoryEventStore, runId: string) {
+  await store.append({ id: 's', runId, type: 'agent.run.started', actor: 'a', timestamp: 1,
+    payload: { agentId: 'x', goal: 'g', input: '曹操爸爸是谁', contextId: runId } })
+  await store.append({ id: 'c', runId, type: 'agent.run.completed', actor: 'a', timestamp: 9,
+    payload: { status: 'completed', lastTextOutput: '赤壁之战发生在公元208年。' } })
+}
+
+describe('makeTraceTools: get_run_io', () => {
+  it('returns the user question and final answer of a run', async () => {
+    const store = new MemoryEventStore()
+    await seedRun(store, 'target-1')
+    const tools = makeTraceTools(store, new MemoryTraceObjectStore())
+    const getRunIo = tools.find(t => t.name === 'get_run_io')!
+    const out = await getRunIo.handler({ runId: 'target-1' }, CTX)
+    expect(out).toEqual({ question: '曹操爸爸是谁', finalAnswer: '赤壁之战发生在公元208年。' })
+  })
+})

--- a/examples/agent-docs-qa/__tests__/trace-tools.test.ts
+++ b/examples/agent-docs-qa/__tests__/trace-tools.test.ts
@@ -22,3 +22,26 @@ describe('makeTraceTools: get_run_io', () => {
     expect(out).toEqual({ question: '曹操爸爸是谁', finalAnswer: '赤壁之战发生在公元208年。' })
   })
 })
+
+describe('makeTraceTools: get_execution', () => {
+  it('returns the execution projection (steps with tool query) of a run', async () => {
+    const store = new MemoryEventStore()
+    const runId = 'target-2'
+    await store.append({ id: 's', runId, type: 'agent.run.started', actor: 'a', timestamp: 1,
+      payload: { agentId: 'x', goal: 'g', input: '曹操爸爸是谁', contextId: runId } })
+    await store.append({ id: 'lq', runId, type: 'llm.requested', actor: 'a', timestamp: 2,
+      payload: { request: { model: 'm', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }, requestHash: 'h1' } })
+    await store.append({ id: 'lr', runId, type: 'llm.responded', actor: 'a', timestamp: 3, causedBy: 'lq',
+      payload: { response: { content: [], toolCalls: [], finishReason: 'tool_use' }, requestHash: 'h1' } })
+    await store.append({ id: 'tq', runId, type: 'tool.requested', actor: 'a', timestamp: 4,
+      payload: { toolName: 'grep', input: { pattern: '赤壁' }, requestHash: 'h2' } })
+    await store.append({ id: 'tr', runId, type: 'tool.responded', actor: 'a', timestamp: 5, causedBy: 'tq',
+      payload: { toolName: 'grep', output: { matches: [] }, requestHash: 'h2' } })
+
+    const tools = makeTraceTools(store, new MemoryTraceObjectStore())
+    const getExec = tools.find(t => t.name === 'get_execution')!
+    const proj = await getExec.handler({ runId }, CTX) as { steps: Array<{ kind: string; tool?: { name: string; input: unknown } }> }
+    const toolStep = proj.steps.find(s => s.kind === 'tool')
+    expect(toolStep?.tool).toMatchObject({ name: 'grep', input: { pattern: '赤壁' } })
+  })
+})

--- a/examples/agent-docs-qa/agents/diagnoser.md
+++ b/examples/agent-docs-qa/agents/diagnoser.md
@@ -1,0 +1,34 @@
+---
+agentId: diagnoser
+version: 0.0.1
+fsm:
+  states:
+    - name: diagnose
+      type: llm
+      instructions: |
+        你是一个诊断 agent。你的输入是一个被诊断 run 的 runId（一个字符串 id）。
+        你的任务:判断那次 run 的最终答案是否答到了用户的问题上;若没有,沿
+        「用户问题 → 工具 query → 命中证据 → 最终答案」定位第一个与问题失配的步骤。
+
+        步骤:
+        1. 调 get_run_io({ runId }) 拿到用户问题(question)和最终答案(finalAnswer)。
+        2. 调 get_execution({ runId }) 拿到执行链(steps:每步 LLM/工具调用、工具的
+           query、命中证据、region 组成)。
+        3. 逐跳评估相关性:每个工具 query 是否针对 question?命中证据是否相关?最终
+           答案是否回答了 question?
+        4. 找出第一个与问题失配的跳(firstBreak)。
+
+        最后**只输出一段 JSON**(不要任何额外文字、不要 markdown 代码围栏):
+        {
+          "verdict": "ok" | "suspect",
+          "firstBreak": { "step": "<eventId 或步序>", "what": "<这一步做了什么>", "why": "<为什么与问题失配>" } | null,
+          "explanation": "<简短中文解释>"
+        }
+        verdict=ok 时 firstBreak 为 null。严格只输出 JSON。
+      tools: [get_run_io, get_execution]
+model:
+  provider: volcengine
+  model: doubao-seed-2-0-pro-260215
+  adapter: openai-compatible
+---
+诊断 agent:读被诊断 run 的 Trace 投影,定位答案与问题之间的相关性断点。

--- a/examples/agent-docs-qa/server.ts
+++ b/examples/agent-docs-qa/server.ts
@@ -16,6 +16,7 @@ import type { IModelGateway } from '../../src/types/model.js'
 import { BroadcastingEventStore } from './trace/broadcast-event-store.js'
 import { scanConversations, readEventsForContext } from './trace/conversation-scanner.js'
 import { makeCorpusToolDefinitions } from './tools/corpus-tools.js'
+import { makeTraceTools } from './tools/trace-tools.js'
 
 export interface ServerConfig {
   port:        number
@@ -281,7 +282,13 @@ export async function startServer(config: ServerConfig): Promise<Server> {
   for (const tool of makeCorpusToolDefinitions(config.corpusRoot)) {
     milkie.registerTool(tool)
   }
+  for (const tool of makeTraceTools(eventStore, traceObjectStore)) {
+    milkie.registerTool(tool)
+  }
   milkie.loadAgentFile(config.agentFile)
+  // The diagnoser is a cross-cutting agent living alongside the domain agent.
+  const diagnoserPath = path.join(path.dirname(config.agentFile), 'diagnoser.md')
+  if (existsSync(diagnoserPath)) milkie.loadAgentFile(diagnoserPath)
 
   // Public dir resolution: prefer co-located public/ when present (production
   // mode using the real example dir), else fall back to this file's

--- a/examples/agent-docs-qa/tools/trace-tools.ts
+++ b/examples/agent-docs-qa/tools/trace-tools.ts
@@ -1,0 +1,34 @@
+import type { IEventStore } from '../../../src/trace/EventStore'
+import type { ITraceObjectStore } from '../../../src/trace/TraceObjectStore'
+import type { ToolDefinition } from '../../../src/types/tool'
+import type { AgentRunStartedPayload, AgentRunCompletedPayload } from '../../../src/trace/types'
+
+/**
+ * Read-Trace tools for the diagnoser agent: deterministic projections over a
+ * recorded run's event log. Wrap core projections; never parse raw events in
+ * the agent. `runId` is the run being DIAGNOSED (distinct from the diagnoser's
+ * own run).
+ */
+export function makeTraceTools(
+  eventStore: IEventStore,
+  _objectStore: ITraceObjectStore,
+): ToolDefinition[] {
+  const get_run_io: ToolDefinition = {
+    name: 'get_run_io',
+    description: '取被诊断 run 的用户问题与最终答案。入参 { runId }。',
+    inputSchema: { type: 'object', properties: { runId: { type: 'string' } }, required: ['runId'] },
+    handler: async (input) => {
+      const { runId } = input as { runId: string }
+      const events = await eventStore.readByRunId(runId)
+      let question = ''
+      let finalAnswer = ''
+      for (const e of events) {
+        if (e.type === 'agent.run.started') question = String((e.payload as AgentRunStartedPayload).input ?? '')
+        if (e.type === 'agent.run.completed') finalAnswer = String((e.payload as AgentRunCompletedPayload).lastTextOutput ?? '')
+      }
+      return { question, finalAnswer }
+    },
+  }
+
+  return [get_run_io]
+}

--- a/examples/agent-docs-qa/tools/trace-tools.ts
+++ b/examples/agent-docs-qa/tools/trace-tools.ts
@@ -2,6 +2,8 @@ import type { IEventStore } from '../../../src/trace/EventStore'
 import type { ITraceObjectStore } from '../../../src/trace/TraceObjectStore'
 import type { ToolDefinition } from '../../../src/types/tool'
 import type { AgentRunStartedPayload, AgentRunCompletedPayload } from '../../../src/trace/types'
+import { regionReuseCounts } from '../../../src/trace/RegionContextView'
+import { buildExecutionProjection } from '../../../src/trace/diagnostics/buildExecutionProjection'
 
 /**
  * Read-Trace tools for the diagnoser agent: deterministic projections over a
@@ -11,7 +13,7 @@ import type { AgentRunStartedPayload, AgentRunCompletedPayload } from '../../../
  */
 export function makeTraceTools(
   eventStore: IEventStore,
-  _objectStore: ITraceObjectStore,
+  objectStore: ITraceObjectStore,
 ): ToolDefinition[] {
   const get_run_io: ToolDefinition = {
     name: 'get_run_io',
@@ -30,5 +32,21 @@ export function makeTraceTools(
     },
   }
 
-  return [get_run_io]
+  const get_execution: ToolDefinition = {
+    name: 'get_execution',
+    description: '取被诊断 run 的执行投影:步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。入参 { runId }。',
+    inputSchema: { type: 'object', properties: { runId: { type: 'string' } }, required: ['runId'] },
+    handler: async (input) => {
+      const { runId } = input as { runId: string }
+      const events = await eventStore.readByRunId(runId)
+      const regionContent = new Map<string, string>()
+      for (const h of regionReuseCounts(events).keys()) {
+        const c = await objectStore.getCanonical(h)
+        if (c !== undefined) regionContent.set(h, c)
+      }
+      return buildExecutionProjection(events, { regionContent })
+    },
+  }
+
+  return [get_run_io, get_execution]
 }


### PR DESCRIPTION
## 背景

现有诊断答"机制"(Why)与"源支撑"(Provenance),答不了"答案对不对 / 错在哪"。补一个**相关性链路断点**诊断:沿 `用户问题 → 工具 query → 命中证据 → 最终答案`,定位第一个与问题失配的跳。封装为**专职 diagnoser agent**(读 Trace 的旁观者)。

设计/讨论见 #88;定位:diagnoser 是横切通用能力,**归宿是 milkie 内置/标准 agent 层(#89)**,PoC 临时**借住** `examples/agent-docs-qa`(整体不拆,不依赖 #89)。

## 改动

- **`tools/trace-tools.ts`**(新增):`makeTraceTools(eventStore, objectStore)` → `[get_run_io, get_execution]`,确定性读-Trace 工具,包装核心投影(`buildExecutionProjection` / `regionReuseCounts`),不让 agent 解析原始事件。
- **`agents/diagnoser.md`**(新增):diagnoser agent(单 llm state、上述两工具、方法论写在 systemPrompt、输出约定 JSON `{verdict, firstBreak, explanation}`)。
- **`server.ts`**:注册 trace 工具 + 条件加载 diagnoser(同目录存在则加载),与领域 agent 并存,零侵入现有流程。
- **测试**:读-Trace 工具确定性单测;stub 管道/契约测(**已验证非 hollow** —— 断言 `get_execution` 的 `tool.responded` 携带真实投影,注释掉工具注册后测试会 FAIL)。
- **README**:标注 diagnoser 借住 / 归宿 #89 + live 验证步骤。

## 测试策略(诚实分层)

- **确定性层(本 PoC 覆盖)**:读-Trace 工具单测 + stub 管道/契约测 → 证"工具正确 + 管道通 + 输出契约成立"。
- **真实 LLM 层(手动 / live,不进 CI)**:诊断**判断质量**依赖真实 LLM 推理,见 README live 验证(例:问"曹操爸爸"却 grep"赤壁",人工核对 firstBreak 指向工具 query 跑偏)。

## 验证

`tsc --noEmit` 干净;`examples/agent-docs-qa/__tests__` + `src/__tests__` 共 **53 suites / 453 tests** 全绿,无回归。

## 非目标(剥离)

UI/panel 集成(endpoint + 按钮 + 渲染,单独 issue)、多轴诊断、grounding 复核(verifier 已有)、可注入 skill 形态、内置 agent 层机制(#89)。

实现经 brainstorm → spec(`docs/superpowers/specs/2026-06-01-diagnoser-agent-design.md`)→ plan → subagent-driven TDD(每 task 两阶段 review)。

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)