### PR TITLE
feat(#113 P2): lazy-promote (grep candidates emit only when cited)

### DIFF
--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -30,6 +30,13 @@ function passageId(file: string, lineStart: number, lineEnd: number): string {
   return 'obj:' + contentAddressForCanonicalBytes(canonicalize({ type: 'passage', meta: { file, lineStart, lineEnd }, hash: null }))
 }
 
+// 1-based line of the first line in `file` containing `substr` (matches grep's view).
+function findLine(file: string, substr: string): number {
+  const content = fs.readFileSync(path.join(__dirname, '..', 'corpus', file), 'utf-8')
+  const lines = content.replace(/\n$/, '').split('\n')
+  return lines.findIndex(l => l.includes(substr)) + 1
+}
+
 describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
   let server: Server
   let baseUrl: string
@@ -155,6 +162,86 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     // Replay re-runs from cache (zero live calls); handlers don't run, so the
     // mintedObjects registry stays empty on replay — yet the cached cite outputs
     // (ok:true / ok:false) are served verbatim, so the run reproduces identically.
+    const replay = await postJson(`${baseUrl}/run/${runId}/replay`, {})
+    expect(replay.status).toBe(200)
+    const body = JSON.parse(replay.body)
+    expect(body.status).toBe('deterministic')
+    expect(body.matchesOriginal).toBe(true)
+  })
+
+  it('P2 lazy: grep registers passages but emits ZERO object.created until cited', async () => {
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      text('done'),  // nothing cited
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    // grep matched, but nothing cited → no candidate object events at all.
+    expect(events.some(e => e.type === 'object.created')).toBe(false)
+    // grep emitted no object events → no artifactRefs on its tool.responded.
+    const grepResp = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'grep')!
+    expect((grepResp.payload as ToolRespondedPayload).artifactRefs).toBeUndefined()
+  })
+
+  it('P2 promote: citing a grep-registered id promotes exactly that ONE passage', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')           // 曹操小字阿瞞 — one specific grep hit
+    expect(line).toBeGreaterThan(0)
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),                       // registers (lazy)
+      toolCall('cite', { claim: '曹操小字阿瞞', objectId: objId }, 'tc-2'), // promotes just this one
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    // Exactly one passage object.created — the cited one, not every grep match.
+    const passages = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'passage')
+    expect(passages.length).toBe(1)
+    expect((passages[0]!.payload as ObjectCreatedPayload).objectId).toBe(objId)
+    expect((passages[0]!.payload as ObjectCreatedPayload).meta).toMatchObject({ file, lineStart: line, lineEnd: line })
+    // and the cites edge points at it.
+    const rel = events.find(e => e.type === 'relation.created')!
+    expect((rel.payload as RelationCreatedPayload).toObjectId).toBe(objId)
+  })
+
+  it('P2: promote is idempotent — citing the same grep passage twice emits ONE passage', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      toolCall('cite', { claim: '陈述一', objectId: objId }, 'tc-2'),
+      toolCall('cite', { claim: '陈述二', objectId: objId }, 'tc-3'),  // same passage again
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const passages = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'passage')
+    const claims   = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'claim')
+    const rels     = events.filter(e => e.type === 'relation.created')
+    expect(passages.length).toBe(1)  // promoted once (idempotent)
+    expect(claims.length).toBe(2)    // two distinct claims
+    expect(rels.length).toBe(2)      // two cites edges → same passage
+  })
+
+  it('P2: a grep→cite lazy-promote run replays deterministically', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      toolCall('cite', { claim: '曹操小字阿瞞', objectId: objId }, 'tc-2'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
     const replay = await postJson(`${baseUrl}/run/${runId}/replay`, {})
     expect(replay.status).toBe(200)
     const body = JSON.parse(replay.body)

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -71,8 +71,10 @@ export function makeCorpusTools(corpusRoot: string) {
           for (let i = 0; i < lines.length; i++) {
             if (re.test(lines[i]!)) {
               const file = path.relative(root, abs)
-              // #37: each hit is a citable single-line passage object.
-              const obj = ctx?.createObject?.({ type: 'passage', meta: { file, lineStart: i + 1, lineEnd: i + 1 } })
+              // #113 P2: grep is wide recall — register each hit lazily (no event)
+              // so dozens of never-cited candidates don't flood the log; cite promotes
+              // only the one the agent actually uses.
+              const obj = ctx?.registerObject?.({ type: 'passage', meta: { file, lineStart: i + 1, lineEnd: i + 1 } })
               matches.push({
                 file,
                 line: i + 1,
@@ -105,6 +107,9 @@ export function makeCorpusTools(corpusRoot: string) {
     if (ctx?.resolveObject && !ctx.resolveObject(objectId)) {
       return { ok: false, error: `objectId '${objectId}' 不存在；请使用 read_file/grep 返回的真实 objectId` }
     }
+    // #113 P2: emit the cited passage's object.created now (a no-op if it was an
+    // eager read_file passage already emitted; emits it if it was a lazy grep hit).
+    ctx?.promoteObject?.(objectId)
     const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
     if (claimObj && ctx?.createRelation) {
       ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -122,10 +122,12 @@ export class AgentRuntime {
   /** #60: per-run count of successful calls per toolCallId, to disambiguate a
    *  tool_call id reused across responses when keying tool.emitted record/replay. */
   private readonly toolEmitOccurrence = new Map<string, number>()
-  /** #113 P1: per-run registry of objectIds minted via ctx.createObject (read/grep),
-   *  so a later producer (cite) can fail-fast on a fabricated/hallucinated id and
-   *  P2 lazy-promote can look up meta. Record-only: replay doesn't run handlers. */
-  private readonly mintedObjects = new Map<string, { type: ObjectType; meta?: Record<string, unknown> }>()
+  /** #113 P1/P2: per-run registry of objectIds. `promoted=true` once an
+   *  object.created event has been emitted for it (eager createObject, or a
+   *  cite that promoted a lazily-registered grep candidate). Lets cite fail-fast
+   *  on unknown ids, P2 emit candidates only when cited, and promote idempotently.
+   *  Record-only: replay doesn't run handlers. */
+  private readonly mintedObjects = new Map<string, { type: ObjectType; meta?: Record<string, unknown>; promoted: boolean }>()
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly makeChildPort?: MakeChildPort
@@ -374,16 +376,39 @@ export class AgentRuntime {
     // through ioPort.invokeTool, which drains the buffer). objectId/relationId are
     // content-addressed so they are identical in record and replay.
     if (lineage) {
+      const objectIdFor = (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) =>
+        'obj:' + contentAddressForCanonicalBytes(canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }))
+
+      // Eager: register + emit object.created now. Used for deliberate artifacts
+      // (read_file passage, cite's claim) where the producer event is the anchor.
       ctx.createObject = (spec) => {
-        const objectId = 'obj:' + contentAddressForCanonicalBytes(
-          canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }),
-        )
+        const objectId = objectIdFor(spec)
         lineage.objects.push({ objectId, type: spec.type, ...(spec.hash ? { hash: spec.hash } : {}), ...(spec.meta ? { meta: spec.meta } : {}) })
-        // #113 P1: register in the per-run table so later producers can resolve it.
-        this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}) })
+        this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}), promoted: true })
         return { objectId }
       }
