### PR TITLE
chore(examples): 顶层索引 + gitignore 去重统一

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,17 @@ their own [README](./docs/stories/README.md) and
 
 ## Examples
 
-Runnable demos paired with their stories live under
-[examples/](./examples/). Each example ships an SDK script and the
-equivalent CLI invocation over a frozen fixture — no API key required.
+Runnable demos live under [examples/](./examples/) — see its
+[README](./examples/README.md) for the full index. In short:
 
-- [`s-005-replay`](./examples/s-005-replay/) — deterministic replay
-  (Phase 3): record a run with an in-process stub gateway, then replay
-  the recorded run twice (once via SDK, once via CLI) and observe
-  identical output with zero live LLM calls.
+- [`s-005-replay`](./examples/s-005-replay/) — deterministic replay over
+  a frozen fixture: record with an in-process stub gateway, replay via
+  SDK and CLI, identical output, zero live LLM calls. No API key.
+- [`s-002-inspect`](./examples/s-002-inspect/) — render a recorded run as
+  a self-contained HTML `trace report`. No API key.
+- [`agent-docs-qa`](./examples/agent-docs-qa/) — a real 三国演义 Q&A agent
+  with live trace observation and skill loading in a local web UI.
+  Requires an API key.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -208,12 +208,16 @@ milkie 由三个 peer 子系统构成：
 
 ## Examples
 
-可跑的 demo 跟对应 story 配对放在 [examples/](./examples/) 下。每个 example
-都有一份 SDK 脚本和一份等价 CLI 调用，跑在固化 fixture 上，**无需 API key**。
+可跑的 demo 放在 [examples/](./examples/) 下，完整索引见其
+[README](./examples/README.md)。简述：
 
-- [`s-005-replay`](./examples/s-005-replay/) — 确定性 replay（Phase 3）：
-  用 in-process stub gateway 录一个 run，然后 replay 两遍（一次 SDK、
-  一次 CLI），输出完全一致，**零真实 LLM 调用**。
+- [`s-005-replay`](./examples/s-005-replay/) — 在固化 fixture 上做确定性
+  replay：用 in-process stub gateway 录一个 run，再经 SDK 与 CLI 各 replay
+  一遍，输出完全一致、**零真实 LLM 调用**。无需 API key。
+- [`s-002-inspect`](./examples/s-002-inspect/) — 把录好的 run 渲染成自包含的
+  HTML `trace report`。无需 API key。
+- [`agent-docs-qa`](./examples/agent-docs-qa/) — 一个真实可用的三国演义 Q&A
+  agent，在本地 web UI 里演示实时 trace 观测与 skill 加载。**需要 API key**。
 
 ---
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+# Runtime SQLite working state — re-created on demand by any example.
+# Unanchored names, so they match .milkie/ in every sub-example.
+state.sqlite
+state.sqlite-*

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Examples
+
+Runnable demos of milkie. Each example is self-contained: it ships an
+SDK script (and, where relevant, the equivalent CLI invocation) plus a
+README that links back to the story or spec it validates.
+
+| Example | Demonstrates | Surface | API key |
+|---|---|---|---|
+| [`s-002-inspect`](./s-002-inspect/) | `trace report` — HTML projection over an event log | CLI | not required (stub gateway) |
+| [`s-005-replay`](./s-005-replay/) | Deterministic replay — re-run a recorded run with zero live LLM calls, identical output via SDK and CLI | SDK + CLI | not required (stub gateway) |
+| [`agent-docs-qa`](./agent-docs-qa/) | A real Q&A agent over a 三国演义 corpus, with live trace observation and skill loading in a local web UI | Web app | **required** (real LLM) |
+
+Start with `s-005-replay` for the core record→replay model, then
+`s-002-inspect` to see the same event log rendered as HTML. Reach for
+`agent-docs-qa` when you want a full agent + live-trace UI you'd actually
+use.
+
+Each example's own README has the exact run commands. All of them assume
+you've built the CLI once from the repo root:
+
+```bash
+npm run build
+```
+
+## Naming
+
+`s-002-` / `s-005-` carry a **story number** that maps one-to-one to a
+file under [`docs/stories/`](../docs/stories/) — the prefix is the link
+between the example and the story it proves. `agent-docs-qa` has no such
+prefix because it validates a design spec rather than a numbered story.
+So the naming difference is intentional, not drift.
+
+## Fixtures vs. runtime state
+
+`s-002-inspect` and `s-005-replay` **commit** their `.milkie/runs/*.jsonl`
+and `.milkie/last-run.txt`. That recorded run is a fixture: replay and the
+HTML report are projections over it, so it has to be frozen and versioned,
+not regenerated on demand. Re-running `record.ts` simply produces a fresh
+run alongside it.
+
+Everything that is genuine runtime state is gitignored: the SQLite working
+state (`state.sqlite*`, ignored for all examples via
+[`examples/.gitignore`](./.gitignore)), and — for `agent-docs-qa`, whose
+runs are live and not fixtures — its `.milkie/runs/` and `.milkie/objects/`.

