### PR TITLE
chore(agent-docs-qa): 清理旧 cite 死代码 + sliceLines 重构

### DIFF
--- a/examples/agent-docs-qa/public/index.html
+++ b/examples/agent-docs-qa/public/index.html
@@ -105,33 +105,11 @@
     .msg.assistant .body h6.md-h { font-size: 1em }
     .msg.assistant .body .md-list { margin: .25em 0; padding-left: 1.5em }
     .msg.assistant .body .md-list li { margin: .15em 0 }
-    .cite {
-      display: inline-block; cursor: pointer; user-select: none;
-      color: var(--cite-fg); background: var(--cite-bg); border-radius: 4px;
-      padding: 0 4px; margin: 0 1px; font-size: 0.72em; font-weight: 600;
-      vertical-align: super; line-height: 1.4;
-    }
-    .cite:hover { background: #e1d5ff }
     #chat-input { display: flex; padding: 14px 20px; border-top: 1px solid var(--border); gap: 8px; background: var(--panel) }
     #chat-input input { flex: 1; padding: 9px 13px; font: inherit; border: 1px solid var(--border); border-radius: 6px }
     #chat-input input:disabled { background: #f5f5f7; color: var(--muted) }
     #chat-input button { padding: 9px 18px; background: var(--accent); color: white; border: none; border-radius: 6px; cursor: pointer; font: inherit }
     #chat-input button:disabled { opacity: 0.5; cursor: not-allowed }
-
-    /* ── Citation popover (anchored, dismissable) ───────────────────── */
-    #cite-popover {
-      position: absolute; z-index: 100; max-width: 320px;
-      background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
-      box-shadow: 0 8px 24px rgba(0,0,0,0.12); padding: 12px 14px;
-      font-size: 13px; line-height: 1.5; display: none;
-    }
-    #cite-popover.open { display: block }
-    #cite-popover .cp-source {
-      font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px;
-      color: var(--text); word-break: break-all;
-    }
-    #cite-popover .cp-line { color: var(--muted); margin-top: 4px; font-size: 11px }
-    #cite-popover .cp-hint { color: var(--muted); margin-top: 8px; font-size: 11px; font-style: italic }
 
     /* ── Audit panel (Layer 2: per-message decision audit) ──────────── */
     #audit-panel {
@@ -502,7 +480,6 @@
       <div id="payload-detail"></div>
     </section>
   </main>
-  <div id="cite-popover" role="dialog" aria-label="引用来源"></div>
   <aside id="audit-panel" role="dialog" aria-label="决策审计">
     <div class="ap-header">
       <div class="ap-title">这个答案是怎么来的</div>
@@ -535,10 +512,6 @@
     // describes), or null if closed. Used to toggle re-clicks.
     let auditAnchorRunId    = null
     let auditActiveTab      = 'sources'
-    // Raw assistant text per runId, kept so the Provenance tab can re-
-    // segment the answer rather than parse it back out of the rendered
-    // DOM (which has already been esc()'d and citation-substituted).
-    const assistantTextByRunId = new Map()
     // file+lineRange → fetched source slice, so opening Provenance for a
     // message with 10 citations doesn't hit the server 10 times if the
     // same source is referenced multiple times.
@@ -556,7 +529,6 @@
     const $tl      = document.getElementById('trace-timeline')
     const $detail  = document.getElementById('payload-detail')
     const $traceHd = document.getElementById('trace-header')
-    const $popover = document.getElementById('cite-popover')
     const $audit   = document.getElementById('audit-panel')
     const $auditTitle = $audit.querySelector('.ap-title')
     const $auditBody  = $audit.querySelector('.ap-body')
@@ -657,59 +629,9 @@
       return `<div class="body">${html}</div>${footer}`
     }
 
-    // ─── Citation popover ──────────────────────────────────────────────
-    function showCitePopover(citeEl) {
-      const file = citeEl.dataset.file
-      const line = citeEl.dataset.line
-      $popover.innerHTML =
-        `<div class="cp-source">${esc(file)}</div>` +
-        `<div class="cp-line">第 ${esc(line)} 行</div>` +
-        `<div class="cp-hint">来源片段预览将在后续更新中提供。</div>`
-      // Position below the chip, clamped to viewport.
-      const rect = citeEl.getBoundingClientRect()
-      $popover.classList.add('open')
-      const pw = $popover.offsetWidth
-      const ph = $popover.offsetHeight
-      const vw = document.documentElement.clientWidth
-      let left = rect.left + window.scrollX
-      if (left + pw > vw - 8) left = vw - pw - 8
-      if (left < 8) left = 8
-      let top = rect.bottom + window.scrollY + 6
-      // If popover would overflow viewport bottom, flip above the chip.
-      if (rect.bottom + ph + 14 > window.innerHeight) {
-        top = rect.top + window.scrollY - ph - 6
-      }
-      $popover.style.left = `${left}px`
-      $popover.style.top  = `${top}px`
-    }
-    function hideCitePopover() {
-      $popover.classList.remove('open')
-    }
-    document.addEventListener('click', (ev) => {
-      const target = ev.target
-      if (target instanceof HTMLElement && target.classList.contains('cite')) {
-        ev.stopPropagation()
-        // Re-clicking the same chip toggles closed.
-        if ($popover.classList.contains('open') && $popover.dataset.anchor === target.dataset.n + ':' + target.dataset.file) {
-          hideCitePopover()
-          return
-        }
-        $popover.dataset.anchor = target.dataset.n + ':' + target.dataset.file
-        showCitePopover(target)
-        return
-      }
-      // Click outside popover dismisses it.
-      if (!$popover.contains(target)) hideCitePopover()
-    })
-    window.addEventListener('resize', hideCitePopover)
-    window.addEventListener('scroll', hideCitePopover, true)
-
     // ─── Audit panel ───────────────────────────────────────────────────
