### PR TITLE
feat(#113 P1): per-run objectId registry + cite fail-fast

### DIFF
--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -90,9 +90,13 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     expect(rp.type).toBe('cites')
     expect(rp.toObjectId).toBe(objId)
     expect(rp.fromObjectId).toBe((claim!.payload as ObjectCreatedPayload).objectId)
+
+    // P1: a real cited objectId passes the registry check → cite reports ok:true.
+    const okCite = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'cite')!
+    expect((okCite.payload as ToolRespondedPayload).output).toMatchObject({ ok: true })
   })
 
-  it('a fabricated objectId still records a cites edge, but it dangles (no matching object.created)', async () => {
+  it('P1 fail-fast: cite with a fabricated objectId → ok:false, NO relation/claim recorded', async () => {
     await start([
       toolCall('cite', { claim: '编造的引用', objectId: 'obj:fabricated-not-real' }, 'tc-1'),
       text('answer'),
@@ -101,11 +105,60 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     const runId = JSON.parse(chat.body).runId as string
     const events = await new JsonlEventStore(runsDir).readByRunId(runId)
 
-    const rel = events.find(e => e.type === 'relation.created')!
-    const toId = (rel.payload as RelationCreatedPayload).toObjectId
-    expect(toId).toBe('obj:fabricated-not-real')
-    // Unforgeable: no object.created mints that id, so the edge resolves to nothing.
-    const resolved = events.some(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).objectId === toId)
-    expect(resolved).toBe(false)
+    // Fail-fast bailed before declaring anything: no cites edge, no claim object.
+    expect(events.some(e => e.type === 'relation.created')).toBe(false)
+    expect(events.some(e => e.type === 'object.created')).toBe(false)
+    // The structured error rides back on cite's tool.responded so the model can self-correct.
+    const citeResp = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'cite')!
+    const out = (citeResp.payload as ToolRespondedPayload).output as { ok: boolean; error?: string }
+    expect(out.ok).toBe(false)
+    expect(out.error).toMatch(/不存在|objectId/)
+  })
+
+  it('P1: the registry is run-level — an id minted in one call resolves in a later cite', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const idA = passageId(file, 1, 5)
+    const idB = passageId(file, 10, 15)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 1, lineEnd: 5 }, 'tc-1'),
+      toolCall('read_file', { relPath: file, lineStart: 10, lineEnd: 15 }, 'tc-2'),
+      toolCall('cite', { claim: 'A 段', objectId: idA }, 'tc-3'),  // minted 2 calls earlier
+      toolCall('cite', { claim: 'B 段', objectId: idB }, 'tc-4'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const cites = events.filter(e => e.type === 'relation.created')
+    expect(cites.length).toBe(2)
+    expect(cites.map(e => (e.payload as RelationCreatedPayload).toObjectId).sort()).toEqual([idA, idB].sort())
+    const citeOks = events
+      .filter(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'cite')
+      .map(e => (e.payload as ToolRespondedPayload).output as { ok: boolean })
+    expect(citeOks.length).toBe(2)
+    expect(citeOks.every(o => o.ok)).toBe(true)
+  })
+
+  it('P1: a run mixing cite ok + fail-fast replays deterministically (registry is record-only)', async () => {
+    const file = 'chapter-49-赤壁借东风.txt'
+    const okId = passageId(file, 4, 5)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 4, lineEnd: 5 }, 'tc-1'),
+      toolCall('cite', { claim: '真引用', objectId: okId }, 'tc-2'),       // ok
+      toolCall('cite', { claim: '假引用', objectId: 'obj:fake' }, 'tc-3'), // fail-fast
+      text('赤壁之战的结局……'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: '赤壁' })
+    const runId = JSON.parse(chat.body).runId as string
+
+    // Replay re-runs from cache (zero live calls); handlers don't run, so the
+    // mintedObjects registry stays empty on replay — yet the cached cite outputs
+    // (ok:true / ok:false) are served verbatim, so the run reproduces identically.
+    const replay = await postJson(`${baseUrl}/run/${runId}/replay`, {})
+    expect(replay.status).toBe(200)
+    const body = JSON.parse(replay.body)
+    expect(body.status).toBe('deterministic')
+    expect(body.matchesOriginal).toBe(true)
   })
 })

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -99,6 +99,12 @@ export function makeCorpusTools(corpusRoot: string) {
   // can't be guessed). Replaces the old "(chapter:line)" prose convention.
   async function cite(input: unknown, ctx?: ToolContext): Promise<unknown> {
     const { claim, objectId } = input as { claim: string; objectId: string }
+    // #113 P1 fail-fast: reject a fabricated/hallucinated objectId before declaring
+    // anything, so the model can self-correct (re-grep/read for a real id) and no
+    // dangling edge enters the lineage graph. Skips the check if lineage isn't wired.
+    if (ctx?.resolveObject && !ctx.resolveObject(objectId)) {
+      return { ok: false, error: `objectId '${objectId}' 不存在；请使用 read_file/grep 返回的真实 objectId` }
+    }
     const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
     if (claimObj && ctx?.createRelation) {
       ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -38,7 +38,7 @@ import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
 import type { CausalCursor } from '../trace/CausalCursor.js'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
 import type { Region } from '../context/Region.js'
-import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation, ToolEmittedPayload, LineageBuffer } from '../trace/types.js'
+import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, GuardEvaluation, ToolEmittedPayload, LineageBuffer, ObjectType } from '../trace/types.js'
 
 export type MakeChildPort = (
   childRunId:  string,
@@ -122,6 +122,10 @@ export class AgentRuntime {
   /** #60: per-run count of successful calls per toolCallId, to disambiguate a
    *  tool_call id reused across responses when keying tool.emitted record/replay. */
   private readonly toolEmitOccurrence = new Map<string, number>()
+  /** #113 P1: per-run registry of objectIds minted via ctx.createObject (read/grep),
+   *  so a later producer (cite) can fail-fast on a fabricated/hallucinated id and
+   *  P2 lazy-promote can look up meta. Record-only: replay doesn't run handlers. */
+  private readonly mintedObjects = new Map<string, { type: ObjectType; meta?: Record<string, unknown> }>()
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly makeChildPort?: MakeChildPort
@@ -375,8 +379,11 @@ export class AgentRuntime {
           canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }),
         )
         lineage.objects.push({ objectId, type: spec.type, ...(spec.hash ? { hash: spec.hash } : {}), ...(spec.meta ? { meta: spec.meta } : {}) })
+        // #113 P1: register in the per-run table so later producers can resolve it.
+        this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}) })
         return { objectId }
       }
