### PR TITLE
feat(#84): portable session export/import API

### DIFF
--- a/src/__tests__/portable-session.test.ts
+++ b/src/__tests__/portable-session.test.ts
@@ -1,0 +1,285 @@
+// #84: portable session export/import — the event log is the single source of
+// truth (#73), so a portable session bundles the run-tree's events + the
+// context's persistent vars (#83) + a versioned manifest. Importing into a fresh
+// Milkie instance and invoking the same contextId must let the agent continue
+// with prior history.
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { AgentConfig } from '../types/agent'
+import type { ToolDefinition } from '../types/tool'
+import type { AgentSpawnedPayload, AgentRunStartedPayload } from '../trace/types'
+
+/** A gateway that answers immediately (end_turn) — a turn that completes still
+ *  emits a continuation checkpoint event (see checkpoint-from-events.test). */
+function endTurnGateway(text = 'done'): IModelGateway {
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+  }
+}
+
+/** Writes a fact into working memory; used to prove history carry-forward. */
+function factWriter(): ToolDefinition {
+  return {
+    name: 'record_fact', description: 'record a fact',
+    inputSchema: { type: 'object', properties: { key: { type: 'string' }, value: { type: 'string' } }, required: ['key', 'value'] },
+    handler: async (input: unknown, ctx) => {
+      const { key, value } = input as { key: string; value: string }
+      ctx.workingMemory.set(key, value)
+      return { recorded: key }
+    },
+  }
+}
+
+/** First call records a fact (tool_use), then completes (end_turn). */
+function recordThenDoneGateway(): IModelGateway {
+  let n = 0
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      n++
+      if (n === 1) {
+        const input = { key: 'fact1', value: 'v1' }
+        return { content: [{ type: 'tool_use', id: 'c1', name: 'record_fact', input }], toolCalls: [{ id: 'c1', name: 'record_fact', input }], finishReason: 'tool_use' }
+      }
+      return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+  }
+}
+
+const recorderAgent: AgentConfig = {
+  agentId: 'recorder', version: '1.0.0', systemPrompt: 'answer',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 50 }] },
+  model: { provider: 'test', model: 'test', adapter: 'test' },
+}
+
+describe('#84 portable session export', () => {
+  it('exports a versioned payload with the run-tree events and context vars', async () => {
+    const stateStore = new MemoryStore()
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({ stateStore, eventStore, gateway: endTurnGateway() })
+    milkie.registerAgent(recorderAgent)
+
+    const contextId = 'ctx-export'
+    const run = await milkie.invoke({ agentId: 'recorder', goal: 'g', input: 'hello', contextId })
+    expect(run.status).toBe('completed')
+    await milkie.setContextVar(contextId, 'user', 'alice')
+
+    const session = await milkie.exportSession(contextId)
+
+    expect(session.manifest.schemaVersion).toBe(1)
+    expect(session.manifest.contextId).toBe(contextId)
+    expect(session.manifest.agentId).toBe('recorder')
+    expect(session.manifest.latestRunId).toBe(run.agentRunId)
+    expect(typeof session.manifest.exportedAt).toBe('number')
+
+    // events bundle the latest run's stream, including its continuation checkpoint.
+    expect(session.events.some(e => e.runId === run.agentRunId)).toBe(true)
+    expect(checkpointFromEvents(session.events.filter(e => e.runId === run.agentRunId))).not.toBeNull()
+
+    // vars are captured as a snapshot.
+    expect(session.variables).toEqual({ user: 'alice' })
+  })
+
+  it('throws when exporting an unknown contextId', async () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: endTurnGateway() })
+    milkie.registerAgent(recorderAgent)
+    await expect(milkie.exportSession('nope')).rejects.toThrow()
+  })
+})
+
+describe('#84 portable session round-trip (single agent)', () => {
+  it('imports into a fresh Milkie so the agent continues with prior history + vars', async () => {
+    // Source instance: one turn that records a fact into WM, then completes.
+    const srcState = new MemoryStore()
+    const srcEvents = new MemoryEventStore()
+    const src = new Milkie({ stateStore: srcState, eventStore: srcEvents, gateway: recordThenDoneGateway(), tools: [factWriter()] })
+    src.registerAgent(recorderAgent)
+
+    const contextId = 'ctx-rt'
+    const run1 = await src.invoke({ agentId: 'recorder', goal: 'g', input: 'remember v1', contextId })
+    expect(run1.status).toBe('completed')
+    await src.setContextVar(contextId, 'user', 'alice')
+
+    const session = await src.exportSession(contextId)
+
+    // Destination instance: brand-new stores, nothing carried over implicitly.
+    const dstState = new MemoryStore()
+    const dstEvents = new MemoryEventStore()
+    const dst = new Milkie({ stateStore: dstState, eventStore: dstEvents, gateway: endTurnGateway('continued'), tools: [factWriter()] })
+    dst.registerAgent(recorderAgent)
+
+    const { contextId: restoredId } = await dst.importSession(session)
+    expect(restoredId).toBe(contextId)
+
+    // Vars are restored into the destination stateStore.
+    expect(await dst.getContextVar(contextId, 'user')).toBe('alice')
+
+    // Continue the conversation: the next turn's first prompt must carry the
+    // prior turn's WM (restored from the imported event log).
+    const run2 = await dst.invoke({ agentId: 'recorder', goal: 'g', input: 'continue', contextId })
+    const ev2 = await dstEvents.readByRunId(run2.agentRunId)
+    const firstLlm = ev2.find(e => e.type === 'llm.requested')!
+    const prompt = JSON.stringify((firstLlm.payload as { request: unknown }).request)
+    expect(prompt).toContain('fact1')
+  })
+})
+
+// ---- multi-agent: a supervisor that spawns a worker sub-agent ----
+
+class StubGateway implements IModelGateway {
+  private responses: ModelResponse[]
+  constructor(responses: ModelResponse[]) { this.responses = responses }
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const r = this.responses.shift()
+    if (!r) throw new Error('No more stub responses')
+    return r
+  }
+  async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+const textResponse = (text: string): ModelResponse => ({ content: [{ type: 'text', text }], toolCalls: [], finishReason: 'end_turn' })
+const toolCallResponse = (id: string, name: string, input: unknown): ModelResponse => ({ content: [{ type: 'tool_use', id, name, input }], toolCalls: [{ id, name, input }], finishReason: 'tool_use' })
+
+const supervisorAgent: AgentConfig = {
+  agentId: 'supervisor', version: '1.0.0', systemPrompt: 'system',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 3 }] },
+  model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  subAgents: { worker: '1.0.0' },
+}
+const workerAgent: AgentConfig = {
+  agentId: 'worker', version: '1.0.0', systemPrompt: 'system',
+  fsm: { states: [{ name: 'react', type: 'llm' }] },
+  model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+}
+
+/** A supervisor turn that spawns one worker, run on the given Milkie. */
+function spawningGateway(): IModelGateway {
+  return new StubGateway([
+    toolCallResponse('s1', 'worker', { goal: 'subgoal', input: 'subinput' }),
+    textResponse('worker done'),   // worker's only LLM turn
+    textResponse('all done'),      // supervisor finishes
+  ])
+}
+
+describe('#84 portable session (multi-agent)', () => {
+  it('export captures the sub-agent run-tree (child events under their own runId)', async () => {
+    const stateStore = new MemoryStore()
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({ stateStore, eventStore, gateway: spawningGateway() })
+    milkie.registerAgent(supervisorAgent)
+    milkie.registerAgent(workerAgent)
+
+    const contextId = 'ctx-ma'
+    const run = await milkie.invoke({ agentId: 'supervisor', goal: 'g', input: 'i', contextId })
+    expect(run.status).toBe('completed')
+
+    // discover the child runId from the parent's spawn event
+    const parentEvents = await eventStore.readByRunId(run.agentRunId)
+    const childRunId = (parentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload).childRunId
+
+    const session = await milkie.exportSession(contextId)
+
+    // both parent and child run events are bundled
+    expect(session.events.some(e => e.runId === run.agentRunId)).toBe(true)
+    expect(session.events.some(e => e.runId === childRunId)).toBe(true)
+    // the child's own lifecycle is present, pointing back at the parent
+    const childStarted = session.events.find(e => e.runId === childRunId && e.type === 'agent.run.started')!
+    expect((childStarted.payload as AgentRunStartedPayload).parentId).toBe(run.agentRunId)
+    expect((childStarted.payload as AgentRunStartedPayload).agentId).toBe('worker')
+  })
+
+  it('round-trips the sub-agent tree: child run is replayable in a fresh instance', async () => {
+    // source
+    const srcEvents = new MemoryEventStore()
+    const src = new Milkie({ stateStore: new MemoryStore(), eventStore: srcEvents, gateway: spawningGateway() })
+    src.registerAgent(supervisorAgent)
+    src.registerAgent(workerAgent)
+    const contextId = 'ctx-ma-rt'
+    const run = await src.invoke({ agentId: 'supervisor', goal: 'g', input: 'i', contextId })
+    const srcParentEvents = await srcEvents.readByRunId(run.agentRunId)
+    const childRunId = (srcParentEvents.find(e => e.type === 'agent.spawned')!.payload as AgentSpawnedPayload).childRunId
+
+    const session = await src.exportSession(contextId)
+
+    // destination: fresh stores, no live gateway responses needed for replay
+    const dstEvents = new MemoryEventStore()
+    const dst = new Milkie({ stateStore: new MemoryStore(), eventStore: dstEvents, gateway: new StubGateway([]) })
+    dst.registerAgent(supervisorAgent)
+    dst.registerAgent(workerAgent)
+
+    await dst.importSession(session)
+
+    // the child run's full event stream landed in the destination store
+    const dstChildEvents = await dstEvents.readByRunId(childRunId)
+    expect(dstChildEvents.length).toBeGreaterThan(0)
+    expect(dstChildEvents.some(e => e.type === 'agent.run.started')).toBe(true)
+
+    // and it replays byte-identically from the imported events (no live LLM)
+    const replayed = await dst.replay(childRunId)
+    expect(replayed.status).toBe('completed')
+  })
+})
+
+describe('#84 portable session (multi-turn + versioning)', () => {
+  /** Records fact{n} on the first call of each turn, completes on the second. */
+  function multiTurnRecorder(): IModelGateway {
+    let calls = 0, facts = 0
+    return {
+      async complete(_req: ModelRequest): Promise<ModelResponse> {
+        calls++
+        if (calls % 2 === 1) {
+          facts++
+          const input = { key: `fact${facts}`, value: `v${facts}` }
+          return { content: [{ type: 'tool_use', id: `c${facts}`, name: 'record_fact', input }], toolCalls: [{ id: `c${facts}`, name: 'record_fact', input }], finishReason: 'tool_use' }
+        }
+        return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+      },
+      async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+    }
+  }
+
+  it('carries multi-turn history forward through export/import', async () => {
+    const src = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: multiTurnRecorder(), tools: [factWriter()] })
+    src.registerAgent(recorderAgent)
+    const contextId = 'ctx-mt'
+    await src.invoke({ agentId: 'recorder', goal: 'g', input: 'turn1', contextId })  // → fact1
+    await src.invoke({ agentId: 'recorder', goal: 'g', input: 'turn2', contextId })  // → fact2
+
+    const session = await src.exportSession(contextId)
+
+    const dstEvents = new MemoryEventStore()
+    const dst = new Milkie({ stateStore: new MemoryStore(), eventStore: dstEvents, gateway: endTurnGateway('next'), tools: [factWriter()] })
+    dst.registerAgent(recorderAgent)
+    await dst.importSession(session)
+
+    const run3 = await dst.invoke({ agentId: 'recorder', goal: 'g', input: 'turn3', contextId })
+    const ev3 = await dstEvents.readByRunId(run3.agentRunId)
+    const firstLlm = ev3.find(e => e.type === 'llm.requested')!
+    const prompt = JSON.stringify((firstLlm.payload as { request: unknown }).request)
+    // both turns' facts survive the round-trip (accumulated working memory)
+    expect(prompt).toContain('fact1')
+    expect(prompt).toContain('fact2')
+  })
+
+  it('rejects an unknown schemaVersion on import', async () => {
+    const dst = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: endTurnGateway() })
+    dst.registerAgent(recorderAgent)
+    const bad = {
+      manifest: { schemaVersion: 999, contextId: 'x', agentId: 'recorder', latestRunId: 'r', exportedAt: 0 },
+      events: [],
+      variables: {},
+    } as unknown as Parameters<typeof dst.importSession>[0]
+    await expect(dst.importSession(bad)).rejects.toThrow(/schemaVersion/)
+  })
+
+  it('rejects import when this instance has no eventStore', async () => {
+    const dst = new Milkie({ stateStore: new MemoryStore(), gateway: endTurnGateway(), defaultModel: { provider: 'test', model: 'test', adapter: 'test' } })
+    const empty = { manifest: { schemaVersion: 1, contextId: 'x', agentId: 'recorder', latestRunId: 'r', exportedAt: 0 }, events: [], variables: {} } as Parameters<typeof dst.importSession>[0]
+    await expect(dst.importSession(empty)).rejects.toThrow(/eventStore/)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ export { AnthropicAdapter }         from './gateway/AnthropicAdapter.js'
 export { OpenAICompatibleAdapter }  from './gateway/OpenAICompatibleAdapter.js'
 export { createGateway }            from './gateway/GatewayFactory.js'
 
+// #84: portable session export/import
+export { PORTABLE_SESSION_SCHEMA_VERSION } from './runtime/PortableSession.js'
+export type { PortableSession } from './runtime/PortableSession.js'
+
 // Trace stores / views
 export { MemoryEventStore } from './trace/MemoryEventStore.js'
 export { JsonlEventStore } from './trace/JsonlEventStore.js'

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -24,8 +24,13 @@ import { ReplayingIOPort } from '../trace/ReplayingIOPort.js'
 import { ReplayError } from '../trace/ReplayError.js'
 import { ReplayDivergenceError } from '../trace/ReplayDivergenceError.js'
 import { extractRunSnapshot } from '../trace/RunSnapshot.js'
-import type { ToolEmittedPayload } from '../trace/types.js'
+import type { ToolEmittedPayload, AgentRunStartedPayload } from '../trace/types.js'
 import { makeTraceTools } from '../tools/trace.js'
+import {
+  type PortableSession,
+  PORTABLE_SESSION_SCHEMA_VERSION,
+  collectRunTree,
+} from './PortableSession.js'
 
 export interface MilkieOptions {
   /**
@@ -539,6 +544,80 @@ export class Milkie {
       }
     }
     return result
+  }
+
+  // ---- #84: portable session export/import ----
+  // The event log is the source of truth (#73): export bundles the run-tree's
+  // events (latest checkpointed run + sub-agent descendants) plus the context's
+  // persistent vars (#83) under a versioned manifest. Import re-injects them into
+  // this instance so `invoke({ contextId })` continues with prior history.
+
+  /**
+   * Export a context's session as a portable, serialisable snapshot.
+   * Requires an eventStore (events are the payload). Throws when the context has
+   * no checkpointed run to export.
+   */
+  async exportSession(contextId: string): Promise<PortableSession> {
+    if (!this.eventStore) {
+      throw new Error('Milkie has no eventStore; cannot export a portable session')
+    }
+    const latestRunId = await this.stateStore.get(`context:${contextId}:checkpoint-run:latest`) as string | undefined
+    if (!latestRunId) {
+      throw new Error(`No session to export for contextId "${contextId}"`)
+    }
+
+    const events = await collectRunTree(this.eventStore, latestRunId)
+
+    // agentId: prefer the latest run's checkpoint meta, fall back to its
+    // agent.run.started event (a run-tree always has at least the root's lifecycle).
+    const latestRunEvents = events.filter(e => e.runId === latestRunId)
+    const cp = checkpointFromEvents(latestRunEvents)
+    const started = latestRunEvents.find(e => e.type === 'agent.run.started')
+    const agentId = cp?.meta.agentId
+      ?? (started?.payload as AgentRunStartedPayload | undefined)?.agentId
+      ?? ''
+
+    return {
+      manifest: {
+        schemaVersion: PORTABLE_SESSION_SCHEMA_VERSION,
+        contextId,
+        agentId,
+        latestRunId,
+        exportedAt: Date.now(),
+      },
+      events,
+      variables: await this.listContextVars(contextId),
+    }
+  }
+
+  /**
+   * Import a portable session into this instance: append its run-tree events
+   * into the eventStore, install the context→run routing pointer, and restore
+   * its persistent vars. Afterwards `invoke({ contextId })` continues the
+   * conversation with the prior history. Returns the contextId now installed.
+   */
+  async importSession(session: PortableSession): Promise<{ contextId: string }> {
+    if (!this.eventStore) {
+      throw new Error('Milkie has no eventStore; cannot import a portable session')
+    }
+    if (session.manifest.schemaVersion !== PORTABLE_SESSION_SCHEMA_VERSION) {
+      throw new Error(
+        `Unsupported portable session schemaVersion ${session.manifest.schemaVersion}; ` +
+        `this build imports v${PORTABLE_SESSION_SCHEMA_VERSION}`)
+    }
+    const { contextId, latestRunId } = session.manifest
+
+    for (const event of session.events) {
+      await this.eventStore.append(event)
+    }
+    // Routing pointer: invoke() reads this to project the resume checkpoint from
+    // the event log (#73).
+    await this.stateStore.set(`context:${contextId}:checkpoint-run:latest`, latestRunId)
+
+    for (const [name, value] of Object.entries(session.variables)) {
+      await this.setContextVar(contextId, name, value)
+    }
+    return { contextId }
   }
 
   async interrupt(contextId: string): Promise<void> {

--- a/src/runtime/PortableSession.ts
+++ b/src/runtime/PortableSession.ts
@@ -1,0 +1,60 @@
+import type { Event, AgentSpawnedPayload } from '../trace/types.js'
+import type { IEventStore } from '../trace/EventStore.js'
+import type { JSONValue } from '../types/common.js'
+
+/**
+ * #84: a portable, serialisable snapshot of a session (one contextId), suitable
+ * for alfred's persistence layer to store and later re-inject into a fresh Milkie.
+ *
+ * The event log is the single source of truth (#73): the snapshot bundles the
+ * run-tree's events (the latest checkpointed run plus its sub-agent descendants),
+ * the context's persistent vars (#83, which live in the stateStore — not the
+ * event log — so they are captured separately), and a versioned manifest.
+ *
+ * Multi-turn note: a context's "history" is carried forward into the latest run's
+ * checkpoint (regions/working-memory), so the latest run + its descendants is
+ * sufficient to continue the conversation. Prior turns' raw I/O events are not
+ * bundled (no by-context index exists, and they are not needed for continuation).
+ */
+export interface PortableSession {
+  manifest: {
+    schemaVersion: 1
+    contextId:     string
+    agentId:       string
+    latestRunId:   string
+    exportedAt:    number
+  }
+  events:    Event[]
+  variables: Record<string, JSONValue>
+}
+
+/** The schema version this build emits and is able to import. */
+export const PORTABLE_SESSION_SCHEMA_VERSION = 1
+
+/**
+ * Collect a run and all of its sub-agent descendants, in breadth-first order.
+ * Descendants are discovered from `agent.spawned` events (each carries the
+ * child's independent runId). Cycles/duplicates are guarded by a visited set.
+ */
+export async function collectRunTree(
+  eventStore: IEventStore,
+  rootRunId:  string,
+): Promise<Event[]> {
+  const visited = new Set<string>()
+  const queue: string[] = [rootRunId]
+  const events: Event[] = []
+  while (queue.length > 0) {
+    const runId = queue.shift()!
+    if (visited.has(runId)) continue
+    visited.add(runId)
+    const runEvents = await eventStore.readByRunId(runId)
+    for (const e of runEvents) {
+      events.push(e)
+      if (e.type === 'agent.spawned') {
+        const childRunId = (e.payload as AgentSpawnedPayload).childRunId
+        if (childRunId && !visited.has(childRunId)) queue.push(childRunId)
+      }
+    }
+  }
+  return events
+}


### PR DESCRIPTION
## Summary
- 新增 `Milkie.exportSession(contextId)` / `importSession(session)`：把某 context 的会话导出为可移植 JSON，并可回灌进全新 Milkie 实例继续 invoke。
- 以 event log 为单一真实来源（#73）：载荷 = 最新 run + 经 `agent.spawned.childRunId` 递归发现的子孙 run 事件 + context 持久变量（#83）+ 带版本号 manifest（schemaVersion 1）。
- 多轮历史由 checkpoint 前向携带，故"最新 run + 子孙 run"已足够继续对话——**不新建 by-context 索引、不触碰 invoke/persist 热路径**（较初版设计的简化，已在 issue 记录）。
- `PortableSession` 类型与 `PORTABLE_SESSION_SCHEMA_VERSION` 从包入口导出，供 alfred 持久化层对接。

## Test Plan
8 个用例全绿（`npx jest src/__tests__/portable-session.test.ts`）：
- [x] 导出载荷结构/版本/含 run-tree 事件+checkpoint+vars；未知 contextId 报错
- [x] 单智能体往返：导出 → 全新实例导入 → 续轮看到上轮 WM + 变量恢复
- [x] 多智能体：supervisor spawn worker → 导出递归捕获子 run；导入新实例后子 run 可独立 `replay()` 字节级重放
- [x] 多轮：两轮分别写 fact1/fact2，仅导最新 run，导入后续轮 prompt 同时含两者
- [x] 边界：未知 schemaVersion 拒绝、无 eventStore 拒绝
- [x] 标准门禁 `npm test` 绿；`npm run build` 绿

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)