-    // Extract citations from an assistant message DOM node — we already
-    // rendered them as <sup class="cite" data-file data-line>, so reuse
-    // those rather than re-running the regex.
-    // #40: Sources tab from lineage events (was: parsed from .cite chips, now
-    // deleted). Group the cited passages by file with their real line ranges.
+    // #40: Sources tab from lineage events (object.created/relation.created).
+    // Group the cited passages by file with their real line ranges.
     function renderSourcesTab(runId) {
       const { citations } = buildLineage(runId)
       const passages = citations.filter(c => c.passage && c.passage.meta)
@@ -1410,7 +1332,6 @@
       if (!document.contains(target)) return
       if ($audit.contains(target)) return
       if (target.classList.contains('audit-trigger')) return
-      if (target.classList.contains('cite')) return
       closeAudit()
     })
 
@@ -1453,9 +1374,7 @@
       if (eventSource) { eventSource.close(); eventSource = null }
       seenEventIds = new Set()
       eventsByRunId = new Map()
-      assistantTextByRunId.clear()
       sourceCache.clear()
-      hideCitePopover()
       closeAudit()
       removePendingBubble()
     }
@@ -1567,7 +1486,6 @@
         div.innerHTML = `<div class="speaker">${roleLabel(role)}</div>${renderAssistantHtml(text, runId)}${trigger}`
         if (runId) {
           div.dataset.runId = runId
-          assistantTextByRunId.set(runId, text)
         }
       } else {
         div.innerHTML = `<div class="speaker">${roleLabel(role)}</div>${esc(text)}`

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -3,6 +3,26 @@ import path from 'path'
 import type { ToolContext } from '../../../src/types/tool.js'
 
 /**
+ * Split file text into lines, dropping the single trailing newline a POSIX file
+ * conventionally ends with — otherwise "a\nb\n".split('\n') yields a phantom
+ * empty last element and the line count is off by one. After this, line N (1-based)
+ * is `lines[N-1]`, and read_file / grep share the same line numbering.
+ */
+function splitLines(text: string): string[] {
+  return text.replace(/\n$/, '').split('\n')
+}
+
+/**
+ * Join lines for the 1-based **inclusive** range [start, end] (both ends kept).
+ * `slice` is 0-based and half-open [a, b): line `start` is index `start-1`, and
+ * line `end` is index `end-1` but slice's exclusive upper bound wants `end`.
+ * Caller is responsible for clamping start/end into range.
+ */
+function sliceLines(lines: string[], start: number, end: number): string {
+  return lines.slice(start - 1, end).join('\n')
+}
+
+/**
  * Build a sandboxed set of corpus tools rooted at `corpusRoot`.
  * Every tool resolves user-provided relPath against corpusRoot, then
  * verifies the resolved absolute path is still inside corpusRoot
@@ -37,13 +57,10 @@ export function makeCorpusTools(corpusRoot: string) {
   async function read_file(input: unknown, ctx?: ToolContext): Promise<unknown> {
     const { relPath, lineStart, lineEnd } = input as { relPath: string; lineStart?: number; lineEnd?: number }
     const abs = resolveInsideRoot(relPath)
-    const full = await fs.readFile(abs, 'utf-8')
-    // Strip a single trailing newline so a file ending in "\n" doesn't report a
-    // phantom extra line; 1-based line numbers then match grep's view.
-    const allLines = full.replace(/\n$/, '').split('\n')
+    const allLines = splitLines(await fs.readFile(abs, 'utf-8'))
     const start = typeof lineStart === 'number' && lineStart >= 1 ? lineStart : 1
     const end   = typeof lineEnd === 'number' && lineEnd >= start ? Math.min(lineEnd, allLines.length) : allLines.length
-    const content = allLines.slice(start - 1, end).join('\n')
+    const content = sliceLines(allLines, start, end)
     const obj = ctx?.createObject?.({ type: 'passage', meta: { file: relPath, lineStart: start, lineEnd: end } })
     // objectId + locator FIRST so they survive the truncate(2000) result strategy
     // even when `content` is a long whole-file read — the agent must see objectId to cite.
@@ -66,8 +83,7 @@ export function makeCorpusTools(corpusRoot: string) {
         if (e.isDirectory()) {
           await walk(abs)
         } else if (e.isFile()) {
-          const content = await fs.readFile(abs, 'utf-8')
-          const lines = content.split('\n')
+          const lines = splitLines(await fs.readFile(abs, 'utf-8'))
           for (let i = 0; i < lines.length; i++) {
             if (re.test(lines[i]!)) {
               const file = path.relative(root, abs)


### PR DESCRIPTION
Closes #114

#40 把前端引用渲染改为 lineage 事件驱动后的收尾。

## 改动
1. **死代码清理**:旧引用 chip/popover 体系已无产出方,移除残骸——`.cite`/`#cite-popover` CSS+DOM、`$popover`、`showCitePopover`/`hideCitePopover` + handler、`assistantTextByRunId`、死的 `.cite` 判断 + 过时注释。
2. **sliceLines 重构**:read_file 的裸边界算术抽成自解释的 `splitLines`/`sliceLines`;grep 同步用 `splitLines` 统一行号。纯重构,行为不变。

## 验证
core 518/518、example 59/59、浏览器四 tab + grounded 溯源零真实 JS 错误(仅 favicon 404 噪音)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)