+      ctx.resolveObject = (objectId) => this.mintedObjects.get(objectId)
       ctx.createRelation = (spec) => {
         const relationId = 'rel:' + contentAddressForCanonicalBytes(
           canonicalize({ type: spec.type, from: spec.fromObjectId, to: spec.toObjectId }),

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -24,6 +24,13 @@ export interface ToolContext {
    * `relation.created` event after `tool.responded`.
    */
   createRelation?: (spec: { type: RelationType; fromObjectId: string; toObjectId: string; meta?: Record<string, unknown> }) => { relationId: string }
+  /**
+   * #113 P1: resolve an objectId minted earlier this run via createObject
+   * (read/grep), or undefined if it was never minted. Lets a producer fail-fast on
+   * a fabricated/hallucinated id — e.g. cite rejecting an objectId the agent invented
+   * — and underpins lazy-promote (P2). Present only when the runtime wired lineage.
+   */
+  resolveObject?:  (objectId: string) => { type: ObjectType; meta?: Record<string, unknown> } | undefined
 }
 
 export interface ToolDefinition {


### PR DESCRIPTION
#113 的 **P1**(分阶段第一步,最高 ROI、纯增量、不动现有词表契约)。

## 改动
- `AgentRuntime` 维护 per-run `mintedObjects` 表;`ctx.createObject` 铸 id 时登记,`ctx.resolveObject(id)` 查询(**run 级**,跨工具调用可见,非 per-call buffer)。
- `cite` **fail-fast**:objectId 查不到 → 返回 `{ ok:false, error }`,**不声明任何东西**(无 claim、无 cites 边),让模型自我纠正;结构化 error 随 `tool.responded` 回传,保留审计痕迹。
- **record-only**:replay 不跑 handler → 注册表为空 → 缓存的 cite 输出原样回放 → replay 仍确定性。

## TDD
红(伪造 id 写出悬空边)→ 绿。

## 测试(充分)
- ok 路径:真实 id → ok:true + cites 边
- fail-fast:伪造 id → ok:false,无 relation/无 claim
- **run 级注册表**:一次调用铸的 id 在后续 cite 可解析
- **replay 确定性**:混合 ok + fail-fast 的 run 重放 `matchesOriginal`
- 回归:core 518/518、example 61/61、浏览器零真实 JS 错误

## 后续
P2 lazy-promote 复用这张表当 pending 表(候选轻、被引重)。

Part of #113(不关闭,P2–P4 待续)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)