### PR TITLE
feat: lineage-driven citation provenance (replaces front-end regex heuristics)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,6 +160,47 @@ writes to Trajectory but **not** to Trace — for an event to be
 replay-visible or appear in event-log–backed UI, it must reach the event
 log too.
 
+### Object
+
+A content-addressable artifact an agent read or produced — a document passage,
+a generated claim, an output blob. An Object is not stored in a side table: it
+exists as one `object.created` Event in the log, which **mints a stable
+`objectId` handle** for some content and tags it with a `type` (from the closed
+vocabulary in `docs/lineage-taxonomy.md`) and locating `meta` (e.g. `{file,
+lineStart, lineEnd}` for a `passage`). The Event's `producerEventId` points back
+to the real Event that produced the content (a `tool.responded` from `read_file`,
+an `llm.responded`, an `agent.returned`). The `objectId` is the only way to refer
+to that content downstream.
+
+*Example:* `read_file(chapter-49, 4-5)` produces a `tool.responded`; an
+`object.created` with `type:'passage'`, `meta:{file, lineStart:4, lineEnd:5}`,
+`producerEventId:<that tool.responded>` mints `obj#1` for those two lines.
+*Not:* the content itself, and not the `tool.responded`. The Object is a typed,
+addressable **handle layer** over content a base Event already produced — it adds
+an id and a type, it does not re-store the bytes. *Not:* agent prose. An Object's
+origin is a tool-call record, never text the agent wrote (`file:26` in an answer
+is a string the agent can fabricate; an `objectId` is a handle the runtime only
+issues after a real read).
+
+### Relation
+
+A typed, directed edge between two Objects, recorded as one `relation.created`
+Event: `{type, fromObjectId, toObjectId, causedByEventId}`, with `type` from the
+closed vocabulary (`cites`, `derives_from`, `supersedes`, `equivalent_to`). Both
+endpoints MUST resolve to `object.created` Events; the edge also carries
+`causedByEventId` onto the trace's causal chain. Objects are nodes, Relations are
+edges, and together they form a **lineage graph** projected from the log — a
+provenance query walks edges (claim ──`cites`──> passage ──`meta`──> `file:line`)
+rather than parsing or string-matching agent text.
+
+*Example:* a `claim` Object「曹操败于火攻」and a `passage` Object (ch-49:4-5) joined
+by a `relation.created` of `type:'cites'` from the claim to the passage.
+*Not:* an edge between Events. Relations connect **Objects** (via `objectId`), not
+raw Events; the `causedByEventId` records which Event triggered the link, separate
+from the `from`/`to` object handles. *Not:* a citation parsed from LLM output —
+producers declare Relations explicitly; the runtime never infers them from text
+(see `docs/lineage-taxonomy.md` and `docs/design/40-lineage-citation-goal.md`).
+
 ### FSM
 
 The finite state machine that structures an agent's control flow: each agent

--- a/docs/design/40-lineage-citation-goal.md
+++ b/docs/design/40-lineage-citation-goal.md
@@ -1,0 +1,192 @@
+# Goal: Lineage 驱动的引用溯源（替代前端正则启发式）
+
+> **一句话目标:** 让 agent-docs-qa 的 citation / provenance **完全由 trace 中的
+> `object.created` / `relation.created` 事件驱动**，彻底删除前端"读心"agent
+> 文本的正则启发式（`CITATION_RE` / `classifySegment` / substring 匹配）。
+>
+> **任务链:** #39 → #37 → #38 → 【新】agent 结构化 cite 产出 → #40
+> （均 Parent: #20）。本文是这条链的北极星，每个 issue 实现时对照此处验收。
+
+---
+
+## 1. 为什么做（问题陈述）
+
+当前 `examples/agent-docs-qa/public/index.html` 用前端正则反推引用：
+
+```
+grep/read_file → agent 看到内容
+              ↓
+agent 生成自由散文，凭记忆写「引文」（引用：file:line）
+              ↑ lossy re-encoding：转简体 / 记错行号 / 合并诗句 / 改标点
+              ↓
+前端 CITATION_RE 解析文本 + 把 quote 拿去 corpus 做 substring 匹配
+              ↑ provenance 误报全部在这里诞生
+```
+
+**根本缺陷:** provenance 是从 agent 的**文本复述**反推的，而文本复述是 agent
+对所读内容的有损重编码。前端在"读心"——事后猜 agent 引用了什么，永远追不上
+文本的各种变形。
+
+我们已经在 #108 用 opencc 繁简归一化 + 全文回退（misattributed）+ 去空白匹配
+堵了三类误报，但那是**打地鼠**：每堵一种变形，下一种（标点）还会冒出来。而且
+这些代码本身就是 #40 标记的**待删债务**——本目标达成时，连同它们一并 burn-down。
+
+## 2. 概念模型：event → object → relation
+
+理解整条链先要分清这三层（**全部都是 trace 里的 event**，区别只是职责）：
+
+```
+event        append-only 流水账的原子记录（llm.requested / tool.responded / …）
+  └─ object.created    也是一种 event：在某条 event 产出的内容上「圈框 + 铸 objectId」
+        producerEventId ──> 指回内容来源（如 read 的 tool.responded）
+        meta            ──> {file, lineStart, lineEnd}（结构化出处，非 agent 文本）
+        └─ relation.created   又是一种 event：在两个 objectId 之间连一条有类型的边
+              from/to ──> 两端都是 objectId（cites: claim → passage）
+              causedByEventId ──> 挂回因果链
+```
+
+- **event** 是地基（一切都是它，append-only、replay-canonical）。
+- **object** 是 event 之上的**句柄层**：把流水账里一段原始内容，提升成有 `id`（不可
+  伪造句柄）、有 `type`（#39 taxonomy）、有定位 `meta` 的可引用实体。
+- **relation** 在 object 之间连边，合成一张 **lineage 图**；provenance 查询 = 在图上
+  沿边走（claim ──cites──> passage ──meta──> file:line），**不在文本上猜**。
+
+> 这套 event/object/relation 概念模型 **ARCHITECTURE.md §Concept Model 现在还没有**
+> （只有 `Event`/`Trace` 等子节，无 `Object`/`Relation`）。补上它正是 **#39** 的职责
+> （见 §6）。本节是 goal 内部的工作定义，最终以 #39 落定的 taxonomy / ARCH 子节为准。
+
+## 3. 设计原则
+
+1. **Producer 显式声明，runtime 记录事件；绝不解析 LLM 文本反推**
+   （#37/#38 的 non-goal 红线）。
+
+2. **引用的不可靠性分两层，分别处理:**
+
+   | 层 | 含义 | 本目标如何处理 |
+   |---|---|---|
+   | 表征层 | agent 怎么*指代*来源（写 `file:26` + 复述引文） | 用 runtime 铸造的 **objectId 句柄**取代 → 造假空间归零 |
+   | 认知层 | agent *判断*"这句是否真基于该来源" | 提供 claim↔object 结构化锚点 → 错误变得**可审计**，交给 verifier/diagnoser 核验（本线不做核验） |
+
+3. **objectId 是不可伪造的句柄（capability-like）:** `file:26` 是 agent 能凭空
+   拼的字符串；`objectId` 是 runtime 在 agent **真读过之后**才发给它的 token。
+   agent 只能"出示"持有的句柄，编不出假出处。这是表征层造假归零的根。
+
+## 4. 北极星验收（End-to-End Definition of Done）
+
+整条链完成时，下列**全部**成立:
+
+- [ ] `index.html` 中**不存在** `CITATION_RE` / `classifySegment` /
+      `hasVerbatimSubstring` / `extractQuotedSnippets`，以及 #108 引入的
+      `normForMatch` / opencc 归一化 / misattributed / 去空白匹配。
+- [ ] citation chip、Sources footer、Provenance tab **全部由
+      `object.created` / `relation.created` 事件投影渲染**，前端零 substring 匹配。
+- [ ] agent prompt **不再要求** agent 在文本里写 `chapter:行号`；引用是
+      结构化声明（见 §6 新 issue）。
+- [ ] Provenance 状态从"匹配置信度代理"（supported/paraphrased/misattributed/
+      tenuous）变为**事实性**两态:有 `cites` 关系且指向真实 read object =
+      **grounded**；无 = **model-generated**。
+- [ ] `Milkie.replay(runId)` 的 cache 序列**不变**，lineage 事件**不引入**
+      任何 live I/O（#37/#38 的硬约束）。
+
+**回归验收（用真实踩过的 case 证明根治）:** 下列三个历史误报场景，在 lineage
+模型下**概念上不可能发生**，因为不再有"匹配"这个动作:
+
+| 历史 case | 旧根因 | lineage 下 |
+|---|---|---|
+| ch-49 行号标错 `:26` | agent 文本里手写错行号 | 出处 = read 工具的真实 range，非笔误 |
+| ch-01 繁简失配 | agent 简体复述 vs 繁体语料 | 引文显示 object 的真实 bytes，不比对文本 |
+| ch-50 跨行诗合并 | agent 合并诗句致 substring 失配 | object 是读取的内容块，无匹配动作 |
+
+## 5. 里程碑（M1 / M2，增量交付）
+
+分两步落地，不必一口气全做。M1 不碰 agent、不赌 LLM 配合，先验证"object 事件能
+驱动 UI"；M2 才是完整目标，风险集中在【新 issue】。
+
+| 里程碑 | 含 issue | 交付 | 不含 |
+|---|---|---|---|
+| **M1 — run 级** | #39 + #37 + #40(footer 部分) | Sources footer「Sourced from chapter-01.txt」由 read 的 `object.created` 事件驱动，**零 agent 改造**，删掉一部分前端正则 | 逐段 provenance |
+| **M2 — 段落级** | #38 + 【新】+ #40(provenance 部分) | 逐 claim 的 `grounded` / `model-generated`，由 `relation.created(cites)` 把 claim 绑到 passage object，**删尽**前端正则 | —— |
+
+**为什么这么切：** M1 的价值是用最小代价(无 agent 改造、不依赖 LLM 配合)证明
+"事件驱动 UI"这条路通，并 burn 掉一部分 #40 债务；M2 才需要 agent 结构化产出
+cites（§6 新 issue），那是整条链风险最高的一环。
+
+## 6. 任务分解与各自验收
+
+> 顺序即依赖序：#38（relation 能力）必须在【新 issue】（用该能力）之前。
+
+### #39 — artifact 类型 taxonomy 定稿（设计 doc，先做，无依赖）
+**DoD:**
+- `docs/lineage-taxonomy.md` 评审通过；object type 含 `passage`、relation type 含
+  `cites`，字段含 `file/lineStart/lineEnd/hash`。
+- **在 ARCHITECTURE.md §Concept Model 新增 `Object` / `Relation` 两个子节定义**
+  （对齐现有 `Event`/`Trace` 子节"定义 + *Not:*"写法）——现在 §Concept Model 只有
+  Event/Trace 等、**无 Object/Relation**，本 issue 负责补上（见 §2）。不是加个链接，
+  是补一等定义。
+- 指出三国 example 的 emit hook 位置（如 corpus `read_file` 处，不要求实现）。
+
+### #37 — `object.created` + tool 关联（依赖 #39；#25 已 done）
+**DoD:**
+- 新增 `EventKind: 'object.created'`，payload 含 `objectId / type / producerEventId
+  / hash? / meta`。
+- `ToolContext`（`src/types/tool.ts:7`，**已经传进 handler**）加 `createObject(...)`
+  方法——往现有接口加方法，**不是新建注入**；`buildToolContext`
+  （`AgentRuntime.ts:358`）是实现处。`producerEventId` 指向真实 `tool.responded`，
+  `hash` 与 #25 的 `outputHash` 对齐。
+- **corpus 工具实质改造（易漏，务必写明）:** `read_file` 现在读整文件、不收行号、
+  不返 id（`corpus-tools.ts:33`）；需改为**支持行号范围** + **tool result 回传
+  objectId**，`grep` 同理。否则 agent 没有可 cite 的精准 passage 句柄。
+- replay cache 序列不变。
+
+### #38 — `relation.created` 事件（依赖 #37/#39；**排在【新】之前**）
+**DoD:** 新增 `EventKind: 'relation.created'`，payload 含 `relationId / type /
+fromObjectId / toObjectId / causedByEventId`；`ToolContext` 加 `createRelation(...)`
+producer API；`from/to` 均可解析到 `object.created`，`causedByEventId` 可解析到生产
+事件；replay 序列不变。本 issue 是**能力**，只需一个最小 producer 满足 acceptance；
+真正的 producer（sanguo-researcher）由下面【新 issue】承载。
+
+### 【新 issue】sanguo-researcher 结构化引用产出（依赖 #37/#38；**当前 gap，风险最高**）
+> 现有 issue 未认领此环:#38 的 acceptance 只要"至少一个 producer 能 emit"
+> （toy 即满足），#40 的 scope 只是前端消费——**没人负责让 agent 真的改造**。
+> 这是整条链成败的关键，必须独立成 issue。
+
+**DoD:**
+- sanguo-researcher 从"单 llm state + 自由文本写 `file:line`"改为**结构化声明
+  cites**:用 #37 回传的 `objectId`，通过 `cite(objectId)` 工具显式产出
+  `relation.created(cites)`。
+- **选型（代码现实决定）:** 走**路线 A — `cite(objectId)` 工具**，复用现有
+  `ctx.createRelation` + 工具调用机制，无需新基建。弱点是 agent 可能漏调，靠 prompt
+  强约束（必要时加"answer 前必须 cite"的 FSM 守卫）。**不走 answer schema**——`src/`
+  当前无 structured output 机制（`responseFormat`/`outputSchema`），schema 路线要从零
+  建基建，列为未来选项。
+- 确立并测试约束:**objectId 由 runtime 铸造、不可伪造**；agent 只能引用收到过的
+  id，无法凭空声明出处（不可伪造性测试）。权衡见 §3。
+
+### #40 — agent-docs-qa 前端正则清算（依赖以上全部，**最终验收**）
+**DoD:** §4 北极星验收的全部勾选项；Sources/Provenance tab 行为不变（但来自
+lineage 事件而非启发式）；删尽 §4 列出的所有正则/匹配代码。
+
+## 7. 不变量与约束
+
+- **不解析文本反推**（贯穿 #37/#38/新 issue/#40）。
+- **objectId 不可伪造**:runtime 铸造，agent 仅持有/出示。
+- **replay determinism 不变**:lineage 事件是记录，不新增 live I/O。
+- **CLI/UI 是投影**:provenance 渲染消费事件投影，不是平行事实源（ARCH invariants）。
+
+## 8. 非目标（明确划界）
+
+- **不做语义核验**:"这段 claim 是否*真的*被 object 支撑"是 LLM 认知层判断，
+  本线只提供锚点，核验交给 verifier / diagnoser（#35/#36）。
+- **不引入 DB / 独立 lineage service**（#37/#38 non-goal）。
+- **不在本线做 reverse index / lineage query**（#41）。
+- **不追求消除认知层错误**:agent 仍可能 cite 错 object；区别是错误从"不可审计
+  的字面失配"变为"可核验的语义错误"。
+
+## 9. 关联
+
+- Parent: #20（Trace substrate gap）
+- 依赖链: #39 → #37 → #38 →【新】→ #40
+- 前置已完成: #25（tool.responded metadata / outputHash）
+- 被本线 burn-down: #108 的前端 provenance 启发式（opencc 归一化 / misattributed /
+  去空白）
+- 下游: #41（reverse index）、#42（lineage UI）、verifier/diagnoser（#35/#36）

