### PR TITLE
refactor(#99): Milkie 构造 stateStore 改必传（去掉 MemoryStore 隐式 fallback）

### DIFF
--- a/examples/agent-docs-qa/__tests__/server.test.ts
+++ b/examples/agent-docs-qa/__tests__/server.test.ts
@@ -6,6 +6,7 @@ import os from 'os'
 import path from 'path'
 import { Milkie } from '../../../src/runtime/Milkie'
 import { JsonlEventStore } from '../../../src/trace/JsonlEventStore'
+import { MemoryStore } from '../../../src/store/MemoryStore'
 import { FileTraceObjectStore } from '../../../src/trace/TraceObjectStore'
 
 class StubGateway implements IModelGateway {
@@ -497,6 +498,7 @@ describe('diagnoser agent (stub pipeline + output contract)', () => {
     const traceObjStore = new FileTraceObjectStore(objsDir)
     const verdict = { verdict: 'suspect', firstBreak: { step: 2, what: 'grep 赤壁', why: '与问题(曹操爸爸)不相关' }, explanation: '工具查询跑偏' }
     const milkie = new Milkie({
+      stateStore: new MemoryStore(),
       eventStore: es,
       traceObjectStore: traceObjStore,
       gateway: new StubGateway([toolCall('d1', 'get_execution', { runId: chat.runId }), text(JSON.stringify(verdict))]),

--- a/examples/s-005-replay/replay-sdk.ts
+++ b/examples/s-005-replay/replay-sdk.ts
@@ -12,6 +12,7 @@ import fs from 'fs'
 import path from 'path'
 import { Milkie } from '../../src/runtime/Milkie'
 import { JsonlEventStore } from '../../src/trace/JsonlEventStore'
+import { MemoryStore } from '../../src/store/MemoryStore'
 
 async function main(): Promise<void> {
   const exampleDir = __dirname
@@ -21,6 +22,7 @@ async function main(): Promise<void> {
   const runId = process.argv[2] ?? fs.readFileSync(path.join(milkieDir, 'last-run.txt'), 'utf-8').trim()
 
   const milkie = new Milkie({
+    stateStore: new MemoryStore(),  // ephemeral: replay is deterministic from the event log
     eventStore: new JsonlEventStore(runsDir),
   })
   await milkie.loadManifest(path.join(milkieDir, 'agents.json'))

--- a/src/__tests__/LoadManifest.test.ts
+++ b/src/__tests__/LoadManifest.test.ts
@@ -1,4 +1,5 @@
 import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
@@ -44,7 +45,7 @@ test prompt`
       { id: 'verifier', file: '../agents/verifier.md' },
     ])
 
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const result = await milkie.loadManifest(manifestPath)
 
     expect(result.loaded).toEqual(['router', 'verifier'])
@@ -61,7 +62,7 @@ test prompt`
       { id: 'verifier', file: '../agents/verifier.md' },
     ])
 
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const result = await milkie.loadManifest(manifestPath)
 
     expect(result.loaded).toEqual(['router'])
@@ -77,7 +78,7 @@ test prompt`
       { id: 'router', file: '../agents/router.md' },
     ])
 
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const result = await milkie.loadManifest(manifestPath)
 
     expect(result.loaded).toEqual([])
@@ -90,7 +91,7 @@ test prompt`
 
   it('throws when the manifest file itself is missing', async () => {
     const nonexistent = path.join(tmpDir, '.milkie', 'agents.json')   // never written
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     await expect(milkie.loadManifest(nonexistent)).rejects.toThrow(/no such file|not found/i)
   })
 
@@ -102,7 +103,7 @@ test prompt`
     const subDir = fs.mkdtempSync(path.join(tmpDir, 'sub-'))
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(subDir)
     try {
-      const milkie = new Milkie()
+      const milkie = new Milkie({ stateStore: new MemoryStore() })
       const result = await milkie.loadManifest()
       expect(result.loaded).toEqual(['router'])
     } finally {
@@ -114,7 +115,7 @@ test prompt`
     // beforeEach made tmpDir/.milkie but no agents.json inside it; nothing to find
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir)
     try {
-      const milkie = new Milkie()
+      const milkie = new Milkie({ stateStore: new MemoryStore() })
       const result = await milkie.loadManifest()
       expect(result.loaded).toEqual([])
       expect(result.skipped).toEqual([])
@@ -130,7 +131,7 @@ test prompt`
       { id: 'router',   file: '../agents/router.md' },
       { id: 'verifier', file: '../agents/verifier.md' },
     ])
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     await milkie.loadManifest(manifestPath)
     expect(milkie.listAgents().sort()).toEqual(['router', 'verifier'])
   })
@@ -138,7 +139,7 @@ test prompt`
   it('throws when the manifest is not valid JSON', async () => {
     const manifestPath = path.join(tmpDir, '.milkie', 'agents.json')
     fs.writeFileSync(manifestPath, '{ not valid json')
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     await expect(milkie.loadManifest(manifestPath)).rejects.toThrow()
   })
 
@@ -150,7 +151,7 @@ test prompt`
       { id: 'router', file: '../agents/router-v2.md' },
     ])
 
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const result = await milkie.loadManifest(manifestPath)
 
     expect(result.loaded).toEqual(['router'])

--- a/src/__tests__/Milkie.stream.test.ts
+++ b/src/__tests__/Milkie.stream.test.ts
@@ -1,4 +1,5 @@
 import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
 import type { AgentConfig } from '../types/agent'
 import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
 import type { ToolDefinition } from '../types/tool'
@@ -78,7 +79,7 @@ describe('Milkie.invoke — onModelEvent end-to-end pass-through (#80)', () => {
       [textCompletion('Hello, world!')],
     )
 
-    const milkie = new Milkie({ gateway })
+    const milkie = new Milkie({ stateStore: new MemoryStore(), gateway })
     milkie.registerAgent(makeConfig())
 
     const events: ModelEvent[] = []
@@ -111,7 +112,7 @@ describe('Milkie.invoke — onModelEvent end-to-end pass-through (#80)', () => {
       [textCompletion('Hello, world!')],
     )
 
-    const milkie = new Milkie({ gateway })
+    const milkie = new Milkie({ stateStore: new MemoryStore(), gateway })
     milkie.registerAgent(makeConfig())
 
     const result = await milkie.invoke({
@@ -162,7 +163,7 @@ describe('Milkie.invoke — onModelEvent end-to-end pass-through (#80)', () => {
       ],
     )
 
-    const milkie = new Milkie({ gateway, tools: [searchTool] })
+    const milkie = new Milkie({ stateStore: new MemoryStore(), gateway, tools: [searchTool] })
     milkie.registerAgent(makeConfig())
 
     const events: ModelEvent[] = []

--- a/src/__tests__/MilkieConstruct.test.ts
+++ b/src/__tests__/MilkieConstruct.test.ts
@@ -1,0 +1,17 @@
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+
+describe('Milkie construction (#99)', () => {
+  it('throws when constructed without an explicit stateStore (no silent in-memory fallback)', () => {
+    // `as any` simulates a JS caller / type-escape that omits stateStore.
+    expect(() => new Milkie({} as any)).toThrow(/stateStore/)
+  })
+
+  it('throws when stateStore is explicitly undefined', () => {
+    expect(() => new Milkie({ stateStore: undefined } as any)).toThrow(/stateStore/)
+  })
+
+  it('constructs fine with an explicit stateStore', () => {
+    expect(() => new Milkie({ stateStore: new MemoryStore() })).not.toThrow()
+  })
+})

--- a/src/__tests__/standardAgentLayer.test.ts
+++ b/src/__tests__/standardAgentLayer.test.ts
@@ -1,5 +1,6 @@
 // src/__tests__/standardAgentLayer.test.ts
 import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
 import { MemoryEventStore } from '../trace/MemoryEventStore'
 import fs from 'fs'
 import os from 'os'
@@ -8,7 +9,7 @@ import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 
 describe('#89 built-in agents/diagnoser.md', () => {
   it('the built-in diagnoser.md template loads with no model', () => {
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const agentPath = path.resolve(__dirname, '../../agents/diagnoser.md')
     const cfg = milkie.loadAgentFile(agentPath)
     expect(cfg.agentId).toBe('diagnoser')
@@ -61,7 +62,7 @@ fsm:
       type: llm
 ---
 sys prompt`)
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     const cfg = milkie.loadAgentFile(file)
     expect(cfg.agentId).toBe('tpl')
     expect(cfg.model).toBeUndefined()
@@ -78,7 +79,7 @@ model:
   provider: x
 ---
 p`)
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     expect(() => milkie.loadAgentFile(file)).toThrow(/model/)
   })
 })
@@ -89,14 +90,14 @@ describe('#89 resolveGateway: no-model agent', () => {
   afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }) })
 
   it('runs a no-model agent using the gateway override', async () => {
-    const milkie = new Milkie({ gateway: new StubGateway([textResp('hi')]) })
+    const milkie = new Milkie({ stateStore: new MemoryStore(), gateway: new StubGateway([textResp('hi')]) })
     milkie.loadAgentFile(writeAgent(tmp, 'a.md', NO_MODEL_AGENT))
     const r = await milkie.invoke({ agentId: 'nomodel', goal: 'g', input: 'i' })
     expect(r.status).toBe('completed')
   })
 
   it('errors clearly when a no-model agent has neither gateway nor defaultModel', async () => {
-    const milkie = new Milkie()
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
     milkie.loadAgentFile(writeAgent(tmp, 'a.md', NO_MODEL_AGENT))
     // resolveGateway is called synchronously near the top of invoke; it should surface
     // a clear error. If invoke rejects, use rejects.toThrow; if invoke swallows it into
@@ -111,7 +112,7 @@ import type { ToolDefinition } from '../types/tool'
 
 describe('#89 loadStandardAgents', () => {
   it('loads the built-in diagnoser and registers the read-Trace tools', () => {
-    const milkie = new Milkie({ eventStore: new MemoryEventStore() })
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
     const ids = milkie.loadStandardAgents()
     expect(ids).toContain('diagnoser')
     expect(milkie.getAgent('diagnoser')).toBeDefined()

--- a/src/__tests__/volcengine.smoke.test.ts
+++ b/src/__tests__/volcengine.smoke.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
 import { ConsoleRecorder } from '../trajectory/ConsoleRecorder'
 import type { AgentConfig } from '../types/agent'
 
@@ -27,7 +28,7 @@ describe('VolcEngine smoke test', () => {
   let milkie: Milkie
 
   beforeAll(() => {
-    milkie = new Milkie()
+    milkie = new Milkie({ stateStore: new MemoryStore() })
     milkie.registerAgent(reactAgent)
   })
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { JsonlEventStore } from '../trace/JsonlEventStore.js'
 import { FileTraceObjectStore } from '../trace/TraceObjectStore.js'
 import { regionReuseCounts } from '../trace/RegionContextView.js'
 import { SQLiteStore } from '../store/SQLiteStore.js'
+import { MemoryStore } from '../store/MemoryStore.js'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
 
 function findMilkieDir(startDir: string): string | undefined {
@@ -75,7 +76,8 @@ export async function main(argv: string[]): Promise<MainResult> {
     .command('list')
     .description('List registered agents (loaded from .milkie/agents.json)')
     .action(async () => {
-      const milkie = new Milkie()
+      // ephemeral: only lists manifest agents, no persistent state needed.
+      const milkie = new Milkie({ stateStore: new MemoryStore() })
       await milkie.loadManifest()
       for (const id of milkie.listAgents()) {
         stdout.push(JSON.stringify({ id, source: 'manifest' }) + '\n')
@@ -237,7 +239,8 @@ export async function main(argv: string[]): Promise<MainResult> {
       }
       const eventStore = new JsonlEventStore(path.join(milkieDir, 'runs'))
       const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
-      const milkie = new Milkie({ eventStore, traceObjectStore })
+      // ephemeral: replay is deterministic from the event log, no persistent state needed.
+      const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore, traceObjectStore })
       await milkie.loadManifest(path.join(milkieDir, 'agents.json'))
       const result = await milkie.replay(runId)
       stdout.push(JSON.stringify({

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -28,7 +28,13 @@ import type { ToolEmittedPayload } from '../trace/types.js'
 import { makeTraceTools } from '../tools/trace.js'
 
 export interface MilkieOptions {
-  stateStore?:      IStateStore
+  /**
+   * #99: required — no silent in-memory fallback. Choose the backend explicitly:
+   * MemoryStore (tests / single-process), SQLiteStore (same-host persistence),
+   * RedisStore (cross-process production). MemoryStore does NOT satisfy #83's
+   * cross-process context vars.
+   */
+  stateStore:       IStateStore
   gateway?:         IModelGateway   // override all agents; if omitted, each agent uses its own adapter
   defaultModel?:    ModelConfig     // fallback model for agents that declare no model block
   tools?:           ToolDefinition[]
@@ -57,8 +63,14 @@ export class Milkie {
 
   private readonly agents:   Map<string, AgentConfig> = new Map()
 
-  constructor(opts: MilkieOptions = {}) {
-    this.stateStore      = opts.stateStore      ?? new MemoryStore()
+  constructor(opts: MilkieOptions) {
+    if (!opts?.stateStore) {
+      throw new Error(
+        'Milkie requires an explicit stateStore. Pass MemoryStore for tests/single-process, ' +
+        'SQLiteStore for same-host persistence, or RedisStore for cross-process production.',
+      )
+    }
+    this.stateStore      = opts.stateStore
     this.gatewayOverride = opts.gateway          ?? null
     this.defaultModel    = opts.defaultModel     ?? null
     this.extraTools      = opts.tools            ?? []


### PR DESCRIPTION
## 背景
`Milkie` 构造里 `opts.stateStore ?? new MemoryStore()` 的隐式 fallback 是温和陷阱：生产忘传 `stateStore` 会**静默**拿到进程内、重启即丢、跨不了进程的 mem（#83 跨进程 context vars 在 mem 下也失效）。源自 #83 讨论。

## 改动
- `MilkieOptions.stateStore` 改**必传**（去 `?`）
- 构造加**运行时 guard**（防 JS 调用方 / 类型逃逸；错误信息指明三种后端选型）
- 去掉 fallback；构造参数不再默认 `{}`

> 为什么不"默认改 SQLite"：SQLite 需文件 path，库不该擅自往用户文件系统写文件——落盘 path 应由应用/CLI 决定（现已如此）。正解是去掉误导性默认。

## 修复的调用点（显式补 MemoryStore，把"有意用 mem"显式化）
- `cli/main.ts`：`agent list` / `trace replay`（只读 / 确定性重放，ephemeral mem 合理）
- 测试：`LoadManifest` / `standardAgentLayer` / `Milkie.stream` / `volcengine.smoke`
- examples：`s-005 replay-sdk` / `agent-docs-qa server.test`

## 非目标
- **不删 `MemoryStore`**（测试命脉 + 单进程 / 零依赖默认值的基础）
- 不改 store 实现

## 测试（TDD 红→绿）
- `MilkieConstruct.test.ts`：无 stateStore / 显式 undefined → 抛（含 `/stateStore/` 信息）；显式传 → 不抛
- 回归：tsc 0 错误；src 全套 **512 passed**；`npm test`（unit + e2e deterministic）全过

Closes #99
