### PR TITLE
feat(#81): tool.requested/responded 携带 toolCallId + status（可读 payload）

### DIFF
--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -4,6 +4,7 @@ import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
 import { InMemoryRecorder } from '../trajectory/InMemoryRecorder'
 import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { RecordingIOPort } from '../trace/RecordingIOPort'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents'
 import { MemoryTraceObjectStore } from '../trace/TraceObjectStore'
 import type { AgentConfig } from '../types/agent'
@@ -604,5 +605,48 @@ describe('#31 guard evaluation capture', () => {
     )
     expect((transition!.payload as import('../trace/types').FsmTransitionPayload).guardEvaluations)
       .toBeUndefined()
+  })
+})
+
+describe('#81 readable tool payload through a run', () => {
+  it('stamps the LLM tool_use id onto tool.requested/responded so they pair', async () => {
+    const eventStore = new MemoryEventStore()
+    const toolDef: ToolDefinition = {
+      name:        'search',
+      description: 'search the web',
+      inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+      handler:     async () => ({ results: ['result1'] }),
+    }
+    const runId  = 'run-81'
+    const ioPort = new RecordingIOPort(
+      new DefaultIOPort(new SequentialGateway([
+        toolCallResponse('tc-xyz', 'search', { q: 'test' }),
+        textResponse('done'),
+      ])),
+      eventStore,
+      runId,
+    )
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'search something',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort,
+      extraTools: [toolDef],
+      eventStore,
+      agentRunId: runId,
+    })
+
+    const result = await runtime.run('go')
+    const events = await eventStore.readByRunId(result.agentRunId)
+    const req = events.find(e => e.type === 'tool.requested')!.payload as import('../trace/types').ToolRequestedPayload
+    const res = events.find(e => e.type === 'tool.responded')!.payload as import('../trace/types').ToolRespondedPayload
+
+    expect(req.toolCallId).toBe('tc-xyz')
+    expect(res.toolCallId).toBe('tc-xyz')
+    expect(res.toolCallId).toBe(req.toolCallId)
+    expect(res.status).toBe('ok')
+    expect(res.output).toEqual({ results: ['result1'] })
   })
 })