--- a/docs/lineage-taxonomy.md
+++ b/docs/lineage-taxonomy.md
@@ -1,0 +1,82 @@
+# Lineage Taxonomy
+
+Controlled vocabulary for `object.created` / `relation.created` events (#37 / #38).
+Without a closed vocabulary every example invents its own `type` strings and
+cross-run lineage queries become meaningless. This document is the contract that
+#37 / #38 implement against, and that #40 (and future lineage consumers) query.
+
+> **Status:** v1, scoped to what citation/provenance needs (`passage` + `cites`).
+> Other types are declared here so the framework is whole, but only the ones
+> marked **v1** must ship in #37/#38.
+
+## Why this is a closed vocabulary
+
+A `type` field that anyone fills freely (`passage` vs `chunk` vs `text`) makes the
+event log unqueryable: "which sources did this run cite?" has no stable predicate
+to match. The vocabulary below is the allowed set; producers MUST use a value from
+it. Adding a value is a deliberate amendment to this doc, not an ad-hoc choice at
+the call site.
+
+## Object types
+
+An **object** is a content-addressable artifact an agent read or produced. The
+`object.created` event mints an `objectId` handle for it (see ARCHITECTURE.md
+§Concept Model → Object). `type` MUST be one of:
+
+| type | v1? | meaning | example (三国) | required `meta` |
+|---|---|---|---|---|
+| `passage` | **v1** | a contiguous slice of a document, with a line range | `read_file(chapter-49, 4-5)` → those two lines | `file`, `lineStart`, `lineEnd` |
+| `file` | — | a whole file as one artifact | the entire `chapter-49.txt` | `file` |
+| `claim` | — | a statement an agent generated | an answer sentence「曹操败于火攻」 | `text` |
+| `artifact-blob` | — | an opaque produced blob (image, json, …) | a generated report | `mime?`, `bytes?` |
+
+**Note on `passage` meta — the whole point of the model:** `lineStart`/`lineEnd`
+come from the **real `read_file` call arguments**, not from text the agent wrote.
+That is why representational drift (繁简 / wrong line number / merged lines) cannot
+occur: the citation's origin is the tool-call record, not the agent's prose.
+
+## Relation types
+
+A **relation** is a typed, directed edge between two objects. The
+`relation.created` event records it (see ARCHITECTURE.md §Concept Model → Relation).
+`type` MUST be one of:
+
+| type | v1? | meaning (`from` → `to`) | example |
+|---|---|---|---|
+| `cites` | **v1** | `from` references / is sourced from `to` | claim「曹操败于火攻」 **cites** passage(ch-49:4-5) |
+| `derives_from` | — | `from` was computed/transformed from `to` | a summary `derives_from` a passage |
+| `supersedes` | — | `from` replaces `to` | a corrected claim `supersedes` an earlier one |
+| `equivalent_to` | — | `from` and `to` are the same artifact under different ids | a re-read passage `equivalent_to` a prior one |
+
+## Field set
+
+Shared object/relation fields (carried in the event payloads, see #37/#38):
+
+- **object.created:** `objectId`, `type` (above), `producerEventId` (the real
+  `tool.responded` / `llm.responded` / `agent.returned` that produced the content),
+  `hash?` (aligns with #25 `outputHash` when alignable), `meta` (type-specific,
+  per the tables above).
+- **relation.created:** `relationId`, `type` (above), `fromObjectId`, `toObjectId`,
+  `causedByEventId`, `meta?`.
+
+**Extension points (forward-compatible with the Context Layer):** `meta` MAY carry
+`tag`, `source-uri`, `version`. These are reserved names; v1 does not require them
+but producers must not repurpose them.
+
+## Emit hook locations (三国 example — indicative, not implemented by #39)
+
+- **`object.created` (passage):** `examples/agent-docs-qa/tools/corpus-tools.ts`
+  `read_file` / `grep` handlers → on `tool.responded`, call `ctx.createObject({ type:
+  'passage', meta: { file, lineStart, lineEnd }, hash: outputHash })` and return the
+  minted `objectId` in the tool result so the agent can later cite it. (#37)
+- **`relation.created` (cites):** the agent declares a citation via a `cite(objectId)`
+  tool, which calls `ctx.createRelation({ type: 'cites', from: <answer claim>, to:
+  <passage objectId> })`. (#38 provides the API; the new sanguo-researcher issue is
+  the real producer.)
+
+## See also
+
+- ARCHITECTURE.md §Concept Model → `Object`, `Relation` (one-line canonical defs).
+- `docs/design/40-lineage-citation-goal.md` (why this exists; the burn-down target).
+- Issues: #39 (this doc), #37 (`object.created`), #38 (`relation.created`), #40
+  (front-end consumes these events).

--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -1,0 +1,111 @@
+import { startServer, stopServer } from '../server'
+import type { Server } from 'http'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../../../src/types/model'
+import type { ObjectCreatedPayload, RelationCreatedPayload, ToolRespondedPayload } from '../../../src/trace/types'
+import { JsonlEventStore } from '../../../src/trace/JsonlEventStore'
+import { canonicalize, contentAddressForCanonicalBytes } from '../../../src/trace/hash'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+class StubGateway implements IModelGateway {
+  constructor(private readonly responses: ModelResponse[]) {}
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const r = this.responses.shift()
+    if (!r) throw new Error('StubGateway exhausted')
+    return r
+  }
+  async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+const text = (s: string): ModelResponse => ({ content: [{ type: 'text', text: s }], toolCalls: [], finishReason: 'end_turn' })
+const toolCall = (name: string, args: unknown, id = 'tc-' + name): ModelResponse => ({ content: [], finishReason: 'tool_use', toolCalls: [{ id, name, input: args }] })
+
+async function postJson(url: string, body: unknown): Promise<{ status: number; body: string }> {
+  const res = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+  return { status: res.status, body: await res.text() }
+}
+
+// Mirrors buildToolContext's content-address of a passage object.
+function passageId(file: string, lineStart: number, lineEnd: number): string {
+  return 'obj:' + contentAddressForCanonicalBytes(canonicalize({ type: 'passage', meta: { file, lineStart, lineEnd }, hash: null }))
+}
+
+describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
+  let server: Server
+  let baseUrl: string
+  let exampleDir: string
+  let runsDir: string
+
+  const start = async (responses: ModelResponse[]) => {
+    exampleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adq-lineage-'))
+    runsDir = path.join(exampleDir, '.milkie', 'runs')
+    fs.mkdirSync(runsDir, { recursive: true })
+    server = await startServer({
+      port: 0, exampleDir,
+      gateway: new StubGateway(responses),
+      agentFile: path.join(__dirname, '..', 'agents', 'sanguo-researcher.md'),
+      corpusRoot: path.join(__dirname, '..', 'corpus'),
+    })
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') throw new Error('no address')
+    baseUrl = `http://localhost:${addr.port}`
+  }
+
+  afterEach(async () => {
+    await stopServer(server)
+    fs.rmSync(exampleDir, { recursive: true, force: true })
+  })
+
+  it('read_file mints a passage object.created; cite mints a claim + cites relation', async () => {
+    const file = 'chapter-49-赤壁借东风.txt'
+    const objId = passageId(file, 4, 5)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 4, lineEnd: 5 }, 'tc-1'),
+      toolCall('cite', { claim: '诸葛亮定计破曹', objectId: objId }, 'tc-2'),
+      text('赤壁之战的结局……'),
+    ])
+
+    const chat = await postJson(`${baseUrl}/chat`, { input: '赤壁之战的结局' })
+    expect(chat.status).toBe(200)
+    const runId = JSON.parse(chat.body).runId as string
+
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    // #37: read_file produced a passage object, anchored to its tool.responded.
+    const passage = events.find(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'passage')
+    expect(passage).toBeTruthy()
+    const pp = passage!.payload as ObjectCreatedPayload
+    expect(pp.objectId).toBe(objId)
+    expect(pp.meta).toMatchObject({ file, lineStart: 4, lineEnd: 5 })
+    const producer = events.find(e => e.id === pp.producerEventId)
+    expect(producer?.type).toBe('tool.responded')
+    expect((producer!.payload as ToolRespondedPayload).artifactRefs).toContain(objId)
+
+    // 新/#38: cite produced a claim object + a cites relation claim → passage.
+    const claim = events.find(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'claim')
+    expect(claim).toBeTruthy()
+    const rel = events.find(e => e.type === 'relation.created')
+    expect(rel).toBeTruthy()
+    const rp = rel!.payload as RelationCreatedPayload
+    expect(rp.type).toBe('cites')
+    expect(rp.toObjectId).toBe(objId)
+    expect(rp.fromObjectId).toBe((claim!.payload as ObjectCreatedPayload).objectId)
+  })
+
+  it('a fabricated objectId still records a cites edge, but it dangles (no matching object.created)', async () => {
+    await start([
+      toolCall('cite', { claim: '编造的引用', objectId: 'obj:fabricated-not-real' }, 'tc-1'),
+      text('answer'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const rel = events.find(e => e.type === 'relation.created')!
+    const toId = (rel.payload as RelationCreatedPayload).toObjectId
+    expect(toId).toBe('obj:fabricated-not-real')
+    // Unforgeable: no object.created mints that id, so the edge resolves to nothing.
+    const resolved = events.some(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).objectId === toId)
+    expect(resolved).toBe(false)
+  })
+})