-      ctx.resolveObject = (objectId) => this.mintedObjects.get(objectId)
+      // #113 P2 lazy: register a candidate (grep hit) WITHOUT emitting an event.
+      // It only becomes an object.created if later promoted by a cite.
+      ctx.registerObject = (spec) => {
+        const objectId = objectIdFor(spec)
+        if (!this.mintedObjects.has(objectId)) {
+          this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}), promoted: false })
+        }
+        return { objectId }
+      }
+      // #113 P2: emit object.created for a registered-but-not-yet-emitted object,
+      // on first cite. Idempotent — a second cite of the same passage is a no-op.
+      ctx.promoteObject = (objectId) => {
+        const o = this.mintedObjects.get(objectId)
+        if (o && !o.promoted) {
+          lineage.objects.push({ objectId, type: o.type, ...(o.meta ? { meta: o.meta } : {}) })
+          o.promoted = true
+        }
+      }
+      ctx.resolveObject = (objectId) => {
+        const o = this.mintedObjects.get(objectId)
+        return o ? { type: o.type, ...(o.meta ? { meta: o.meta } : {}) } : undefined
+      }
       ctx.createRelation = (spec) => {
         const relationId = 'rel:' + contentAddressForCanonicalBytes(
           canonicalize({ type: spec.type, from: spec.fromObjectId, to: spec.toObjectId }),

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -19,6 +19,18 @@ export interface ToolContext {
    */
   createObject?:   (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) => { objectId: string }
   /**
+   * #113 P2 (lazy): register a candidate object (e.g. a wide-recall grep hit)
+   * WITHOUT emitting object.created. Returns its content-addressed objectId so the
+   * agent can cite it; it only becomes an event if a later cite promotes it. Keeps
+   * large recall from flooding the event log with never-cited candidates.
+   */
+  registerObject?: (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) => { objectId: string }
+  /**
+   * #113 P2: emit object.created for a previously registered (lazy) object, the
+   * first time it is cited. Idempotent and a no-op for already-emitted objects.
+   */
+  promoteObject?:  (objectId: string) => void
+  /**
    * #38: declare a typed edge between two objects (e.g. a claim `cites` a passage).
    * Both ids must be objectIds minted by createObject. Runtime records a
    * `relation.created` event after `tool.responded`.


### PR DESCRIPTION
#113 的 **P2**(治大召回膨胀)。**Stacked on #116(P1)** — base 指向 P1 分支,合并 P1 后 GitHub 自动改 base 到 main。

## 改动
- `ctx.registerObject`(lazy):登记 grep 命中的 objectId 但**不**落 object.created;`ctx.promoteObject(id)`:首次被 cite 时才落,幂等。
- 注册表加 `promoted` 标志;`createObject`(read_file/claim)仍 eager。
- `grep` → `registerObject`(宽召回不再刷屏);`cite` → 先 `promoteObject`(对已 eager 落地的 read_file passage 是 no-op)。
- 效果:**50 条 grep 命中 + 2 条 cite → 2 个 passage 事件,而非 50**。

record-only → replay 确定性不变。

## TDD
红(grep eager 落事件)→ 绿。

## 测试(充分)
- `grep` 后未 cite → **零** object.created;`tool.responded` 无 artifactRefs
- cite 一个 grep id → **恰好一个** passage 被 promote
- **幂等**:同一 passage cite 两次 → 一个 passage、两个 claim、两条 cites 边
- **replay 确定性**:grep→cite lazy-promote 的 run 重放 `matchesOriginal`
- 回归:core 518/518、example 65/65、浏览器零真实 JS 错误

Part of #113(不关闭)。下一步 P3:内置 typed-link 工具。

🤖 Generated with [Claude Code](https://claude.com/claude-code)