### PR TITLE
feat(#82): per-turn variables 注入 turn-context region（不破坏 prefix cache）

### DIFF
--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -606,3 +606,105 @@ describe('#31 guard evaluation capture', () => {
       .toBeUndefined()
   })
 })
+
+describe('#82 per-turn variables', () => {
+  class CaptureGateway implements IModelGateway {
+    captured: ModelRequest[] = []
+    async complete(req: ModelRequest): Promise<ModelResponse> {
+      this.captured.push(req)
+      return textResponse('done')
+    }
+    async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+  }
+
+  it('injects variables into the messages, never into the system block', async () => {
+    const gw = new CaptureGateway()
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'g',
+      input:      'hi',
+      variables:  { current_time: '2026-06-01T00:00:00Z', workspace: 'demo' },
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(gw),
+    })
+
+    await runtime.run('hi')
+
+    const req = gw.captured[0]!
+    const msgText = req.messages
+      .flatMap(m => m.content)
+      .map(c => (c.type === 'text' ? c.text : ''))
+      .join('\n')
+    expect(msgText).toContain('current_time')
+    expect(msgText).toContain('2026-06-01T00:00:00Z')
+    expect(msgText).toContain('demo')
+    // prefix-cache safety: per-turn variables must never enter the system prefix
+    expect(req.system ?? '').not.toContain('current_time')
+    expect(req.system ?? '').not.toContain('demo')
+  })
+
+  it('keeps the system block byte-identical when only variables differ', async () => {
+    const systemFor = async (variables: Record<string, string>): Promise<string> => {
+      const gw = new CaptureGateway()
+      await new AgentRuntime({
+        config:     makeConfig(),
+        goal:       'g',
+        input:      'hi',
+        variables,
+        stateStore: new MemoryStore(),
+        recorder:   new InMemoryRecorder(),
+        ioPort:     new DefaultIOPort(gw),
+      }).run('hi')
+      return gw.captured[0]!.system ?? ''
+    }
+
+    const s1 = await systemFor({ current_time: 'T1' })
+    const s2 = await systemFor({ current_time: 'T2' })
+    expect(s1).toBe(s2)
+  })
+
+  it('adds no turn-context message when no variables are supplied', async () => {
+    const gw = new CaptureGateway()
+    await new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'g',
+      input:      'hi',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(gw),
+    }).run('hi')
+
+    const req = gw.captured[0]!
+    const msgText = req.messages
+      .flatMap(m => m.content)
+      .map(c => (c.type === 'text' ? c.text : ''))
+      .join('\n')
+    expect(msgText).not.toContain('--- Turn Context ---')
+  })
+
+  it('Milkie.invoke forwards request.variables into the turn', async () => {
+    const gw = new CaptureGateway()
+    const milkie = new Milkie({ stateStore: new MemoryStore(), gateway: gw })
+    milkie.registerAgent(makeConfig({
+      agentId: 'var-agent',
+      fsm: { states: [{ name: 'react', type: 'llm' }] },
+    }))
+
+    await milkie.invoke({
+      agentId:   'var-agent',
+      goal:      'g',
+      input:     'hi',
+      variables: { session_id: 'sess-9', foo: 'BAR' },
+    })
+
+    const req = gw.captured[0]!
+    const msgText = req.messages
+      .flatMap(m => m.content)
+      .map(c => (c.type === 'text' ? c.text : ''))
+      .join('\n')
+    expect(msgText).toContain('session_id')
+    expect(msgText).toContain('sess-9')
+    expect(msgText).toContain('BAR')
+  })
+})