--- a/examples/agent-docs-qa/agents/sanguo-researcher.md
+++ b/examples/agent-docs-qa/agents/sanguo-researcher.md
@@ -13,9 +13,14 @@ fsm:
 
         工作流程:
         - 用 list_dir({ relPath: "." }) 查看有哪些章节
-        - 用 grep({ pattern: "..." }) 找出相关章节(关键词可以是人名、地名、事件、对白)
-        - 用 read_file({ relPath: "chapter-XX-..." }) 读相关段落
-        - 回答时尽量给出 chapter:行号 形式的引用
+        - 用 grep({ pattern: "..." }) 找出相关章节(关键词可以是人名、地名、事件、对白)。
+          每条 match 带一个 objectId。
+        - 用 read_file({ relPath: "chapter-XX-...", lineStart, lineEnd }) 读相关段落。
+          读尽量窄的行区间,返回里带一个 objectId。
+        - 引用规则(重要):**不要**在正文里写 "(chapter:行号)" 之类的引用标记。
+          对答案里每一条来自原文的陈述,调用
+          cite({ claim: "<这条陈述的原话>", objectId: "<read_file/grep 返回的 objectId>" })
+          来登记来源。objectId 只能用工具真实返回给你的那个——不要自己编造。
 
         重要:当用户对你的回答表达怀疑("你确定吗" / "再确认下" /
         "verify" / "are you sure" / "真的吗" 等),调用
@@ -29,7 +34,7 @@ fsm:
 
         verifier 是一次性加载——同一会话内不要反复 request;如果用户
         再次怀疑、且 verifier 已加载,直接以严格模式重新验证即可。
-      tools: [list_dir, read_file, grep, skill_request]
+      tools: [list_dir, read_file, grep, cite, skill_request]
 model:
   provider: volcengine
   model: doubao-seed-2-0-pro-260215
@@ -41,7 +46,7 @@ skillInstructions:
     你已进入 verifier 模式。
 
     重新读你前一轮回答里引用过的所有原文段落,把每一条陈述分类:
-    - (a) 直接 supported by text:原文措辞与你陈述高度一致,给出 chapter:行号 citation
+    - (a) 直接 supported by text:原文措辞与你陈述高度一致,用 cite({ claim, objectId }) 登记来源
     - (b) inferred from text:基于原文推理得出(明示推理链)
     - (c) unfounded:原文没有支撑,承认错误并更正
 

--- a/examples/agent-docs-qa/package-lock.json
+++ b/examples/agent-docs-qa/package-lock.json
@@ -6,16 +6,7 @@
   "packages": {
     "": {
       "name": "agent-docs-qa-example",
-      "version": "0.0.0",
-      "dependencies": {
-        "opencc-js": "^1.3.1"
-      }
-    },
-    "node_modules/opencc-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/opencc-js/-/opencc-js-1.3.1.tgz",
-      "integrity": "sha512-EyKDnjHNYlxo3Blll0OGH5qcyZBI3YmXpqeDEity/db50A5TFfCdvylrBlTyx1XvlSRUmh2a5AHvSf89h4u87Q==",
-      "license": "MIT"
+      "version": "0.0.0"
     }
   }
 }

--- a/examples/agent-docs-qa/package.json
+++ b/examples/agent-docs-qa/package.json
@@ -5,8 +5,5 @@
   "description": "milkie example — 三国 Q&A agent with skill loading + live trace UI",
   "scripts": {
     "start": "npx tsx server.ts"
-  },
-  "dependencies": {
-    "opencc-js": "^1.3.1"
   }
 }

