### PR TITLE
feat(#113 P3): built-in lineage tools (cite + declare_relation)

### DIFF
--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -169,6 +169,43 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     expect(body.matchesOriginal).toBe(true)
   })
 
+  it('P3: built-in declare_relation links two existing objects with a typed edge', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const idA = passageId(file, 1, 5)
+    const idB = passageId(file, 6, 10)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 1, lineEnd: 5 }, 'tc-1'),
+      toolCall('read_file', { relPath: file, lineStart: 6, lineEnd: 10 }, 'tc-2'),
+      toolCall('declare_relation', { type: 'equivalent_to', fromObjectId: idA, toObjectId: idB }, 'tc-3'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const rel = events.find(e => e.type === 'relation.created' && (e.payload as RelationCreatedPayload).type === 'equivalent_to')
+    expect(rel).toBeTruthy()
+    expect((rel!.payload as RelationCreatedPayload).fromObjectId).toBe(idA)
+    expect((rel!.payload as RelationCreatedPayload).toObjectId).toBe(idB)
+  })
+
+  it('P3: declare_relation fail-fasts on an unknown objectId (no edge written)', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const idA = passageId(file, 1, 5)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 1, lineEnd: 5 }, 'tc-1'),
+      toolCall('declare_relation', { type: 'derives_from', fromObjectId: idA, toObjectId: 'obj:fake' }, 'tc-2'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    expect(events.some(e => e.type === 'relation.created')).toBe(false)
+    const resp = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'declare_relation')!
+    expect((resp.payload as ToolRespondedPayload).output).toMatchObject({ ok: false })
+  })
+
   it('P2 lazy: grep registers passages but emits ZERO object.created until cited', async () => {
     await start([
       toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),

--- a/examples/agent-docs-qa/agents/sanguo-researcher.md
+++ b/examples/agent-docs-qa/agents/sanguo-researcher.md
@@ -34,7 +34,7 @@ fsm:
 
         verifier 是一次性加载——同一会话内不要反复 request;如果用户
         再次怀疑、且 verifier 已加载,直接以严格模式重新验证即可。
-      tools: [list_dir, read_file, grep, cite, skill_request]
+      tools: [list_dir, read_file, grep, cite, declare_relation, skill_request]
 model:
   provider: volcengine
   model: doubao-seed-2-0-pro-260215

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -94,30 +94,10 @@ export function makeCorpusTools(corpusRoot: string) {
     }
   }
 
-  // 【新 issue】#38 producer: the agent declares "this claim is sourced from that
-  // passage". Mints a `claim` object and a `cites` relation claim → passage. The
-  // objectId must be one the agent received from read_file/grep — a fabricated id
-  // produces a dangling edge the UI renders as ungrounded (content-addressed ids
-  // can't be guessed). Replaces the old "(chapter:line)" prose convention.
-  async function cite(input: unknown, ctx?: ToolContext): Promise<unknown> {
-    const { claim, objectId } = input as { claim: string; objectId: string }
-    // #113 P1 fail-fast: reject a fabricated/hallucinated objectId before declaring
-    // anything, so the model can self-correct (re-grep/read for a real id) and no
-    // dangling edge enters the lineage graph. Skips the check if lineage isn't wired.
-    if (ctx?.resolveObject && !ctx.resolveObject(objectId)) {
-      return { ok: false, error: `objectId '${objectId}' 不存在；请使用 read_file/grep 返回的真实 objectId` }
-    }
-    // #113 P2: emit the cited passage's object.created now (a no-op if it was an
-    // eager read_file passage already emitted; emits it if it was a lazy grep hit).
-    ctx?.promoteObject?.(objectId)
-    const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
-    if (claimObj && ctx?.createRelation) {
-      ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })
-    }
-    return { ok: true, claimId: claimObj?.objectId, cites: objectId }
-  }
-
-  return { list_dir, read_file, grep, cite }
+  // #113 P3: `cite` is now a framework built-in (src/tools/lineage.ts), available
+  // to any agent. The corpus tools only produce objects (read_file/grep); the
+  // lineage-declaration tools are framework-level.
+  return { list_dir, read_file, grep }
 }
 
 /**
@@ -169,19 +149,6 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
         required: ['pattern'],
       },
       handler: t.grep,
-    },
-    {
-      name:        'cite',
-      description: 'Record that a specific claim in your answer is sourced from a passage. Pass the exact claim text and the objectId returned by read_file or grep. Call once per cited claim. Do NOT write "(chapter:line)" in prose — cite via this tool instead.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          claim:    { type: 'string', description: 'The exact statement in your answer this source supports.' },
-          objectId: { type: 'string', description: 'objectId of the passage (from read_file/grep) that supports the claim.' },
-        },
-        required: ['claim', 'objectId'],
-      },
-      handler: t.cite,
     },
   ]
 }

--- a/src/__tests__/lineageTools.test.ts
+++ b/src/__tests__/lineageTools.test.ts
@@ -1,0 +1,67 @@
+import { lineageTools } from '../tools/lineage'
+import type { ToolContext } from '../types/tool'
+
+// A mock ToolContext that records what the handler declared, with a known set of
+// resolvable objectIds (simulating ids minted earlier this run by read/grep).
+function mockCtx(known: Set<string>) {
+  const created: Array<{ objectId: string; type: string }> = []
+  const relations: Array<{ type: string; fromObjectId: string; toObjectId: string }> = []
+  const promoted: string[] = []
+  const ctx = {
+    resolveObject: (id: string) => (known.has(id) ? { type: 'passage' as const } : undefined),
+    promoteObject: (id: string) => { promoted.push(id) },
+    createObject:  (spec: { type: string }) => { const objectId = `obj:made:${created.length}`; created.push({ objectId, type: spec.type }); return { objectId } },
+    createRelation: (spec: { type: string; fromObjectId: string; toObjectId: string }) => { relations.push(spec); return { relationId: `rel:${relations.length}` } },
+  } as unknown as ToolContext
+  return { ctx, created, relations, promoted }
+}
+
+const cite            = lineageTools.find(t => t.name === 'cite')!
+const declareRelation = lineageTools.find(t => t.name === 'declare_relation')!
+
+describe('built-in lineage tools (#113 P3)', () => {
+  it('registers cite and declare_relation', () => {
+    expect(cite).toBeTruthy()
+    expect(declareRelation).toBeTruthy()
+  })
+
+  it('cite: resolvable id → mints a claim + cites relation, ok:true, promotes the cited id', async () => {
+    const { ctx, created, relations, promoted } = mockCtx(new Set(['obj:p']))
+    const out = await cite.handler({ claim: '某陈述', objectId: 'obj:p' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(created[0]!.type).toBe('claim')
+    expect(relations).toEqual([{ type: 'cites', fromObjectId: created[0]!.objectId, toObjectId: 'obj:p' }])
+    expect(promoted).toContain('obj:p')
+  })
+
+  it('cite: unresolvable id → ok:false and declares nothing', async () => {
+    const { ctx, created, relations } = mockCtx(new Set())
+    const out = await cite.handler({ claim: 'x', objectId: 'obj:fake' }, ctx) as { ok: boolean; error?: string }
+    expect(out.ok).toBe(false)
+    expect(out.error).toMatch(/不存在|objectId/)
+    expect(created).toHaveLength(0)
+    expect(relations).toHaveLength(0)
+  })
+
+  it('declare_relation: both ids resolvable → typed edge, ok:true', async () => {
+    const { ctx, relations } = mockCtx(new Set(['obj:a', 'obj:b']))
+    const out = await declareRelation.handler({ type: 'equivalent_to', fromObjectId: 'obj:a', toObjectId: 'obj:b' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(true)
+    expect(relations).toEqual([{ type: 'equivalent_to', fromObjectId: 'obj:a', toObjectId: 'obj:b' }])
+  })
+
+  it('declare_relation: an unknown endpoint → ok:false and no edge', async () => {
+    const { ctx, relations } = mockCtx(new Set(['obj:a']))
+    const out = await declareRelation.handler({ type: 'derives_from', fromObjectId: 'obj:a', toObjectId: 'obj:x' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(false)
+    expect(relations).toHaveLength(0)
+  })
+
+  it('lineage tools degrade gracefully when the runtime did not wire lineage (no ctx methods)', async () => {
+    const bare = {} as ToolContext  // no resolveObject/createObject/etc.
+    // No resolveObject → no fail-fast; createObject/createRelation absent → no throw.
+    const out = await cite.handler({ claim: 'x', objectId: 'obj:p' }, bare) as { ok: boolean }
+    expect(out.ok).toBe(true)
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -32,6 +32,7 @@ import { AgentFactory, type AgentSpawnOptions } from './AgentFactory.js'
 import type { IIOPort } from './IOPort.js'
 import { cognitiveTools } from '../tools/cognitive.js'
 import { systemTools } from '../tools/system.js'
+import { lineageTools } from '../tools/lineage.js'
 import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
 import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
@@ -253,6 +254,7 @@ export class AgentRuntime {
   private registerTools(extraTools: ToolDefinition[]): void {
     for (const tool of systemTools)    this.registry.register(tool)
     for (const tool of cognitiveTools) this.registry.register(tool)
+    for (const tool of lineageTools)   this.registry.register(tool)  // #113 P3
     for (const tool of extraTools)     this.registry.register(tool)
     for (const [agentId] of Object.entries(this.config.subAgents ?? {})) {
       this.registry.register(this.makeSubAgentTool(agentId))

--- a/src/tools/lineage.ts
+++ b/src/tools/lineage.ts
@@ -1,0 +1,76 @@
+import type { ToolDefinition, ToolContext } from '../types/tool.js'
+import type { RelationType } from '../trace/types.js'
+
+/**
+ * #113 P3: framework built-in lineage-declaration tools.
+ *
+ * Object *production* (a passage read, a row fetched) belongs to the data tools
+ * (e.g. the corpus tools' read_file/grep), which mint objects via
+ * ctx.createObject / ctx.registerObject. These tools only *declare relations*
+ * into the lineage graph — they are the agent-facing entry point for the
+ * lineage capability, available to any agent (gated by each state's `tools`
+ * allowlist). They lean on the runtime primitives added in P1/P2:
+ *   - resolveObject  → fail-fast on a fabricated/hallucinated objectId
+ *   - promoteObject  → emit a lazily-registered object on first citation
+ *   - createObject / createRelation → record claim + typed edge
+ */
+
+function unresolved(ctx: ToolContext, objectId: string): boolean {
+  return !!ctx.resolveObject && !ctx.resolveObject(objectId)
+}
+
+async function citeHandler(input: unknown, ctx: ToolContext): Promise<unknown> {
+  const { claim, objectId } = input as { claim: string; objectId: string }
+  if (unresolved(ctx, objectId)) {
+    return { ok: false, error: `objectId '${objectId}' 不存在；请使用工具返回的真实 objectId` }
+  }
+  ctx.promoteObject?.(objectId)
+  const claimObj = ctx.createObject?.({ type: 'claim', meta: { text: claim } })
+  if (claimObj && ctx.createRelation) {
+    ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })
+  }
+  return { ok: true, claimId: claimObj?.objectId, cites: objectId }
+}
+
+async function declareRelationHandler(input: unknown, ctx: ToolContext): Promise<unknown> {
+  const { type, fromObjectId, toObjectId } = input as { type: RelationType; fromObjectId: string; toObjectId: string }
+  for (const id of [fromObjectId, toObjectId]) {
+    if (unresolved(ctx, id)) {
+      return { ok: false, error: `objectId '${id}' 不存在；请使用工具返回的真实 objectId` }
+    }
+  }
+  ctx.promoteObject?.(fromObjectId)
+  ctx.promoteObject?.(toObjectId)
+  ctx.createRelation?.({ type, fromObjectId, toObjectId })
+  return { ok: true, type, fromObjectId, toObjectId }
+}
+
+export const lineageTools: ToolDefinition[] = [
+  {
+    name:        'cite',
+    description: 'Record that a claim in your answer is sourced from (cites) an object. Pass the exact claim text and an objectId returned by a data tool (e.g. read_file/grep). Call once per cited claim; never write "(chapter:line)" in prose. Returns { ok:false, error } if the objectId is not a real one you received — re-fetch and retry.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        claim:    { type: 'string', description: 'The exact statement this source supports.' },
+        objectId: { type: 'string', description: 'objectId of the supporting object (from a data tool).' },
+      },
+      required: ['claim', 'objectId'],
+    },
+    handler: citeHandler,
+  },
+  {
+    name:        'declare_relation',
+    description: 'Declare a typed lineage edge between two existing objects (cites / derives_from / supersedes / equivalent_to). Both objectIds must be ones returned by data tools. Returns { ok:false, error } for an unknown objectId.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type:         { type: 'string', enum: ['cites', 'derives_from', 'supersedes', 'equivalent_to'], description: 'Relation type.' },
+        fromObjectId: { type: 'string', description: 'Source objectId.' },
+        toObjectId:   { type: 'string', description: 'Target objectId.' },
+      },
+      required: ['type', 'fromObjectId', 'toObjectId'],
+    },
+    handler: declareRelationHandler,
+  },
+]