--- a/examples/agent-docs-qa/.gitignore
+++ b/examples/agent-docs-qa/.gitignore
@@ -1,10 +1,5 @@
-# Runtime state — re-created on demand
-.milkie/state.sqlite
-.milkie/state.sqlite-journal
-.milkie/state.sqlite-wal
-.milkie/state.sqlite-shm
+# Live runs and content-addressed objects — NOT fixtures for this example,
+# so they stay out of git (unlike s-002 / s-005, which commit theirs).
+# Runtime SQLite state is ignored by examples/.gitignore; *.log by the root.
 .milkie/runs/
 .milkie/objects/
-
-# Browser cached state (none today; future-proofing)
-*.log

--- a/examples/s-002-inspect/.gitignore
+++ b/examples/s-002-inspect/.gitignore
@@ -1,6 +1,3 @@
-# Runtime state — re-created on demand, not part of the example
-.milkie/state.sqlite
-.milkie/state.sqlite-journal
-.milkie/state.sqlite-wal
-.milkie/state.sqlite-shm
+# Generated report artifact (re-created by report.sh).
+# Runtime SQLite state is ignored by examples/.gitignore.
 report.html

--- a/examples/s-005-replay/.gitignore
+++ b/examples/s-005-replay/.gitignore
@@ -1,5 +1,0 @@
-# Runtime state — re-created on demand, not part of the example
-.milkie/state.sqlite
-.milkie/state.sqlite-journal
-.milkie/state.sqlite-wal
-.milkie/state.sqlite-shm


### PR DESCRIPTION
Closes #105

## 改动

1. **新增 `examples/README.md`** — 顶层索引：三示例总览表格（演示内容 / 接口 / 是否需要 API key）、推荐阅读顺序，并新增两段说明：
   - *Naming*：`s-00x` 编号是 `docs/stories/` 锚点、`agent-docs-qa` 无对应 story 故无前缀——把命名差异正名为「有意为之」。
   - *Fixtures vs runtime state*：解释为什么 s-002/s-005 提交 `.milkie/runs`（fixture）、agent-docs-qa 的 runs 被忽略（实时产物）。

2. **gitignore 去重** — 新增 `examples/.gitignore` 承载公共 `state.sqlite*`（非锚定名，对所有子示例 `.milkie/` 生效）；各子 `.gitignore` 只留特有项（s-002 → `report.html`，agent-docs-qa → `runs/`+`objects/`），删除已空的 `s-005-replay/.gitignore`。

3. **修正顶层 README** — `README.md` / `README_CN.md` 的 Examples 段原来只列 `s-005` 且误标「无需 API key」，现指向新索引、列全三个并标注各自 API key 需求。

## 不做

命名不改名——详见 #105。

## 验证

`git check-ignore` 确认：三示例 `state.sqlite` 均被忽略、agent-docs-qa `runs/` 被忽略，而 s-002/s-005 的 fixture `runs/*.jsonl` 仍正常跟踪。纯文档 + gitignore 改动，无代码逻辑变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)