--- a/examples/agent-docs-qa/public/index.html
+++ b/examples/agent-docs-qa/public/index.html
@@ -422,8 +422,6 @@
     .ap-seg.s-supported   .ap-seg-label { color: #2da14b }
     .ap-seg.s-paraphrased { border-color: #d4a017; background: #fdf8ec }
     .ap-seg.s-paraphrased .ap-seg-label { color: #b8860b }
-    .ap-seg.s-misattributed { border-color: #3b6fd4; background: #eef3fc }
-    .ap-seg.s-misattributed .ap-seg-label { color: #2c54a8 }
     .ap-seg.s-tenuous     { border-color: #e07a00; background: #fdf2e6 }
     .ap-seg.s-tenuous     .ap-seg-label { color: #c66800 }
     .ap-seg.s-unsupported { border-color: #d93030; background: #fdf0f0 }
@@ -443,7 +441,6 @@
     .ap-prov-legend .lg-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin: 0 4px 0 8px; vertical-align: middle }
     .ap-prov-legend .lg-dot.s-supported   { background: #2da14b }
     .ap-prov-legend .lg-dot.s-paraphrased { background: #d4a017 }
-    .ap-prov-legend .lg-dot.s-misattributed { background: #3b6fd4 }
     .ap-prov-legend .lg-dot.s-tenuous     { background: #e07a00 }
     .ap-prov-legend .lg-dot.s-unsupported { background: #d93030 }
     .ap-prov-legend .lg-dot.s-unverified  { background: #b0b0b5 }
@@ -479,10 +476,6 @@
     }
     #payload-detail:empty { display: none }
   </style>
-  <!-- OpenCC 繁→简 bundle. Loaded before the inline script (which runs at end
-       of <body>) so provenance matching can normalize 繁/简 before comparing
-       model quotes to the traditional corpus. Degrades to exact match if absent. -->
-  <script src="/vendor/opencc-t2cn.js"></script>
 </head>
 <body>
   <header>
@@ -585,22 +578,6 @@
       history.replaceState(null, '', url.toString())
     }
 
-    // ─── Citation parsing ──────────────────────────────────────────────
-    // The sanguo-researcher agent emits citations in several shapes —
-    // the prompt asks for "chapter:行号" but the model picks its own
-    // syntactic frame. Observed in the wild:
-    //   (引用：chapter-01-桃园三结义.txt:33)
-    //   (引用：`chapter-01-桃园三结义.txt:33-34`)
-    //   （引用：chapter-01-桃园三结义.txt:34）            ← fullwidth parens
-    //   > **chapter-01-桃园三结义.txt:33**     殺到…    ← markdown blockquote header
-    //   请看 chapter-01-桃园三结义.txt:42 这行         ← bare inline mention
-    //
-    // The regex anchors on the corpus file shape (chapter-NN-…txt) and
-    // optionally eats the surrounding decoration: any of "(引用：…)",
-    // markdown bold "**…**", backticks, or full-/half-width parens.
-    // Captures: 1 = relative file path, 2 = line number ("N" or "N-M").
-    const CITATION_RE = /(?:[（(]\s*引用\s*[：:]\s*)?\*{0,2}`?(chapter-[^\s`)）"<>:*]+\.txt):(\d+(?:-\d+)?)`?\*{0,2}(?:\s*[)）])?/g
-
     // Minimal markdown subset the agent actually emits: bold (**), inline
     // code (`), and blockquote line prefix (> ). We deliberately do NOT
     // pull in a general-purpose markdown parser because (a) the corpus
@@ -663,42 +640,19 @@
     //   2. Escape the (still placeholder-bearing) text.
     //   3. Apply markdown — placeholders are inert.
     //   4. Substitute placeholders back with the final <sup> chip HTML.
-    function renderAssistantHtml(text) {
-      const cites = []
-      let cursor  = 0
-      let buffer  = ''
-      let m
-      CITATION_RE.lastIndex = 0
-      while ((m = CITATION_RE.exec(text)) !== null) {
-        const [match, file, line] = m
-        buffer += text.slice(cursor, m.index)
-        const n = cites.length + 1
-        cites.push({ file, line })
-        //  is non-printable and never appears in plain prose; it
-        // survives esc() because the regex below doesn't touch it.
-        buffer += `CITE${n}`
-        cursor = m.index + match.length
-      }
-      buffer += text.slice(cursor)
-
-      let html = renderMinimalMarkdown(esc(buffer))
-      html = html.replace(/CITE(\d+)/g, (_match, idx) => {
-        const c = cites[parseInt(idx, 10) - 1]
-        return `<sup class="cite" data-n="${esc(idx)}" data-file="${esc(c.file)}" data-line="${esc(c.line)}">${esc(idx)}</sup>`
-      })
-
+    // #40: the answer prose carries NO citation markers (the agent declares
+    // sources via the cite tool). Body is plain markdown; the Sources footer is
+    // derived from the run's lineage events (object.created/relation.created),
+    // not parsed from text. See buildLineage() in the Provenance section.
+    function renderAssistantHtml(text, runId) {
+      const html = renderMinimalMarkdown(esc(text))
       let footer = ''
-      if (cites.length > 0) {
-        const seenFiles = new Set()
-        const fileList  = []
-        for (const c of cites) {
-          if (!seenFiles.has(c.file)) {
-            seenFiles.add(c.file)
-            fileList.push(c.file)
-          }
+      if (runId) {
+        const { files } = buildLineage(runId)
+        if (files.length > 0) {
+          const srcChips = files.map(f => `<span class="src">${esc(f)}</span>`).join(' ')
+          footer = `<div class="sources-footer">Sourced from ${files.length} file${files.length > 1 ? 's' : ''} · ${srcChips}</div>`
         }
-        const srcChips = fileList.map(f => `<span class="src">${esc(f)}</span>`).join(' ')
-        footer = `<div class="sources-footer">Sourced from ${fileList.length} file${fileList.length > 1 ? 's' : ''} · ${srcChips}</div>`
       }
       return `<div class="body">${html}</div>${footer}`
     }
@@ -754,28 +708,24 @@
     // Extract citations from an assistant message DOM node — we already
     // rendered them as <sup class="cite" data-file data-line>, so reuse
     // those rather than re-running the regex.
-    function citationsFromMessage(msgEl) {
-      const cites = []
-      msgEl.querySelectorAll('.cite').forEach(el => {
-        cites.push({ file: el.dataset.file, line: el.dataset.line })
-      })
-      return cites
-    }
-
-    function renderSourcesTab(runId, msgEl) {
-      const cites = msgEl ? citationsFromMessage(msgEl) : []
-      if (cites.length === 0) {
-        return `<div class="ap-empty">本回答未引用任何来源。</div>`
+    // #40: Sources tab from lineage events (was: parsed from .cite chips, now
+    // deleted). Group the cited passages by file with their real line ranges.
+    function renderSourcesTab(runId) {
+      const { citations } = buildLineage(runId)
+      const passages = citations.filter(c => c.passage && c.passage.meta)
+      if (passages.length === 0) {
+        return `<div class="ap-empty">本回答未引用任何来源（agent 未调用 cite）。</div>`
       }
-      // Group line ranges by file, preserving first-seen order.
       const byFile = new Map()
-      for (const c of cites) {
-        if (!byFile.has(c.file)) byFile.set(c.file, [])
-        byFile.get(c.file).push(c.line)
+      for (const c of passages) {
+        const m = c.passage.meta
+        const range = m.lineStart === m.lineEnd ? `${m.lineStart}` : `${m.lineStart}-${m.lineEnd}`
+        if (!byFile.has(m.file)) byFile.set(m.file, [])
+        if (!byFile.get(m.file).includes(range)) byFile.get(m.file).push(range)
       }
       let html = ''
-      for (const [file, lines] of byFile) {
-        const lineChips = lines.map(l => `<span class="ln">行${esc(l)}</span>`).join('')
+      for (const [file, ranges] of byFile) {
+        const lineChips = ranges.map(l => `<span class="ln">行${esc(l)}</span>`).join('')
         html += `<div class="ap-source-file">
           <div class="sf-path">${esc(file)}</div>
           <div class="sf-lines">${lineChips}</div>
@@ -1052,261 +1002,76 @@
       return String(output).slice(0, 40)
     }
 
-    // ─── Provenance ────────────────────────────────────────────────────
-    // Split the answer into paragraph segments and pull out the citation
-    // markers in each. The segment "text" is the paragraph with citation
-    // markers stripped, so the comparison against source content is
-    // against the prose only (citation markers are formatting noise).
-    // Strip markdown markers so a provenance segment reads as clean prose.
-    // The corpus has no markdown, so removing #/-/1./> and **/` also keeps
-    // verbatim-substring matching (classifySegment) from being defeated by
-    // formatting noise. Quote extraction uses seg.raw, so it's unaffected.
-    function stripMarkdownMarkers(s) {
-      return s.split('\n')
-        .map(line => line.replace(/^\s*(?:#{1,6}\s+|[-*]\s+|\d+\.\s+|>\s?)/, ''))
-        .join('\n')
-        .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
-        .replace(/`([^`\n]+)`/g, '$1')
-        .trim()
-    }
-
-    function segmentAnswer(text) {
-      const paragraphs = text.split(/\n\n+/).map(p => p.trim()).filter(Boolean)
-      return paragraphs.map(p => {
-        const cites = []
-        const stripped = p.replace(CITATION_RE, (_match, file, line) => {
-          cites.push({ file, line })
-          return ''
-        }).trim()
-        return { text: stripMarkdownMarkers(stripped), raw: p, citations: cites }
-      })
-    }
-
-    // Extract verbatim quoted snippets from a segment. The agent wraps
-    // direct quotes in any of: straight " ", Chinese curly “ ”
-    // (U+201C/U+201D), Chinese corner 「 」 (U+300C/U+300D), or Chinese
-    // double corner 『 』 (U+300E/U+300F). The negated set inside the
-    // capture group lists all of these so a greedy match stops at the
-    // first closing quote of any flavor.
-    function extractQuotedSnippets(text) {
-      const QUOTE_CHARS = '"“”「」『』'
-      const re = new RegExp(`[${QUOTE_CHARS}]([^${QUOTE_CHARS}]+)[${QUOTE_CHARS}]`, 'g')
-      const out = []
-      let m
-      while ((m = re.exec(text)) !== null) {
-        if (m[1].trim().length > 0) out.push(m[1].trim())
+    // ─── Provenance (lineage-driven, #40) ──────────────────────────────
+    // Citations come from the run's object.created / relation.created events
+    // (the agent declared them via the cite tool); we never parse answer prose.
+    // A `cites` relation links a claim object → a passage object whose meta is
+    // {file, lineStart, lineEnd} from the real read_file call — so 出处 is fact,
+    // not text the model wrote. No substring matching, no 繁简, no line tolerance.
+    function buildLineage(runId) {
+      const events = eventsByRunId.get(runId) || []
+      const objects = new Map()
+      for (const e of events) {
+        if (e.type === 'object.created') objects.set(e.payload.objectId, e.payload)
       }
-      return out
-    }
-
-    // LLM-emitted citation line numbers are often off by 1-2 lines —
-    // models eyeball line counts from tool output and round, or pick the
-    // line containing the chapter break rather than the line containing
-    // the prose. To make Provenance verification robust to this, we
-    // widen every cited range by ±2 lines before fetching. Display still
-    // shows the agent's original line numbers.
-    const LINE_TOLERANCE = 2
-    function expandedLineRange(line) {
-      const m = line.match(/^(\d+)(?:-(\d+))?$/)
-      if (!m) return line
-      const start = Math.max(1, parseInt(m[1], 10) - LINE_TOLERANCE)
-      const end   = (m[2] ? parseInt(m[2], 10) : parseInt(m[1], 10)) + LINE_TOLERANCE
-      return `${start}-${end}`
-    }
-    function verifyCacheKey(file, line) {
-      return `${file}::${expandedLineRange(line)}`
-    }
-
-    async function fetchVerifySlice(file, line) {
-      const key = verifyCacheKey(file, line)
-      if (sourceCache.has(key)) return sourceCache.get(key)
-      const expanded = expandedLineRange(line)
-      try {
-        const r = await fetch(`/source/${encodeURIComponent(file)}?lines=${encodeURIComponent(expanded)}`)
-        if (r.status !== 200) {
-          sourceCache.set(key, null)
-          return null
+      const citations = []
+      for (const e of events) {
+        if (e.type === 'relation.created' && e.payload.type === 'cites') {
+          const claim = objects.get(e.payload.fromObjectId)
+          const passage = objects.get(e.payload.toObjectId)
+          citations.push({
+            claimText:  claim && claim.meta ? claim.meta.text : null,
+            passage:    passage || null,
+            toObjectId: e.payload.toObjectId,
+          })
         }
-        const j = await r.json()
-        sourceCache.set(key, j)
-        return j
-      } catch {
-        sourceCache.set(key, null)
-        return null
       }
+      const files = [...new Set(citations.filter(c => c.passage && c.passage.meta && c.passage.meta.file).map(c => c.passage.meta.file))]
+      return { objects, citations, files }
     }
 
-    // Fetch a cited file in full (no lines query → server returns whole file).
-    // Used as the fallback when a quote is absent from the cited line slice:
-    // if it exists anywhere in the file, the line number is wrong, not the
-    // quote. Cached under a distinct key so it coexists with line slices.
-    async function fetchSourceFull(file) {
-      const key = `${file}::__full__`
+    // Fetch the exact cited lines for display. file:line is a fact from the
+    // object's meta (the real read range), so no tolerance / normalization.
+    async function fetchLines(file, lineStart, lineEnd) {
+      const key = `${file}:${lineStart}-${lineEnd}`
       if (sourceCache.has(key)) return sourceCache.get(key)
       try {
-        const r = await fetch(`/source/${encodeURIComponent(file)}`)
-        if (r.status !== 200) { sourceCache.set(key, null); return null }
-        const j = await r.json()
-        sourceCache.set(key, j)
-        return j
-      } catch {
-        sourceCache.set(key, null)
-        return null
-      }
-    }
-
-    // Substring match between a segment and its source. Catches the
-    // "verbatim copy without quote wrappers" case — e.g. when the agent
-    // pastes a passage into a markdown blockquote (`> …`) or just inlines
-    // it bare. Markdown formatting chars are stripped before comparison
-    // since the source corpus has none of them.
-    // Traditional/simplified normalizer for provenance matching. The corpus is
-    // traditional; the model may quote in either script. Normalizing both sides
-    // to simplified before comparison turns a 繁/简 字形 difference into a match
-    // instead of a false "not found". Degrades to identity if the OpenCC bundle
-    // didn't load (matching reverts to the pre-fix exact comparison).
-    const _t2s = (typeof OpenCC !== 'undefined' && OpenCC.Converter)
-      ? OpenCC.Converter({ from: 't', to: 'cn' })
-      : (s => s)
-    // Also strip whitespace (incl. \n and 全角空格 U+3000): the model often
-    // merges a quote spanning several source lines into one run, dropping the
-    // line breaks the corpus has between them. Comparing 字-only turns that
-    // into a match — for 引文核对 a quote means the characters, not the layout.
-    function normForMatch(s) {
-      try { return _t2s(s).replace(/[\s　]/g, '') }
-      catch { return s.replace(/[\s　]/g, '') }
-    }
-
-    const SUBSTRING_MIN_LEN = 20
-    function hasVerbatimSubstring(segText, sourceText) {
-      const strip = s => normForMatch(s.replace(/[*`>]/g, ''))
-      const seg = strip(segText)
-      const src = strip(sourceText)
-      if (seg.length < SUBSTRING_MIN_LEN) return false
-      for (let i = 0; i + SUBSTRING_MIN_LEN <= seg.length; i++) {
-        if (src.includes(seg.slice(i, i + SUBSTRING_MIN_LEN))) return true
-      }
-      return false
-    }
-
-    // Decide a segment's provenance state from its citations and the
-    // (already-fetched) source slices. Rules in priority order:
-    //   1. No citation → unsupported (red).
-    //   2. Citation but every source fetch failed → unverified (gray).
-    //   3. Citation + explicit quoted snippets (curly/corner quotes):
-    //        all snippets in source → supported (green)
-    //        any snippet absent → tenuous (orange, possible hallucination)
-    //   4. Citation + a ≥20-char contiguous substring of source appears
-    //      in the segment (verbatim copy without quote wrappers, e.g.
-    //      a markdown blockquote header followed by pasted text) →
-    //      supported (green).
-    //   5. Otherwise (citation, summary in own words) → paraphrased (yellow).
-    function classifySegment(seg, sourceSlices, fullTexts) {
-      if (seg.citations.length === 0) return { state: 'unsupported' }
-      const okSlices = sourceSlices.filter(s => s != null)
-      if (okSlices.length === 0) return { state: 'unverified' }
-      const allSrc = okSlices.map(s => s.content).join('\n')
-
-      const quotes = extractQuotedSnippets(seg.raw)
-      if (quotes.length > 0) {
-        // Normalize 繁/简 on both sides before matching (corpus is traditional;
-        // the model may quote in simplified). The arrays keep the ORIGINAL
-        // quote text for display — only the comparison is normalized.
-        const allSrcN = normForMatch(allSrc)
-        const notInSlice = quotes.filter(q => !allSrcN.includes(normForMatch(q)))
-        if (notInSlice.length === 0) return { state: 'supported', quotes }
-        // Some quotes aren't at the cited lines. Before flagging a possible
-        // hallucination, check the FULL text of the cited files — models often
-        // get the quote verbatim right but the line number wrong (the same
-        // off-by-N that LINE_TOLERANCE only partly covers). A quote that lives
-        // in the cited file but not at the cited line is misattribution, not
-        // fabrication; only a quote absent from the whole file is tenuous.
-        const allFullN = normForMatch((fullTexts || []).filter(t => t != null).map(t => t.content).join('\n'))
-        const trulyMissing = notInSlice.filter(q => !allFullN.includes(normForMatch(q)))
-        if (trulyMissing.length > 0) return { state: 'tenuous', quotes, missingQuotes: trulyMissing }
-        return { state: 'misattributed', quotes, misattributedQuotes: notInSlice }
-      }
-
-      if (hasVerbatimSubstring(seg.text, allSrc)) {
-        return { state: 'supported' }
-      }
-      return { state: 'paraphrased' }
-    }
-
-    const STATE_LABELS = {
-      supported:     '有来源直接支撑',
-      paraphrased:   '引用转述（无逐字引文）',
-      misattributed: '引文属实，但标注行号不符',
-      tenuous:       '引文在来源中未找到——需核实',
-      unsupported:   '无来源引用——模型生成',
-      unverified:    '已引用但来源无法获取',
+        const r = await fetch(`/source/${encodeURIComponent(file)}?lines=${encodeURIComponent(lineStart + '-' + lineEnd)}`)
+        const j = r.status === 200 ? await r.json() : null
+        sourceCache.set(key, j); return j
+      } catch { sourceCache.set(key, null); return null }
     }
 
     async function renderProvenanceTab(runId) {
-      const text = assistantTextByRunId.get(runId)
-      if (!text) return `<div class="ap-empty">答案文本不可用。</div>`
-      const segments = segmentAnswer(text)
-      if (segments.length === 0) return `<div class="ap-empty">答案为空。</div>`
-
-      // Resolve all unique (file, line) pairs in parallel, populating
-      // sourceCache as a side effect. Subsequent renders are zero-fetch.
-      // We dedupe across the expanded line ranges so two adjacent
-      // citations (e.g. :33 and :33-34) hit the server only once each
-      // after tolerance expansion.
-      const toFetch = []
-      const seen    = new Set()
-      for (const s of segments) {
-        for (const c of s.citations) {
-          const k = verifyCacheKey(c.file, c.line)
-          if (seen.has(k)) continue
-          seen.add(k)
-          toFetch.push([c.file, c.line])
-        }
+      const { citations } = buildLineage(runId)
+      if (citations.length === 0) {
+        return `<div class="ap-empty">本回答没有登记任何来源（agent 未调用 cite）。</div>`
       }
-      await Promise.all(toFetch.map(([file, line]) => fetchVerifySlice(file, line)))
-
-      // Also fetch each cited file in full, for the misattribution fallback in
-      // classifySegment (quote present in the file but not at the cited line).
-      const citedFiles = [...new Set(segments.flatMap(s => s.citations.map(c => c.file)))]
-      await Promise.all(citedFiles.map(f => fetchSourceFull(f)))
-
+      await Promise.all(citations.map(c => (c.passage && c.passage.meta)
+        ? fetchLines(c.passage.meta.file, c.passage.meta.lineStart, c.passage.meta.lineEnd)
+        : Promise.resolve(null)))
       const legend = `
         <div class="ap-prov-legend">
-          <span class="lg-dot s-supported"></span>有支撑
-          <span class="lg-dot s-paraphrased"></span>转述
-          <span class="lg-dot s-misattributed"></span>行号不符
-          <span class="lg-dot s-tenuous"></span>存疑
-          <span class="lg-dot s-unsupported"></span>无来源
-          <span class="lg-dot s-unverified"></span>未核实
+          <span class="lg-dot s-supported"></span>有来源（grounded）
+          <span class="lg-dot s-unsupported"></span>来源失效（dangling）
         </div>`
-
-      const segHtml = segments.map(seg => {
-        const slices = seg.citations.map(c => sourceCache.get(verifyCacheKey(c.file, c.line)))
-        const segFiles = [...new Set(seg.citations.map(c => c.file))]
-        const fulls = segFiles.map(f => sourceCache.get(`${f}::__full__`))
-        const klass = classifySegment(seg, slices, fulls)
-        const label = STATE_LABELS[klass.state]
-        const citeMeta = seg.citations.length > 0
-          ? seg.citations.map(c => `${c.file}:${c.line}`).join(' · ')
-          : ''
-        let quoteBlock = ''
-        if (klass.state === 'supported' && klass.quotes && klass.quotes.length > 0) {
-          quoteBlock = `<span class="ap-seg-quote">${esc(klass.quotes.join('\n'))}</span>`
-        } else if (klass.state === 'misattributed' && klass.misattributedQuotes && klass.misattributedQuotes.length > 0) {
-          quoteBlock = `<span class="ap-seg-quote">引文属实，但不在标注行（已在引用文件中找到）：\n${esc(klass.misattributedQuotes.join('\n'))}</span>`
-        } else if (klass.state === 'tenuous' && klass.missingQuotes && klass.missingQuotes.length > 0) {
-          quoteBlock = `<span class="ap-seg-quote">来源中缺失：\n${esc(klass.missingQuotes.join('\n'))}</span>`
-        }
+      const rows = citations.map(c => {
+        const meta = c.passage && c.passage.meta
+        const grounded = !!meta
+        const slice = grounded ? sourceCache.get(`${meta.file}:${meta.lineStart}-${meta.lineEnd}`) : null
+        const cite = grounded
+          ? `${meta.file}:${meta.lineStart}${meta.lineEnd !== meta.lineStart ? '-' + meta.lineEnd : ''}`
+          : c.toObjectId
+        const label = grounded ? '有来源直接支撑' : '来源失效——objectId 未对应任何已读段落'
         return `
-          <div class="ap-seg s-${klass.state}">
-            <span class="ap-seg-text">${esc(seg.text)}</span>
+          <div class="ap-seg s-${grounded ? 'supported' : 'unsupported'}">
+            <span class="ap-seg-text">${esc(c.claimText || '(未记录陈述)')}</span>
             <span class="ap-seg-label">${esc(label)}</span>
-            ${citeMeta ? `<span class="ap-seg-meta">${esc(citeMeta)}</span>` : ''}
-            ${quoteBlock}
+            <span class="ap-seg-meta">${esc(cite)}</span>
+            ${slice ? `<span class="ap-seg-quote">${esc(slice.content)}</span>` : ''}
           </div>`
       }).join('')
-
-      return legend + segHtml
+      return legend + rows
     }
 
     // Find the user input that started this run, so the audit panel can
@@ -1799,7 +1564,7 @@
         const trigger = runId
           ? `<span class="audit-trigger" data-run-id="${esc(runId)}">查看审计 ▾</span>`
           : ''
-        div.innerHTML = `<div class="speaker">${roleLabel(role)}</div>${renderAssistantHtml(text)}${trigger}`
+        div.innerHTML = `<div class="speaker">${roleLabel(role)}</div>${renderAssistantHtml(text, runId)}${trigger}`
         if (runId) {
           div.dataset.runId = runId
           assistantTextByRunId.set(runId, text)

--- a/examples/agent-docs-qa/server.ts
+++ b/examples/agent-docs-qa/server.ts
@@ -387,20 +387,6 @@ export async function startServer(config: ServerConfig): Promise<Server> {
         )
       }
 
-      // Serve the OpenCC traditional→simplified UMD bundle to the browser so
-      // provenance matching can normalize 繁/简 before comparing model quotes
-      // to the (traditional) corpus. Fixed path; no user input touches the FS.
-      if (req.method === 'GET' && route === '/vendor/opencc-t2cn.js') {
-        const f = path.join(__dirname, 'node_modules', 'opencc-js', 'dist', 'umd', 't2cn.js')
-        try {
-          const js = await fs.readFile(f, 'utf-8')
-          res.writeHead(200, { 'content-type': 'application/javascript; charset=utf-8' }).end(js)
-        } catch {
-          res.writeHead(404).end()
-        }
-        return
-      }
-
       if (req.method === 'GET' && (route === '/' || route === '/index.html')) {
         return serveStatic(res, path.join(state.publicDir, 'index.html'))
       }

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import path from 'path'
+import type { ToolContext } from '../../../src/types/tool.js'
 
 /**
  * Build a sandboxed set of corpus tools rooted at `corpusRoot`.
@@ -30,20 +31,31 @@ export function makeCorpusTools(corpusRoot: string) {
     }
   }
 
-  async function read_file(input: unknown): Promise<unknown> {
-    const { relPath } = input as { relPath: string }
+  // #37: read a file (optionally a line range) and mint a `passage` object for
+  // exactly what was returned. The objectId is the citable handle — the agent
+  // cites it later via cite(objectId), so provenance no longer parses prose.
+  async function read_file(input: unknown, ctx?: ToolContext): Promise<unknown> {
+    const { relPath, lineStart, lineEnd } = input as { relPath: string; lineStart?: number; lineEnd?: number }
     const abs = resolveInsideRoot(relPath)
-    const content = await fs.readFile(abs, 'utf-8')
-    const lines = content.trimEnd().split('\n').length
-    return { content, lines }
+    const full = await fs.readFile(abs, 'utf-8')
+    // Strip a single trailing newline so a file ending in "\n" doesn't report a
+    // phantom extra line; 1-based line numbers then match grep's view.
+    const allLines = full.replace(/\n$/, '').split('\n')
+    const start = typeof lineStart === 'number' && lineStart >= 1 ? lineStart : 1
+    const end   = typeof lineEnd === 'number' && lineEnd >= start ? Math.min(lineEnd, allLines.length) : allLines.length
+    const content = allLines.slice(start - 1, end).join('\n')
+    const obj = ctx?.createObject?.({ type: 'passage', meta: { file: relPath, lineStart: start, lineEnd: end } })
+    // objectId + locator FIRST so they survive the truncate(2000) result strategy
+    // even when `content` is a long whole-file read — the agent must see objectId to cite.
+    return { ...(obj ? { objectId: obj.objectId } : {}), lineStart: start, lineEnd: end, lines: allLines.length, content }
   }
 
-  async function grep(input: unknown): Promise<unknown> {
+  async function grep(input: unknown, ctx?: ToolContext): Promise<unknown> {
     const { pattern, caseInsensitive = false } = input as { pattern: string; caseInsensitive?: boolean }
     const maxMatches = 50
     const flags = caseInsensitive ? 'gi' : 'g'
     const re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
-    const matches: Array<{ file: string; line: number; text: string }> = []
+    const matches: Array<{ file: string; line: number; text: string; objectId?: string }> = []
 
     async function walk(dir: string): Promise<void> {
       if (matches.length >= maxMatches) return
@@ -58,10 +70,14 @@ export function makeCorpusTools(corpusRoot: string) {
           const lines = content.split('\n')
           for (let i = 0; i < lines.length; i++) {
             if (re.test(lines[i]!)) {
+              const file = path.relative(root, abs)
+              // #37: each hit is a citable single-line passage object.
+              const obj = ctx?.createObject?.({ type: 'passage', meta: { file, lineStart: i + 1, lineEnd: i + 1 } })
               matches.push({
-                file: path.relative(root, abs),
+                file,
                 line: i + 1,
                 text: lines[i]!.slice(0, 200),
+                ...(obj ? { objectId: obj.objectId } : {}),
               })
               if (matches.length >= maxMatches) break
             }
@@ -76,7 +92,21 @@ export function makeCorpusTools(corpusRoot: string) {
     }
   }
 
-  return { list_dir, read_file, grep }
+  // 【新 issue】#38 producer: the agent declares "this claim is sourced from that
+  // passage". Mints a `claim` object and a `cites` relation claim → passage. The
+  // objectId must be one the agent received from read_file/grep — a fabricated id
+  // produces a dangling edge the UI renders as ungrounded (content-addressed ids
+  // can't be guessed). Replaces the old "(chapter:line)" prose convention.
+  async function cite(input: unknown, ctx?: ToolContext): Promise<unknown> {
+    const { claim, objectId } = input as { claim: string; objectId: string }
+    const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
+    if (claimObj && ctx?.createRelation) {
+      ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })
+    }
+    return { ok: true, claimId: claimObj?.objectId, cites: objectId }
+  }
+
+  return { list_dir, read_file, grep, cite }
 }
 
 /**
@@ -99,10 +129,14 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
     },
     {
       name:        'read_file',
-      description: 'Read full content of a file within the corpus.',
+      description: 'Read a file within the corpus, optionally a line range. Returns { objectId, lineStart, lineEnd, lines, content }. Read a tight line range, then pass the returned objectId to the cite tool to source a claim — never write "(chapter:line)" in prose.',
       inputSchema: {
         type: 'object',
-        properties: { relPath: { type: 'string', description: 'Path relative to corpus root.' } },
+        properties: {
+          relPath:   { type: 'string', description: 'Path relative to corpus root.' },
+          lineStart: { type: 'number', description: 'Optional 1-based first line (inclusive). Omit to read the whole file.' },
+          lineEnd:   { type: 'number', description: 'Optional 1-based last line (inclusive).' },
+        },
         required: ['relPath'],
       },
       handler: t.read_file,
@@ -114,7 +148,7 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
     },
     {
       name:        'grep',
-      description: 'Search for a pattern across all files in the corpus. Returns up to 50 matches.',
+      description: 'Search for a pattern across all files in the corpus. Returns up to 50 matches, each { file, line, text, objectId }. Pass a match objectId to the cite tool to source a claim from that line.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -124,6 +158,19 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
         required: ['pattern'],
       },
       handler: t.grep,
+    },
+    {
+      name:        'cite',
+      description: 'Record that a specific claim in your answer is sourced from a passage. Pass the exact claim text and the objectId returned by read_file or grep. Call once per cited claim. Do NOT write "(chapter:line)" in prose — cite via this tool instead.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          claim:    { type: 'string', description: 'The exact statement in your answer this source supports.' },
+          objectId: { type: 'string', description: 'objectId of the passage (from read_file/grep) that supports the claim.' },
+        },
+        required: ['claim', 'objectId'],
+      },
+      handler: t.cite,
     },
   ]
 }

--- a/src/__tests__/RecordingIOPort.lineage.test.ts
+++ b/src/__tests__/RecordingIOPort.lineage.test.ts
@@ -1,0 +1,88 @@
+import { RecordingIOPort } from '../trace/RecordingIOPort'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { IIOPort } from '../runtime/IOPort'
+import type { ModelRequest, ModelResponse } from '../types/model'
+import type { LineageBuffer, ObjectCreatedPayload, RelationCreatedPayload, ToolRespondedPayload } from '../trace/types'
+
+class ExecInnerPort implements IIOPort {
+  private nextClock = 1000
+  private nextUuid  = 1
+  async invokeLLM(_req: ModelRequest): Promise<ModelResponse> {
+    return { content: [], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async invokeTool(_n: string, _i: unknown, execute: () => Promise<unknown>): Promise<unknown> {
+    return execute()
+  }
+  now():  number { return this.nextClock++ }
+  uuid(): string { return `uuid-${this.nextUuid++}` }
+}
+
+describe('RecordingIOPort — lineage flush (#37/#38)', () => {
+  it('emits object.created after tool.responded with producerEventId resolving to it', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+    // The handler "declares" a passage object mid-execute (what ctx.createObject does).
+    const lineage: LineageBuffer = { objects: [], relations: [] }
+    await port.invokeTool('read_file', { relPath: 'ch.txt' }, async () => {
+      lineage.objects.push({ objectId: 'obj:abc', type: 'passage', meta: { file: 'ch.txt', lineStart: 4, lineEnd: 5 } })
+      return { content: '诗两行', objectId: 'obj:abc' }
+    }, { lineage })
+
+    const events = await store.readByRunId('r1')
+    const respIdx = events.findIndex(e => e.type === 'tool.responded')
+    const objIdx  = events.findIndex(e => e.type === 'object.created')
+    expect(respIdx).toBeGreaterThanOrEqual(0)
+    // object.created comes AFTER tool.responded.
+    expect(objIdx).toBeGreaterThan(respIdx)
+
+    const resp = events[respIdx]!.payload as ToolRespondedPayload
+    const obj  = events[objIdx]!.payload as ObjectCreatedPayload
+    // producerEventId points at the tool.responded event id.
+    expect(obj.producerEventId).toBe(events[respIdx]!.id)
+    expect(obj).toMatchObject({ objectId: 'obj:abc', type: 'passage', meta: { file: 'ch.txt', lineStart: 4, lineEnd: 5 } })
+    // tool.responded lists the produced object via artifactRefs.
+    expect(resp.artifactRefs).toEqual(['obj:abc'])
+  })
+
+  it('emits relation.created with from/to and causedByEventId at the tool.responded', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+    const lineage: LineageBuffer = { objects: [], relations: [] }
+    await port.invokeTool('cite', { objectId: 'obj:p' }, async () => {
+      lineage.relations.push({ relationId: 'rel:1', type: 'cites', fromObjectId: 'obj:claim', toObjectId: 'obj:p' })
+      return { ok: true }
+    }, { lineage })
+
+    const events = await store.readByRunId('r1')
+    const resp = events.find(e => e.type === 'tool.responded')!
+    const rel  = events.find(e => e.type === 'relation.created')!
+    const p = rel.payload as RelationCreatedPayload
+    expect(p).toMatchObject({ type: 'cites', fromObjectId: 'obj:claim', toObjectId: 'obj:p' })
+    expect(p.causedByEventId).toBe(resp.id)
+  })
+
+  it('records nothing when no lineage buffer is passed (back-compat)', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+    await port.invokeTool('t', {}, async () => 'x')
+    const events = await store.readByRunId('r1')
+    expect(events.some(e => e.type === 'object.created')).toBe(false)
+    const resp = events.find(e => e.type === 'tool.responded')!.payload as ToolRespondedPayload
+    expect(resp.artifactRefs).toBeUndefined()
+  })
+
+  it('does not emit object.created on the error branch (no output, no objects)', async () => {
+    const store = new MemoryEventStore()
+    const port  = new RecordingIOPort(new ExecInnerPort(), store, 'r1')
+    const lineage: LineageBuffer = { objects: [], relations: [] }
+    await expect(
+      port.invokeTool('read_file', {}, async () => {
+        // even if something got pushed before throwing, the error branch skips flush
+        lineage.objects.push({ objectId: 'obj:x', type: 'passage' })
+        throw new Error('boom')
+      }, { lineage })
+    ).rejects.toThrow('boom')
+    const events = await store.readByRunId('r1')
+    expect(events.some(e => e.type === 'object.created')).toBe(false)
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -38,7 +38,7 @@ import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
 import type { CausalCursor } from '../trace/CausalCursor.js'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
 import type { Region } from '../context/Region.js'
-import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation, ToolEmittedPayload } from '../trace/types.js'
+import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation, ToolEmittedPayload, LineageBuffer } from '../trace/types.js'
 
 export type MakeChildPort = (
   childRunId:  string,
@@ -355,14 +355,37 @@ export class AgentRuntime {
     )
   }
 
-  private buildToolContext(emitFn: (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void): ToolContext {
-    return {
+  private buildToolContext(
+    emitFn: (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void,
+    lineage?: LineageBuffer,
+  ): ToolContext {
+    const ctx: ToolContext = {
       workingMemory: this.memory,
       agentFactory:  this.factory,
       stateStore:    this.stateStore,
       emit:          emitFn,
       requestSkill:  (name: string, scope?: 'turn' | 'session') => this.requestSkill(name, scope),
     }
+    // #37/#38: only wire lineage when a sink is present (LLM-state tool calls go
+    // through ioPort.invokeTool, which drains the buffer). objectId/relationId are
+    // content-addressed so they are identical in record and replay.
+    if (lineage) {
+      ctx.createObject = (spec) => {
+        const objectId = 'obj:' + contentAddressForCanonicalBytes(
+          canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }),
+        )
+        lineage.objects.push({ objectId, type: spec.type, ...(spec.hash ? { hash: spec.hash } : {}), ...(spec.meta ? { meta: spec.meta } : {}) })
+        return { objectId }
+      }
+      ctx.createRelation = (spec) => {
+        const relationId = 'rel:' + contentAddressForCanonicalBytes(
+          canonicalize({ type: spec.type, from: spec.fromObjectId, to: spec.toObjectId }),
+        )
+        lineage.relations.push({ relationId, type: spec.type, fromObjectId: spec.fromObjectId, toObjectId: spec.toObjectId, ...(spec.meta ? { meta: spec.meta } : {}) })
+        return { relationId }
+      }
+    }
+    return ctx
   }
 
   private requestSkill(name: string, scope: 'turn' | 'session' = 'turn'): { requested: string; status: string; version?: string; scope?: 'turn' | 'session' } {
@@ -1171,6 +1194,9 @@ export class AgentRuntime {
     // the winner makes replay reproduce one transition regardless of how a
     // parallel batch's emits race.
     let capturedEmit: { name: string; payload?: unknown; guard?: GuardEvaluation[] } | undefined
+    // #37/#38: handler declares objects/relations into this buffer; RecordingIOPort
+    // drains it into object.created/relation.created right after tool.responded.
+    const lineage: LineageBuffer = { objects: [], relations: [] }
     const ctx = this.buildToolContext((event, payload, guard) => {
       const hadPending = this.fsm.hasPendingEvent()
       this.fsm.emitEvent(event, payload, guard)
@@ -1181,7 +1207,7 @@ export class AgentRuntime {
           ...(guard ? { guard: Array.isArray(guard) ? guard : [guard] } : {}),
         }
       }
-    })
+    }, lineage)
 
     const maxRetries = 3
 
@@ -1201,7 +1227,7 @@ export class AgentRuntime {
           call.name,
           call.input,
           () => this.registry.execute(call.name, call.input, ctx),
-          { toolCallId: call.id },  // #81: stamp the LLM tool_use id onto tool.requested/responded for pairing
+          { toolCallId: call.id, lineage },  // #81 pairing id; #37/#38 lineage sink
         )
         span.attributes['output'] = output
         // SPIKE(#73): event-source tool WM side-effects so replay reconstructs them.

--- a/src/runtime/IOPort.ts
+++ b/src/runtime/IOPort.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import type { ModelRequest, ModelResponse, ModelEvent, IModelGateway } from '../types/model.js'
+import type { LineageBuffer } from '../trace/types.js'
 import { aggregateStream } from '../gateway/StreamAggregator.js'
 
 /**
@@ -50,12 +51,16 @@ export interface IIOPort {
    *
    * `opts.toolCallId` (#81) is the LLM-side tool_use id; recording IOPorts stamp
    * it onto tool.requested / tool.responded so external consumers can pair them.
+   *
+   * `opts.lineage` (#37/#38) is a buffer the handler fills via ctx.createObject /
+   * ctx.createRelation; recording IOPorts drain it into object.created /
+   * relation.created events right after tool.responded.
    */
   invokeTool(
     toolName: string,
     input: unknown,
     execute: () => Promise<unknown>,
-    opts?: { toolCallId?: string },
+    opts?: { toolCallId?: string; lineage?: LineageBuffer },
   ): Promise<unknown>
 
   /** Current epoch milliseconds. Replacement for direct `Date.now()`. */

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -465,9 +465,9 @@ export class Milkie {
           throw err
         }
       },
-      async invokeTool(name, input, execute) {
+      async invokeTool(name, input, execute, opts) {
         try {
-          return await ioPort.invokeTool(name, input, execute)
+          return await ioPort.invokeTool(name, input, execute, opts)
         } catch (err) {
           if (err instanceof ReplayDivergenceError) divergenceError = err
           throw err

--- a/src/trace/RecordingIOPort.ts
+++ b/src/trace/RecordingIOPort.ts
@@ -10,6 +10,9 @@ import type {
   AgentRunCompletedPayload,
   ClockReadPayload,
   UuidGeneratedPayload,
+  ObjectCreatedPayload,
+  RelationCreatedPayload,
+  LineageBuffer,
 } from './types.js'
 import { hashModelRequest, hashToolCall, canonicalize, contentAddressForCanonicalBytes } from './hash.js'
 import type { ITraceObjectStore } from './TraceObjectStore.js'
@@ -187,11 +190,43 @@ export class RecordingIOPort implements IIOPort {
     return response
   }
 
+  /**
+   * #37/#38: drain the lineage buffer the handler filled, as object.created /
+   * relation.created events anchored to the just-written tool.responded
+   * (`producerEventId` / `causedByEventId` = respEventId). Each event's own id is
+   * infrastructure bookkeeping (inner.uuid), like the nondet flush above.
+   */
+  private async flushLineage(lineage: LineageBuffer | undefined, producerEventId: string): Promise<void> {
+    if (!lineage) return
+    for (const o of lineage.objects) {
+      await this.store.append({
+        id:        this.inner.uuid(),
+        runId:     this.runId,
+        type:      'object.created',
+        actor:     this.actor,
+        causedBy:  producerEventId,
+        timestamp: this.inner.now(),
+        payload:   { objectId: o.objectId, type: o.type, producerEventId, ...(o.hash ? { hash: o.hash } : {}), ...(o.meta ? { meta: o.meta } : {}) } satisfies ObjectCreatedPayload,
+      })
+    }
+    for (const r of lineage.relations) {
+      await this.store.append({
+        id:        this.inner.uuid(),
+        runId:     this.runId,
+        type:      'relation.created',
+        actor:     this.actor,
+        causedBy:  producerEventId,
+        timestamp: this.inner.now(),
+        payload:   { relationId: r.relationId, type: r.type, fromObjectId: r.fromObjectId, toObjectId: r.toObjectId, causedByEventId: producerEventId, ...(r.meta ? { meta: r.meta } : {}) } satisfies RelationCreatedPayload,
+      })
+    }
+  }
+
   async invokeTool(
     toolName: string,
     input: unknown,
     execute: () => Promise<unknown>,
-    opts?: { toolCallId?: string },
+    opts?: { toolCallId?: string; lineage?: LineageBuffer },
   ): Promise<unknown> {
     await this.flushPendingNondet()
     const requestHash = hashToolCall(toolName, input)
@@ -214,6 +249,9 @@ export class RecordingIOPort implements IIOPort {
     try {
       const output = await this.inner.invokeTool(toolName, input, execute, opts)
       const meta = await this.outputMetadata(output)
+      // #37: the handler may have declared objects during execute; list their ids
+      // on tool.responded (artifactRefs) and emit object.created/relation.created.
+      const artifactRefs = opts?.lineage?.objects.map(o => o.objectId)
       const respEventId = this.inner.uuid()
       await this.store.append({
         id:        respEventId,
@@ -222,8 +260,9 @@ export class RecordingIOPort implements IIOPort {
         actor:     this.actor,
         causedBy:  reqEventId,
         timestamp: this.inner.now(),
-        payload:   { toolName, ...idField, status: 'ok', output, requestHash, ...meta } satisfies ToolRespondedPayload,
+        payload:   { toolName, ...idField, status: 'ok', output, requestHash, ...meta, ...(artifactRefs && artifactRefs.length ? { artifactRefs } : {}) } satisfies ToolRespondedPayload,
       })
+      await this.flushLineage(opts?.lineage, respEventId)
       // tool.responded is a turn terminator for the next llm.requested (edge 2).
       // Under a parallel tool batch, several tool.responded race to write this; the
       // last-completed wins. That is intentional and harmless: any of the batch's

--- a/src/trace/ReplayingIOPort.ts
+++ b/src/trace/ReplayingIOPort.ts
@@ -1,5 +1,6 @@
 import type { IIOPort } from '../runtime/IOPort.js'
 import type { ModelRequest, ModelResponse, ModelEvent } from '../types/model.js'
+import type { LineageBuffer } from './types.js'
 import { CacheIndex, CacheIndexEmptyError } from './CacheIndex.js'
 import { hashModelRequest, hashToolCall } from './hash.js'
 import { ReplayDivergenceError } from './ReplayDivergenceError.js'
@@ -39,7 +40,11 @@ export class ReplayingIOPort implements IIOPort {
     toolName: string,
     input: unknown,
     _execute: () => Promise<unknown>,
+    _opts?: { toolCallId?: string; lineage?: LineageBuffer },
   ): Promise<unknown> {
+    // Replay serves cached output and never runs the handler, so no lineage is
+    // declared and `_opts.lineage` stays empty — object.created/relation.created
+    // are not re-emitted (the original run's log already has them).
     const hash = hashToolCall(toolName, input)
     try {
       return this.cache.consumeTool(hash)

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -26,6 +26,8 @@ export type EventKind =
   | 'wm.mutated'
   | 'tool.emitted'
   | 'agent.checkpoint'
+  | 'object.created'
+  | 'relation.created'
 
 export interface Event<P = unknown> {
   id: string
@@ -250,6 +252,77 @@ export interface FsmTransitionPayload {
   guardEvaluations?: GuardEvaluation[]
 }
 
+// ---- Lineage payloads (#37 / #38; vocabulary in docs/lineage-taxonomy.md) ----
+
+/** Object types — closed vocabulary (#39). v1 ships `passage`. */
+export type ObjectType = 'passage' | 'file' | 'claim' | 'artifact-blob'
+
+/** Relation types — closed vocabulary (#39). v1 ships `cites`. */
+export type RelationType = 'cites' | 'derives_from' | 'supersedes' | 'equivalent_to'
+
+/**
+ * #37: a content-addressable artifact an agent read or produced. Mints a stable
+ * `objectId` handle (content-addressed → identical across record/replay). Recorded
+ * by RecordingIOPort right after the producing `tool.responded`; replay does not
+ * re-run the handler, so this is NOT re-emitted on replay (the cached tool output
+ * already carries the id). Pure lineage metadata — does not touch the cache/replay
+ * sequence.
+ */
+export interface ObjectCreatedPayload {
+  objectId: string
+  type:     ObjectType
+  /** The real event that produced the content (e.g. the `tool.responded`). */
+  producerEventId: string
+  /** Aligns with the producer's `outputHash` (#25) when alignable. */
+  hash?:    string
+  /** Type-specific locator, e.g. {file, lineStart, lineEnd} for a passage. */
+  meta?:    Record<string, unknown>
+}
+
+/**
+ * #38: a typed, directed edge between two Objects (by objectId). Producer declares
+ * it explicitly (e.g. a `cite` tool); the runtime never infers it from LLM text.
+ */
+export interface RelationCreatedPayload {
+  relationId: string
+  type:       RelationType
+  fromObjectId: string
+  toObjectId:   string
+  /** The event that triggered the link (onto the causal chain). */
+  causedByEventId: string
+  meta?:      Record<string, unknown>
+}
+
+// ---- Lineage buffer (declared during a tool call, flushed by RecordingIOPort) ----
+
+/** A createObject declaration, buffered during a tool call. */
+export interface PendingObject {
+  objectId: string
+  type:     ObjectType
+  hash?:    string
+  meta?:    Record<string, unknown>
+}
+
+/** A createRelation declaration, buffered during a tool call (#38). */
+export interface PendingRelation {
+  relationId:   string
+  type:         RelationType
+  fromObjectId: string
+  toObjectId:   string
+  meta?:        Record<string, unknown>
+}
+
+/**
+ * Per-tool-call sink for lineage declarations. `ctx.createObject` /
+ * `ctx.createRelation` push here during the handler; RecordingIOPort drains it
+ * right after appending `tool.responded` (so `producerEventId` / `causedByEventId`
+ * resolve to that event). On replay the handler never runs → buffer stays empty.
+ */
+export interface LineageBuffer {
+  objects:   PendingObject[]
+  relations: PendingRelation[]
+}
+
 // ---- Typed event aliases ----
 
 export type LlmRequestedEvent       = Event<LlmRequestedPayload>       & { type: 'llm.requested' }
@@ -269,6 +342,8 @@ export type FsmTransitionEvent     = Event<FsmTransitionPayload>     & { type: '
 export type ToolEmittedEvent       = Event<ToolEmittedPayload>       & { type: 'tool.emitted' }
 export type SkillLoadedEvent       = Event<SkillLifecyclePayload>    & { type: 'skill.loaded' }
 export type SkillUnloadedEvent     = Event<SkillLifecyclePayload>    & { type: 'skill.unloaded' }
+export type ObjectCreatedEvent     = Event<ObjectCreatedPayload>     & { type: 'object.created' }
+export type RelationCreatedEvent   = Event<RelationCreatedPayload>   & { type: 'relation.created' }
 
 export type AnyEvent =
   | LlmRequestedEvent
@@ -288,3 +363,5 @@ export type AnyEvent =
   | ToolEmittedEvent
   | SkillLoadedEvent
   | SkillUnloadedEvent
+  | ObjectCreatedEvent
+  | RelationCreatedEvent

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -2,7 +2,7 @@ import type { JSONSchema } from './common.js'
 import type { WorkingMemory } from '../store/WorkingMemory.js'
 import type { IStateStore } from './store.js'
 import type { AgentFactory } from '../runtime/AgentFactory.js'
-import type { GuardEvaluation } from '../trace/types.js'
+import type { GuardEvaluation, ObjectType, RelationType } from '../trace/types.js'
 
 export interface ToolContext {
   workingMemory: WorkingMemory
@@ -10,6 +10,20 @@ export interface ToolContext {
   stateStore:    IStateStore
   emit:          (event: string, payload?: unknown, guard?: GuardEvaluation | GuardEvaluation[]) => void
   requestSkill?: (name: string, scope?: 'turn' | 'session') => { requested: string; status: string; version?: string; scope?: 'turn' | 'session' }
+  /**
+   * #37: declare a content-addressable object (a passage read, a claim produced).
+   * Returns a stable `objectId` handle (content-addressed → identical across
+   * record/replay) the handler should surface in its result so the agent can later
+   * cite it. Runtime records an `object.created` event after this tool's
+   * `tool.responded`. Present only when the runtime wired a lineage sink.
+   */
+  createObject?:   (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) => { objectId: string }
+  /**
+   * #38: declare a typed edge between two objects (e.g. a claim `cites` a passage).
+   * Both ids must be objectIds minted by createObject. Runtime records a
+   * `relation.created` event after `tool.responded`.
+   */
+  createRelation?: (spec: { type: RelationType; fromObjectId: string; toObjectId: string; meta?: Record<string, unknown> }) => { relationId: string }
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
Closes #39
Closes #37
Closes #38
Closes #111
Closes #40

实现 `docs/design/40-lineage-citation-goal.md` 整条任务链:把 agent-docs-qa 的 citation/provenance 从「前端正则反推 agent 文本 + substring 匹配」彻底换成「由 `object.created` / `relation.created` 事件驱动」。这是一个连贯 epic(强依赖,#40 离开 #37/#38 跑不起来),故单 PR、内部按 issue 切 4 个 commit。

## 设计

引用的不可靠性分两层。**表征层**(agent 怎么*指代*来源)用 runtime 铸造的 `objectId` 句柄取代 `file:line` 字符串——agent 只能出示读过的句柄、编不出假出处,造假空间归零。**认知层**(agent *判断*某句是否真基于某来源)用结构化 cite 声明给出可审计锚点(交给 verifier/diagnoser,本线不做核验)。详见 ARCHITECTURE.md §Concept Model 新增的 `Object`/`Relation` 定义。

## 改动(按 commit)

1. **#39** — `docs/lineage-taxonomy.md`(受控词表 passage/cites + 字段)+ ARCH §Concept Model 新增 Object/Relation 一等定义 + goal doc。
2. **#37/#38 core** — `object.created`/`relation.created` EventKind + `ToolContext.createObject`/`createRelation`(内容寻址 id,replay 稳定);`RecordingIOPort` 在 `tool.responded` 后 flush 缓冲、盖 `artifactRefs`。**replay 安全**:replay 不重跑 handler→不重发,纯元数据、cache 序列零改动。
3. **#37 example + #111** — corpus `read_file` 支持行号区间 + 回传 objectId,`grep` 每条 match 带 objectId;`cite` 工具(mint claim object + cites relation);sanguo-researcher 改为结构化 cite。
4. **#40** — 删尽 `CITATION_RE`/`classifySegment`/`hasVerbatimSubstring`/`extractQuotedSnippets`/`segmentAnswer` + #108 的 opencc 归一化/misattributed/去空白;citation/Sources/Provenance 改由事件投影,状态 grounded/dangling;移除 `/vendor/opencc-t2cn.js` 路由 + `opencc-js` 依赖。

## 根因消除

三类历史误报(繁简 / 行号标错 / 跨行合并)在本模型下**结构上不可能发生**——因为不再有任何文本比对。

## 验证

- `tsc --noEmit` clean;核心 src **518/518**;example **59/59**(含新增 `RecordingIOPort.lineage` 4 例 + 端到端 `lineage` 2 例)。
- **真实浏览器复验**(真实 doubao):正文 markdown、Sources footer、来源/执行/溯源/归因 四 tab、诊断按钮(面板保持 open,#108 回归点)、多轮——全部通过,零 JS 错误。复验中发现并修复一个回归:来源 tab 原读已删的 `.cite` chip,已改为读 lineage 事件。
- 不可伪造性测试:cite 到伪造 id → 悬空边(无对应 object.created)。

## 已知边界(非本线目标)

- 语义核验(claim 是否*真被* object 支撑)交给 verifier/diagnoser(#35/#36)。
- doubao 倾向读整文件(行1-63)而非窄区间;lineage 如实记录,想更精准可在 prompt 加约束。
- 答案偶现 doubao thinking-token 泄漏(`</think_...>`),pre-existing,与本线无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)