### PR DESCRIPTION
#113 的 **P3**(cite 提升为框架标准工具)。**Stacked on #117(P2)**。

## 改动
- 新增 `src/tools/lineage.ts`:框架内置 `cite`(claim cites object)+ 通用 `declare_relation`(两个已有 object 间的 typed edge)。都 fail-fast(P1)+ promote(P2)。
- 在 `AgentRuntime` 与 system/cognitive 工具一并注册(任意 agent 可用,受 state.tools allowlist 约束)。
- example:`cite` 从 corpus-tools 移除(现为框架级);corpus 工具只**产出** object(read_file/grep)。

**保持最小**:不加投机的 derive/supersede 别名——`declare_relation` 已通用覆盖其它 relation type,别名等真实消费者出现再加(避免过度工程)。

## TDD
红(移除 example cite → cite 未注册,测试失败)→ 绿(内置接管)。

## 测试(充分)
- 内置 cite 经 example 端到端(P1/P2 全部用例回归通过 = 内置 cite 工作)
- `declare_relation` 连边 + fail-fast
- **6 个核心单测**(mock ctx:cite/declare_relation 两分支 + 无 lineage 时优雅降级)
- 回归:core 524/524、example 67/67、浏览器零真实 JS 错误

Part of #113。下一步 P4:object 拆 role/resourceKind + resolver + 可扩展词表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)