--- a/src/__tests__/turnContextRegion.test.ts
+++ b/src/__tests__/turnContextRegion.test.ts
@@ -1,0 +1,71 @@
+import { assemble } from '../context/assemble'
+import type { AssembleScope } from '../context/assemble'
+import { ContextRegions } from '../context/ContextRegions'
+import { makeTurnContextRegion } from '../context/lifecycleEngine'
+import type { RegionInput } from '../context/Region'
+import type { Message } from '../types/common.js'
+
+function scope(): AssembleScope {
+  return { currentState: 'default', currentTurnId: 'turn-1', currentEpoch: 0 }
+}
+
+function msgRegion(section: 'history' | 'current-turn', text: string): RegionInput {
+  return {
+    target:    'message',
+    section,
+    intraTurn: 'turn-persistent',
+    interTurn: section === 'history' ? 'session-persistent' : 'turn-local',
+    stability: section === 'history' ? 'session-stable' : 'volatile',
+    content:   { role: 'user' as const, content: [{ type: 'text' as const, text }] },
+    format:    (c) => c as Message,
+  }
+}
+
+function textOf(m: Message | undefined): string {
+  const c = m?.content[0]
+  return c && c.type === 'text' ? c.text : ''
+}
+
+describe('makeTurnContextRegion (#82)', () => {
+  it('renders variables into a message placed between history and current-turn', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('history', msgRegion('history', 'PREV'))
+    store.set('turn-context', makeTurnContextRegion({ current_time: 'T1', workspace: 'W' }))
+    store.set('current-turn', msgRegion('current-turn', 'NOW'))
+
+    const out = assemble(store, scope())
+
+    // ordering: history → turn-context → current-turn
+    expect(out.messages).toHaveLength(3)
+    expect(textOf(out.messages[0])).toBe('PREV')
+    expect(textOf(out.messages[2])).toBe('NOW')
+
+    // the middle message carries the injected variables (key + value readable)
+    const mid = textOf(out.messages[1])
+    expect(mid).toContain('current_time')
+    expect(mid).toContain('T1')
+    expect(mid).toContain('workspace')
+    expect(mid).toContain('W')
+  })
+
+  it('never touches the system block (prefix-cache safety)', () => {
+    const store = new ContextRegions(() => 0)
+    store.set('header', {
+      target: 'system', section: 'header', intraTurn: 'turn-persistent',
+      interTurn: 'session-persistent', stability: 'immutable',
+      content: 'You are an agent.', format: (c) => String(c),
+    })
+    store.set('turn-context', makeTurnContextRegion({ secret_var: 'XYZ' }))
+
+    const out = assemble(store, scope())
+    expect(out.system).toBe('You are an agent.')
+    expect(out.system).not.toContain('secret_var')
+    expect(out.system).not.toContain('XYZ')
+  })
+
+  it('renders byte-identical output for identical variables (sorted keys)', () => {
+    const a = makeTurnContextRegion({ b: '2', a: '1' })
+    const b = makeTurnContextRegion({ a: '1', b: '2' })
+    expect(textOf(a.format(a.content) as Message)).toBe(textOf(b.format(b.content) as Message))
+  })
+})

--- a/src/context/Region.ts
+++ b/src/context/Region.ts
@@ -15,6 +15,7 @@ export type SystemSection =
 
 export type MessageSection =
   | 'history'
+  | 'turn-context'   // #82: per-turn injected variables (volatile, between history and current-turn)
   | 'current-turn'
   | 'scratchpad'
 

--- a/src/context/lifecycleEngine.ts
+++ b/src/context/lifecycleEngine.ts
@@ -9,7 +9,7 @@
 
 import type { ContextRegions } from './ContextRegions'
 import type { Region, RegionInput, RegionSnapshot } from './Region'