--- a/src/__tests__/RecordingIOPort.toolCallId.test.ts
+++ b/src/__tests__/RecordingIOPort.toolCallId.test.ts
@@ -1,0 +1,88 @@
+import { RecordingIOPort } from '../trace/RecordingIOPort'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { IIOPort } from '../runtime/IOPort'
+import type { ModelRequest, ModelResponse } from '../types/model'
+import type { ToolRequestedPayload, ToolRespondedPayload } from '../trace/types'
+
+class ExecInnerPort implements IIOPort {
+  private nextClock = 1000
+  private nextUuid  = 1
+  async invokeLLM(_req: ModelRequest): Promise<ModelResponse> {
+    return { content: [], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async invokeTool(_n: string, _i: unknown, execute: () => Promise<unknown>): Promise<unknown> {
+    return execute()
+  }
+  now():  number { return this.nextClock++ }
+  uuid(): string { return `uuid-${this.nextUuid++}` }
+}
+
+async function payloads(store: MemoryEventStore) {
+  const events = await store.readByRunId('r1')
+  const req = events.find(e => e.type === 'tool.requested')!.payload as ToolRequestedPayload
+  const res = events.find(e => e.type === 'tool.responded')!.payload as ToolRespondedPayload
+  return { req, res }
+}
+
+describe('RecordingIOPort — readable tool payload (#81)', () => {
+  it('stamps toolCallId onto both tool.requested and tool.responded so they pair', async () => {
+    const store = new MemoryEventStore()
+    const port: IIOPort = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+
+    await port.invokeTool('search', { q: 'milkie' }, async () => ({ hits: 3 }), {
+      toolCallId: 'call-abc',
+    })
+
+    const { req, res } = await payloads(store)
+    expect(req.toolCallId).toBe('call-abc')
+    expect(res.toolCallId).toBe('call-abc')
+    // pairing: same toolCallId links the two events for an external consumer
+    expect(res.toolCallId).toBe(req.toolCallId)
+  })
+
+  it('marks status="ok" on the success branch and keeps name/input/output readable', async () => {
+    const store = new MemoryEventStore()
+    const port: IIOPort = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+
+    await port.invokeTool('search', { q: 'milkie' }, async () => ({ hits: 3 }), {
+      toolCallId: 'call-ok',
+    })
+
+    const { req, res } = await payloads(store)
+    expect(req.toolName).toBe('search')
+    expect(req.input).toEqual({ q: 'milkie' })
+    expect(res.status).toBe('ok')
+    expect(res.output).toEqual({ hits: 3 })
+    expect(res.error).toBeUndefined()
+  })
+
+  it('marks status="error" and keeps toolCallId on the failure branch', async () => {
+    const store = new MemoryEventStore()
+    const port: IIOPort = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+
+    await expect(
+      port.invokeTool('search', { q: 'x' }, async () => { throw new Error('boom') }, {
+        toolCallId: 'call-err',
+      }),
+    ).rejects.toThrow('boom')
+
+    const { req, res } = await payloads(store)
+    expect(req.toolCallId).toBe('call-err')
+    expect(res.toolCallId).toBe('call-err')
+    expect(res.status).toBe('error')
+    expect(res.error?.message).toBe('boom')
+    expect(res.output).toBeUndefined()
+  })
+
+  it('omits toolCallId when none is supplied (back-compat), still sets status', async () => {
+    const store = new MemoryEventStore()
+    const port: IIOPort = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+
+    await port.invokeTool('t', {}, async () => 'hi')
+
+    const { req, res } = await payloads(store)
+    expect(req.toolCallId).toBeUndefined()
+    expect(res.toolCallId).toBeUndefined()
+    expect(res.status).toBe('ok')
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -1154,6 +1154,7 @@ export class AgentRuntime {
           call.name,
           call.input,
           () => this.registry.execute(call.name, call.input, ctx),
+          { toolCallId: call.id },  // #81: stamp the LLM tool_use id onto tool.requested/responded for pairing
         )
         span.attributes['output'] = output
         // SPIKE(#73): event-source tool WM side-effects so replay reconstructs them.

--- a/src/runtime/IOPort.ts
+++ b/src/runtime/IOPort.ts
@@ -36,11 +36,15 @@ export interface IIOPort {
    *
    * `toolName` and `input` are exposed so future implementations can hash
    * them as a cache key without inspecting the thunk.
+   *
+   * `opts.toolCallId` (#81) is the LLM-side tool_use id; recording IOPorts stamp
+   * it onto tool.requested / tool.responded so external consumers can pair them.
    */
   invokeTool(
     toolName: string,
     input: unknown,
     execute: () => Promise<unknown>,
+    opts?: { toolCallId?: string },
   ): Promise<unknown>
 
   /** Current epoch milliseconds. Replacement for direct `Date.now()`. */

--- a/src/trace/RecordingIOPort.ts
+++ b/src/trace/RecordingIOPort.ts
@@ -191,9 +191,13 @@ export class RecordingIOPort implements IIOPort {
     toolName: string,
     input: unknown,
     execute: () => Promise<unknown>,
+    opts?: { toolCallId?: string },
   ): Promise<unknown> {
     await this.flushPendingNondet()
     const requestHash = hashToolCall(toolName, input)
+    // #81: only stamp toolCallId when supplied, so id-less callers stay clean and
+    // old traces (no id) read back identically.
+    const idField = opts?.toolCallId ? { toolCallId: opts.toolCallId } : {}
     const reqEventId  = this.inner.uuid()
     await this.store.append({
       id:        reqEventId,
@@ -203,12 +207,12 @@ export class RecordingIOPort implements IIOPort {
       // edge 1: this call was decided by the most recent llm.responded (the frame carrying toolCalls).
       ...(this.cursor?.lastLlmRespondedId ? { causedBy: this.cursor.lastLlmRespondedId } : {}),
       timestamp: this.inner.now(),
-      payload:   { toolName, input, requestHash } satisfies ToolRequestedPayload,
+      payload:   { toolName, ...idField, input, requestHash } satisfies ToolRequestedPayload,
     })
     if (this.cursor) this.cursor.lastIoEventId = reqEventId
 
     try {
-      const output = await this.inner.invokeTool(toolName, input, execute)
+      const output = await this.inner.invokeTool(toolName, input, execute, opts)
       const meta = await this.outputMetadata(output)
       const respEventId = this.inner.uuid()
       await this.store.append({
@@ -218,7 +222,7 @@ export class RecordingIOPort implements IIOPort {
         actor:     this.actor,
         causedBy:  reqEventId,
         timestamp: this.inner.now(),
-        payload:   { toolName, output, requestHash, ...meta } satisfies ToolRespondedPayload,
+        payload:   { toolName, ...idField, status: 'ok', output, requestHash, ...meta } satisfies ToolRespondedPayload,
       })
       // tool.responded is a turn terminator for the next llm.requested (edge 2).
       // Under a parallel tool batch, several tool.responded race to write this; the
@@ -247,7 +251,7 @@ export class RecordingIOPort implements IIOPort {
         actor:     this.actor,
         causedBy:  reqEventId,
         timestamp: this.inner.now(),
-        payload:   { toolName, error: errorPayload, requestHash } satisfies ToolRespondedPayload,
+        payload:   { toolName, ...idField, status: 'error', error: errorPayload, requestHash } satisfies ToolRespondedPayload,
       })
       // An errored tool.responded still terminates the turn — the next llm.requested follows it.
       if (this.cursor) {

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -62,12 +62,28 @@ export interface LlmRespondedPayload {
 export interface ToolRequestedPayload {
   toolName: string
   input: unknown
+  /**
+   * #81: LLM 侧 tool_use id（来自 ModelResponse.toolCalls[].id）。外部消费方
+   * （如 alfred turn orchestrator）按此与 tool.responded 配对。旧 trace 无此字段
+   * → optional。
+   */
+  toolCallId?: string
   /** Phase 3: hash of canonicalized (toolName + input); cache key for replay. */
   requestHash: string
 }
 
 export interface ToolRespondedPayload {
   toolName: string
+  /**
+   * #81: 与对应 tool.requested 相同的 LLM 侧 tool_use id，用于配对 requested↔responded。
+   * 旧 trace 无此字段 → optional。
+   */
+  toolCallId?: string
+  /**
+   * #81: 显式成功/失败标志。'ok' = output 分支，'error' = error 分支。
+   * 外部消费方据此判断而无需推导 output/error 的存在性。旧 trace 无此字段 → optional。
+   */
+  status?: 'ok' | 'error'
   output?: unknown
   /** Phase 3: structured to preserve retryable/code/name; replay rebuilds Error. */
   error?: {


### PR DESCRIPTION
## 背景
alfred 用 milkie 替换 dolphin provider 的 **P0 阻塞项**。外部消费方（alfred turn orchestrator / 前端）此前只能拿到内部 event id，无法与 LLM 侧 `tool_use` id 配对；成功/失败也只能靠 `output`/`error` 字段存在性隐含推导，导致 phantom 检测 / 重复 intent 去重 / 预算熔断等防失控机制失效。

设计提案见 issue 评论：#81 (comment)。本 PR 按提案"推荐项"实现。

## 改动
- `ToolRequestedPayload` / `ToolRespondedPayload` 增加 `toolCallId?`（配对）
- `ToolRespondedPayload` 增加 `status?: 'ok' | 'error'`（显式成功/失败）
- `IOPort.invokeTool` 增加 `opts?: { toolCallId? }`；`RecordingIOPort` 写入两条事件
- `AgentRuntime` 工具调用点透传 `call.id`

## 兼容性 / replay
- `toolCallId` 仅在提供时写入 → 向后兼容旧 trace（无该字段读回一致）
- **不进 `requestHash`**（hash 仍是 `toolName + input`），replay 配对逻辑不变
- 决定论 e2e 通过，确认未破坏 replay

## 测试（TDD，红→绿）
- `src/__tests__/RecordingIOPort.toolCallId.test.ts`（单元，4 例）：toolCallId 配对 / status=ok / status=error / 无 id 向后兼容
- `AgentRuntime` `#81` 端到端：一次含工具调用的 run，读事件断言 requested↔responded 按 toolCallId 配对
- 回归：`tsc --noEmit` 0 错误；trace+runtime 66/66；`npm test`（unit 39 + deterministic e2e 8）全过

## 验收对照
一次含工具调用的 run，其 `tool.requested`/`tool.responded` 事件可被外部解析出 `name / input / output / status`，并能按 `toolCallId` 配对 requested↔responded ✓

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)