### PR TITLE
feat(#113 P4): extensible lineage vocabulary (namespaced types)

### DIFF
--- a/docs/lineage-taxonomy.md
+++ b/docs/lineage-taxonomy.md
@@ -63,6 +63,24 @@ Shared object/relation fields (carried in the event payloads, see #37/#38):
 `tag`, `source-uri`, `version`. These are reserved names; v1 does not require them
 but producers must not repurpose them.
 
+**Extensible types (#113 P4).** `ObjectType` / `RelationType` are no longer hard
+closed unions: the core kinds above stay the framework's controlled vocabulary,
+but an application MAY introduce its own kind using a `namespace:kind` convention
+— e.g. `code:function`, `db:row` (objects), `app:tested_by` (relations). The
+namespace keeps cross-run queries meaningful: a consumer can group by core kind
+*and* distinguish app kinds, instead of colliding in one flat space. Core kinds
+carry no namespace; app kinds MUST. Apps that need a custom-typed object/relation
+define their own producer tool (using `ctx.createObject` / `ctx.createRelation`);
+the framework's built-in `cite` / `declare_relation` cover the core vocabulary.
+
+> **Deferred (not built — avoids premature abstraction).** The taxonomy also
+> anticipates splitting an object's type into a closed `role` (source / claim /
+> derived) and an open `resourceKind` (passage / file / function / …), plus a
+> `resourceKind → resolver` registration so a UI/verifier can fetch any cited
+> resource's real bytes. With a single resource kind (`passage`) today, building
+> that registry would be premature; it lands when a second resource kind exists.
+> See #113 (P4 scope note).
+
 ## Emit hook locations (三国 example — indicative, not implemented by #39)
 
 - **`object.created` (passage):** `examples/agent-docs-qa/tools/corpus-tools.ts`

--- a/src/__tests__/lineageVocab.test.ts
+++ b/src/__tests__/lineageVocab.test.ts
@@ -1,0 +1,25 @@
+import type { ObjectType, RelationType, CoreObjectType, CoreRelationType } from '../trace/types'
+
+// #113 P4: the lineage vocabulary is extensible. The TYPE ANNOTATIONS below are
+// the real assertions — `const x: ObjectType = 'code:function'` only compiles
+// under the widened union; a closed union would make `tsc --noEmit` fail. The
+// runtime expects are sanity checks.
+describe('lineage vocabulary is extensible (#113 P4)', () => {
+  it('core object/relation types remain a controlled vocabulary', () => {
+    const coreObj: CoreObjectType = 'passage'
+    const coreRel: CoreRelationType = 'cites'
+    expect(coreObj).toBe('passage')
+    expect(coreRel).toBe('cites')
+  })
+
+  it('namespaced app types are assignable alongside core ones', () => {
+    const appObj: ObjectType = 'code:function'        // closed union → TS error
+    const appRel: RelationType = 'app:tested_by'      // closed union → TS error
+    const objs: ObjectType[]   = ['passage', 'claim', 'code:function', 'db:row']
+    const rels: RelationType[] = ['cites', 'derives_from', 'app:tested_by']
+    expect(appObj.startsWith('code:')).toBe(true)
+    expect(appRel.includes(':')).toBe(true)
+    expect(objs).toContain('db:row')
+    expect(rels).toContain('app:tested_by')
+  })
+})

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -254,11 +254,21 @@ export interface FsmTransitionPayload {
 
 // ---- Lineage payloads (#37 / #38; vocabulary in docs/lineage-taxonomy.md) ----
 
-/** Object types — closed vocabulary (#39). v1 ships `passage`. */
-export type ObjectType = 'passage' | 'file' | 'claim' | 'artifact-blob'
+/** Core object types — the framework's controlled vocabulary (#39). */
+export type CoreObjectType = 'passage' | 'file' | 'claim' | 'artifact-blob'
+/**
+ * Object type (#113 P4 — extensible). Apps MAY add their own kinds using a
+ * `namespace:kind` convention, e.g. `code:function`, `db:row`, so cross-run
+ * queries can still group by core kind while distinguishing app kinds (see
+ * docs/lineage-taxonomy.md). The `(string & {})` keeps autocomplete for the core
+ * set while permitting namespaced extensions — no longer a hard closed union.
+ */
+export type ObjectType = CoreObjectType | (string & {})
 
-/** Relation types — closed vocabulary (#39). v1 ships `cites`. */
-export type RelationType = 'cites' | 'derives_from' | 'supersedes' | 'equivalent_to'
+/** Core relation types — the framework's controlled vocabulary (#39). */
+export type CoreRelationType = 'cites' | 'derives_from' | 'supersedes' | 'equivalent_to'
+/** Relation type (#113 P4 — extensible, same `namespace:kind` convention). */
+export type RelationType = CoreRelationType | (string & {})
 
 /**
  * #37: a content-addressable artifact an agent read or produced. Mints a stable


### PR DESCRIPTION
#113 的 **P4**(收尾)。**Stacked on #119(P3)**。

## 范围判断(重要)
P4 原本捆绑四件事。本 PR 只做**非过早抽象**的那件——**可扩展词表**(`封闭 union 挡路` 的真实 blocker)。其余(object 拆 role/resourceKind、resourceKind→resolver 注册、前端 resolver 改写)在**只有一种 resource kind(passage)**时构建属于过早抽象,与"避免过度工程"原则冲突,故**显式 DEFER**,待出现第二种 resource kind 再做(已写进 taxonomy doc + 本 issue 备注)。

## 改动
- `ObjectType`/`RelationType` 从硬封闭 union → "核心受控词表 + `(string & {})`":核心 kind 保留自动补全,应用用 `namespace:kind` 约定(`code:function`/`db:row`/`app:tested_by`)扩展,命名空间保证跨 run 查询仍有意义。导出 `CoreObjectType`/`CoreRelationType`。
- taxonomy doc 记录命名空间约定 + deferred 说明。

## 测试
命名空间类型的类型标注**只在放宽 union 下编译**(`tsc` 是真正的 gate)+ 运行时 sanity。回归:core 526/526、example 67/67。

Part of #113。

🤖 Generated with [Claude Code](https://claude.com/claude-code)