-import type { Message, MessageContent } from '../types/common.js'
+import type { Message, MessageContent, JSONValue } from '../types/common.js'
 import type { ToolSchema } from '../types/model.js'
 
 interface ScratchAssistantContent {
@@ -100,6 +100,30 @@ export function makeWmRegion(
     content:   { data: sortedData, log },
     format:    (c) =>
       '\n--- Working Memory ---\n' + JSON.stringify(c, null, 2),
+  }
+}
+
+export function makeTurnContextRegion(variables: Record<string, JSONValue>): RegionInput {
+  return {
+    target:    'message',
+    section:   'turn-context',
+    intraTurn: 'turn-persistent',
+    interTurn: 'turn-local',
+    stability: 'volatile',
+    content:   variables,
+    // Sorted keys → byte-identical render for the same variables (deterministic,
+    // replay-friendly). Compact `key: value`; non-string values JSON-encoded.
+    format:    (c): Message => {
+      const vars = c as Record<string, JSONValue>
+      const lines = Object.keys(vars).sort().map((k) => {
+        const v = vars[k]
+        return `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`
+      })
+      return {
+        role:    'user',
+        content: [{ type: 'text', text: `--- Turn Context ---\n${lines.join('\n')}` }],
+      }
+    },
   }
 }
 

--- a/src/context/sectionSchema.ts
+++ b/src/context/sectionSchema.ts
@@ -26,6 +26,8 @@ export const SECTION_SCHEMA: {
   ],
   message: [
     'history',
+    // #82: per-turn variables — after stable history, before the volatile current turn.
+    'turn-context',
     'current-turn',
     'scratchpad',
   ],

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -7,7 +7,7 @@ import type { IStateStore, AgentCheckpoint, ChildAgentRecord } from '../types/st
 import type { ITrajectoryRecorder, Span } from '../types/trajectory.js'
 import type { ToolDefinition, ToolContext, ToolResult, ToolResultStrategy } from '../types/tool.js'
 import { applyShape, serializeOutput } from './toolResultStrategy.js'
-import type { MessageContent } from '../types/common.js'
+import type { MessageContent, JSONValue } from '../types/common.js'
 import { FSMEngine } from '../fsm/FSMEngine.js'
 import { ContextRegions } from '../context/ContextRegions.js'
 import { assemble, type AssembleScope } from '../context/assemble.js'
@@ -15,6 +15,7 @@ import {
   makeHeaderRegion,
   makeSkillRegion,
   makeCurrentTurnRegion,
+  makeTurnContextRegion,
   makeScratchpadAssistantRegion,
   makeScratchpadToolResultRegion,
   makeStateInstructionsRegion,
@@ -51,6 +52,9 @@ export interface AgentRuntimeOptions {
   contextId?:        string
   agentRunId?:       string  // if provided, use this (allows caller to correlate with recorder meta)
   parentId?:         string
+  /** #82: per-turn variables injected into the volatile turn-context region (message
+   *  section, after history, before current-turn). Not persisted; this turn only. */
+  variables?:        Record<string, JSONValue>
   stateStore:        IStateStore
   recorder:          ITrajectoryRecorder
   ioPort:            IIOPort
@@ -91,6 +95,7 @@ type SkillLoadRequest = {
 export class AgentRuntime {
   private readonly config:           AgentConfig
   private readonly goal:             string
+  private readonly variables?:       Record<string, JSONValue>  // #82: per-turn injected vars
   readonly contextId:        string
   private readonly agentRunId:       string
   private readonly parentId?:        string
@@ -137,6 +142,7 @@ export class AgentRuntime {
     this.ioPort          = opts.ioPort
     this.config          = opts.config
     this.goal            = opts.goal
+    this.variables       = opts.variables
     this.contextId       = opts.contextId ?? this.ioPort.uuid()
     this.agentRunId      = opts.agentRunId ?? this.ioPort.uuid()
     this.parentId        = opts.parentId
@@ -398,6 +404,15 @@ export class AgentRuntime {
 
   private setCurrentTurn(input: string): void {
     this.regions.set('current-turn', makeCurrentTurnRegion(input))
+  }
+
+  // #82: inject per-turn variables into the volatile turn-context region (message
+  // section, after history, before current-turn). Skipped when no variables → no
+  // empty region, and the system prefix stays byte-stable for prefix cache.
+  private setTurnContext(): void {
+    if (this.variables && Object.keys(this.variables).length > 0) {
+      this.regions.set('turn-context', makeTurnContextRegion(this.variables))
+    }
   }
 
   private getCurrentTurn(): string | null {
@@ -841,6 +856,7 @@ export class AgentRuntime {
 
     const turnInput = `Goal: ${this.goal}\n\n${input}`
     this.setCurrentTurn(turnInput)
+    this.setTurnContext()
     this.turnNumber++
 
     try {

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -227,6 +227,7 @@ export class Milkie {
       config,
       goal:            request.goal,
       input:           request.input,
+      variables:       request.variables,  // #82: per-turn variables → turn-context region
       contextId,
       agentRunId,
       stateStore:      this.stateStore,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,9 @@ export interface AgentInvokeRequest {
   goal: string
   input: string
   contextId?: string
+  /** #82: per-turn variables injected into the turn-context region for this turn
+   *  only (not persisted). Same shape #83 will reuse for persistent session vars. */
+  variables?: Record<string, JSONValue>
 }
 
 export interface AgentResult {


### PR DESCRIPTION
## 背景
alfred 用 milkie 替换 dolphin provider 的 P1 功能缺口。需要每轮动态刷新 `current_time` / `workspace_instructions` / 可用 skills 等。

设计讨论与最终方案见 issue（已 promote 进 #82 body）。

## 方向修正（重要）
issue 字面写的是「per-turn **system prompt** override（整段替换）」——这会把逐轮变化内容塞进 prompt 靠前位置，**击穿 prefix cache**。milkie 的 prompt 是分区组装（region substrate，region 自带 `stability` / `cacheBreakpoint`）。

经评审确认，改为：**per-turn 变量注入到 message 段的 volatile `turn-context` region**（`history` 之后、`current-turn` 之前），满足逐轮刷新且 **system 前缀逐字节稳定**。`systemPromptOverride`（整段替换）评审确认不做。

## 改动
- `Region.ts` / `sectionSchema.ts`：新增 message section `turn-context`（history→**turn-context**→current-turn）
- `lifecycleEngine.ts`：`makeTurnContextRegion`（紧凑 `key: value`，排序 keys → 逐字节确定性渲染）
- `common.ts` / `AgentRuntimeOptions`：增加 `variables?: Record<string, JSONValue>`（本轮临时、**不持久化**）
- `AgentRuntime.run`：每轮 `setTurnContext()`（无变量则不建空 region）
- `Milkie.invoke`：转发 `request.variables`

## 缓存约束（已测）
逐轮变量**不进 system 前缀**；仅 variables 不同时 system 段渲染逐字节相同。

## 与 #83 边界
- #82 = 本轮临时注入（volatile，不落盘）；#83 = 持久化会话变量（落盘、跨进程）。
- 共享 `variables: Record<string, JSONValue>` 数据形态，#83 后续复用并提供持久层。

## 已知边界
- 仅 `invoke` 路径转发 variables；**`resume` 路径暂未带** per-turn variables（issue 验收聚焦 invoke；resume 注入更适合随 #85 interrupt/resume 一起处理）。

## 测试（TDD，红→绿）
- `turnContextRegion.test.ts`（region 层）：渲染 / 顺序（history→turn-context→current-turn）/ 缓存隔离（不进 system）/ 确定性
- `AgentRuntime #82`（端到端）：注入进 messages 且不进 system / 仅 variables 不同时 system 逐字节相同 / 无变量不建区 / `Milkie.invoke` 转发
- 回归：`tsc` 0 错误；context+runtime 100/100；`npm test`（unit 42 + deterministic e2e 8）全过——replay 未破坏

## 验收对照（修正后）
同一 agent / 同一 contextId，两次 invoke 传不同 `variables` → 模型实际收到的本轮上下文相应不同，且 system 前缀保持稳定（不破坏 prefix cache）✓

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
