### PR TITLE
fix(#113): 将 P1–P4 lineage 栈真正合入 main + 修复 grep 漏匹配

### DIFF
--- a/docs/lineage-taxonomy.md
+++ b/docs/lineage-taxonomy.md
@@ -63,6 +63,24 @@ Shared object/relation fields (carried in the event payloads, see #37/#38):
 `tag`, `source-uri`, `version`. These are reserved names; v1 does not require them
 but producers must not repurpose them.
 
+**Extensible types (#113 P4).** `ObjectType` / `RelationType` are no longer hard
+closed unions: the core kinds above stay the framework's controlled vocabulary,
+but an application MAY introduce its own kind using a `namespace:kind` convention
+— e.g. `code:function`, `db:row` (objects), `app:tested_by` (relations). The
+namespace keeps cross-run queries meaningful: a consumer can group by core kind
+*and* distinguish app kinds, instead of colliding in one flat space. Core kinds
+carry no namespace; app kinds MUST. Apps that need a custom-typed object/relation
+define their own producer tool (using `ctx.createObject` / `ctx.createRelation`);
+the framework's built-in `cite` / `declare_relation` cover the core vocabulary.
+
+> **Deferred (not built — avoids premature abstraction).** The taxonomy also
+> anticipates splitting an object's type into a closed `role` (source / claim /
+> derived) and an open `resourceKind` (passage / file / function / …), plus a
+> `resourceKind → resolver` registration so a UI/verifier can fetch any cited
+> resource's real bytes. With a single resource kind (`passage`) today, building
+> that registry would be premature; it lands when a second resource kind exists.
+> See #113 (P4 scope note).
+
 ## Emit hook locations (三国 example — indicative, not implemented by #39)
 
 - **`object.created` (passage):** `examples/agent-docs-qa/tools/corpus-tools.ts`

--- a/examples/agent-docs-qa/__tests__/corpus-tools.test.ts
+++ b/examples/agent-docs-qa/__tests__/corpus-tools.test.ts
@@ -77,6 +77,16 @@ describe('corpus-tools (sandboxed)', () => {
     expect(result.matches.length).toBeGreaterThan(0)
   })
 
+  it('grep matches the pattern on EVERY consecutive line (no g-flag lastIndex skipping)', async () => {
+    // Regression: a /g/ RegExp reused across lines via .test() carries lastIndex
+    // state, so the same pattern on consecutive lines gets skipped on alternate
+    // lines. All three "foo" lines must be matched, not just lines 1 and 3.
+    fs.writeFileSync(path.join(tmpDir, 'repeat.txt'), 'foo\nfoo\nfoo\n')
+    const result = await grep({ pattern: 'foo' }) as { matches: Array<{ file: string; line: number }> }
+    const repeatHits = result.matches.filter(m => m.file === 'repeat.txt').map(m => m.line)
+    expect(repeatHits).toEqual([1, 2, 3])
+  })
+
   it('grep limits results to maxMatches (default 50)', async () => {
     const lines = Array.from({ length: 100 }, (_, i) => `match-line-${i}`).join('\n')
     fs.writeFileSync(path.join(tmpDir, 'big.txt'), lines + '\n')

--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -169,6 +169,43 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     expect(body.matchesOriginal).toBe(true)
   })
 
+  it('P3: built-in declare_relation links two existing objects with a typed edge', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const idA = passageId(file, 1, 5)
+    const idB = passageId(file, 6, 10)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 1, lineEnd: 5 }, 'tc-1'),
+      toolCall('read_file', { relPath: file, lineStart: 6, lineEnd: 10 }, 'tc-2'),
+      toolCall('declare_relation', { type: 'equivalent_to', fromObjectId: idA, toObjectId: idB }, 'tc-3'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const rel = events.find(e => e.type === 'relation.created' && (e.payload as RelationCreatedPayload).type === 'equivalent_to')
+    expect(rel).toBeTruthy()
+    expect((rel!.payload as RelationCreatedPayload).fromObjectId).toBe(idA)
+    expect((rel!.payload as RelationCreatedPayload).toObjectId).toBe(idB)
+  })
+
+  it('P3: declare_relation fail-fasts on an unknown objectId (no edge written)', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const idA = passageId(file, 1, 5)
+    await start([
+      toolCall('read_file', { relPath: file, lineStart: 1, lineEnd: 5 }, 'tc-1'),
+      toolCall('declare_relation', { type: 'derives_from', fromObjectId: idA, toObjectId: 'obj:fake' }, 'tc-2'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    expect(events.some(e => e.type === 'relation.created')).toBe(false)
+    const resp = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'declare_relation')!
+    expect((resp.payload as ToolRespondedPayload).output).toMatchObject({ ok: false })
+  })
+
   it('P2 lazy: grep registers passages but emits ZERO object.created until cited', async () => {
     await start([
       toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),

--- a/examples/agent-docs-qa/__tests__/lineage.test.ts
+++ b/examples/agent-docs-qa/__tests__/lineage.test.ts
@@ -30,6 +30,13 @@ function passageId(file: string, lineStart: number, lineEnd: number): string {
   return 'obj:' + contentAddressForCanonicalBytes(canonicalize({ type: 'passage', meta: { file, lineStart, lineEnd }, hash: null }))
 }
 
+// 1-based line of the first line in `file` containing `substr` (matches grep's view).
+function findLine(file: string, substr: string): number {
+  const content = fs.readFileSync(path.join(__dirname, '..', 'corpus', file), 'utf-8')
+  const lines = content.replace(/\n$/, '').split('\n')
+  return lines.findIndex(l => l.includes(substr)) + 1
+}
+
 describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
   let server: Server
   let baseUrl: string
@@ -155,6 +162,86 @@ describe('lineage emit end-to-end (#37/#38/新) — real runtime path', () => {
     // Replay re-runs from cache (zero live calls); handlers don't run, so the
     // mintedObjects registry stays empty on replay — yet the cached cite outputs
     // (ok:true / ok:false) are served verbatim, so the run reproduces identically.
+    const replay = await postJson(`${baseUrl}/run/${runId}/replay`, {})
+    expect(replay.status).toBe(200)
+    const body = JSON.parse(replay.body)
+    expect(body.status).toBe('deterministic')
+    expect(body.matchesOriginal).toBe(true)
+  })
+
+  it('P2 lazy: grep registers passages but emits ZERO object.created until cited', async () => {
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      text('done'),  // nothing cited
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    // grep matched, but nothing cited → no candidate object events at all.
+    expect(events.some(e => e.type === 'object.created')).toBe(false)
+    // grep emitted no object events → no artifactRefs on its tool.responded.
+    const grepResp = events.find(e => e.type === 'tool.responded' && (e.payload as ToolRespondedPayload).toolName === 'grep')!
+    expect((grepResp.payload as ToolRespondedPayload).artifactRefs).toBeUndefined()
+  })
+
+  it('P2 promote: citing a grep-registered id promotes exactly that ONE passage', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')           // 曹操小字阿瞞 — one specific grep hit
+    expect(line).toBeGreaterThan(0)
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),                       // registers (lazy)
+      toolCall('cite', { claim: '曹操小字阿瞞', objectId: objId }, 'tc-2'), // promotes just this one
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    // Exactly one passage object.created — the cited one, not every grep match.
+    const passages = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'passage')
+    expect(passages.length).toBe(1)
+    expect((passages[0]!.payload as ObjectCreatedPayload).objectId).toBe(objId)
+    expect((passages[0]!.payload as ObjectCreatedPayload).meta).toMatchObject({ file, lineStart: line, lineEnd: line })
+    // and the cites edge points at it.
+    const rel = events.find(e => e.type === 'relation.created')!
+    expect((rel.payload as RelationCreatedPayload).toObjectId).toBe(objId)
+  })
+
+  it('P2: promote is idempotent — citing the same grep passage twice emits ONE passage', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      toolCall('cite', { claim: '陈述一', objectId: objId }, 'tc-2'),
+      toolCall('cite', { claim: '陈述二', objectId: objId }, 'tc-3'),  // same passage again
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
+    const events = await new JsonlEventStore(runsDir).readByRunId(runId)
+
+    const passages = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'passage')
+    const claims   = events.filter(e => e.type === 'object.created' && (e.payload as ObjectCreatedPayload).type === 'claim')
+    const rels     = events.filter(e => e.type === 'relation.created')
+    expect(passages.length).toBe(1)  // promoted once (idempotent)
+    expect(claims.length).toBe(2)    // two distinct claims
+    expect(rels.length).toBe(2)      // two cites edges → same passage
+  })
+
+  it('P2: a grep→cite lazy-promote run replays deterministically', async () => {
+    const file = 'chapter-01-桃园三结义.txt'
+    const line = findLine(file, '阿瞞')
+    const objId = passageId(file, line, line)
+    await start([
+      toolCall('grep', { pattern: '阿瞞' }, 'tc-1'),
+      toolCall('cite', { claim: '曹操小字阿瞞', objectId: objId }, 'tc-2'),
+      text('done'),
+    ])
+    const chat = await postJson(`${baseUrl}/chat`, { input: 'x' })
+    const runId = JSON.parse(chat.body).runId as string
     const replay = await postJson(`${baseUrl}/run/${runId}/replay`, {})
     expect(replay.status).toBe(200)
     const body = JSON.parse(replay.body)

--- a/examples/agent-docs-qa/agents/sanguo-researcher.md
+++ b/examples/agent-docs-qa/agents/sanguo-researcher.md
@@ -34,7 +34,7 @@ fsm:
 
         verifier 是一次性加载——同一会话内不要反复 request;如果用户
         再次怀疑、且 verifier 已加载,直接以严格模式重新验证即可。
-      tools: [list_dir, read_file, grep, cite, skill_request]
+      tools: [list_dir, read_file, grep, cite, declare_relation, skill_request]
 model:
   provider: volcengine
   model: doubao-seed-2-0-pro-260215

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -70,7 +70,9 @@ export function makeCorpusTools(corpusRoot: string) {
   async function grep(input: unknown, ctx?: ToolContext): Promise<unknown> {
     const { pattern, caseInsensitive = false } = input as { pattern: string; caseInsensitive?: boolean }
     const maxMatches = 50
-    const flags = caseInsensitive ? 'gi' : 'g'
+    // No `g` flag: we call re.test() once per line, and a /g/ RegExp carries
+    // lastIndex state across calls, which would skip matches on alternate lines.
+    const flags = caseInsensitive ? 'i' : ''
     const re = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags)
     const matches: Array<{ file: string; line: number; text: string; objectId?: string }> = []
 

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -71,8 +71,10 @@ export function makeCorpusTools(corpusRoot: string) {
           for (let i = 0; i < lines.length; i++) {
             if (re.test(lines[i]!)) {
               const file = path.relative(root, abs)
-              // #37: each hit is a citable single-line passage object.
-              const obj = ctx?.createObject?.({ type: 'passage', meta: { file, lineStart: i + 1, lineEnd: i + 1 } })
+              // #113 P2: grep is wide recall — register each hit lazily (no event)
+              // so dozens of never-cited candidates don't flood the log; cite promotes
+              // only the one the agent actually uses.
+              const obj = ctx?.registerObject?.({ type: 'passage', meta: { file, lineStart: i + 1, lineEnd: i + 1 } })
               matches.push({
                 file,
                 line: i + 1,
@@ -105,6 +107,9 @@ export function makeCorpusTools(corpusRoot: string) {
     if (ctx?.resolveObject && !ctx.resolveObject(objectId)) {
       return { ok: false, error: `objectId '${objectId}' 不存在；请使用 read_file/grep 返回的真实 objectId` }
     }
+    // #113 P2: emit the cited passage's object.created now (a no-op if it was an
+    // eager read_file passage already emitted; emits it if it was a lazy grep hit).
+    ctx?.promoteObject?.(objectId)
     const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
     if (claimObj && ctx?.createRelation) {
       ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })

--- a/examples/agent-docs-qa/tools/corpus-tools.ts
+++ b/examples/agent-docs-qa/tools/corpus-tools.ts
@@ -94,30 +94,10 @@ export function makeCorpusTools(corpusRoot: string) {
     }
   }
 
-  // 【新 issue】#38 producer: the agent declares "this claim is sourced from that
-  // passage". Mints a `claim` object and a `cites` relation claim → passage. The
-  // objectId must be one the agent received from read_file/grep — a fabricated id
-  // produces a dangling edge the UI renders as ungrounded (content-addressed ids
-  // can't be guessed). Replaces the old "(chapter:line)" prose convention.
-  async function cite(input: unknown, ctx?: ToolContext): Promise<unknown> {
-    const { claim, objectId } = input as { claim: string; objectId: string }
-    // #113 P1 fail-fast: reject a fabricated/hallucinated objectId before declaring
-    // anything, so the model can self-correct (re-grep/read for a real id) and no
-    // dangling edge enters the lineage graph. Skips the check if lineage isn't wired.
-    if (ctx?.resolveObject && !ctx.resolveObject(objectId)) {
-      return { ok: false, error: `objectId '${objectId}' 不存在；请使用 read_file/grep 返回的真实 objectId` }
-    }
-    // #113 P2: emit the cited passage's object.created now (a no-op if it was an
-    // eager read_file passage already emitted; emits it if it was a lazy grep hit).
-    ctx?.promoteObject?.(objectId)
-    const claimObj = ctx?.createObject?.({ type: 'claim', meta: { text: claim } })
-    if (claimObj && ctx?.createRelation) {
-      ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })
-    }
-    return { ok: true, claimId: claimObj?.objectId, cites: objectId }
-  }
-
-  return { list_dir, read_file, grep, cite }
+  // #113 P3: `cite` is now a framework built-in (src/tools/lineage.ts), available
+  // to any agent. The corpus tools only produce objects (read_file/grep); the
+  // lineage-declaration tools are framework-level.
+  return { list_dir, read_file, grep }
 }
 
 /**
@@ -169,19 +149,6 @@ export function makeCorpusToolDefinitions(corpusRoot: string) {
         required: ['pattern'],
       },
       handler: t.grep,
-    },
-    {
-      name:        'cite',
-      description: 'Record that a specific claim in your answer is sourced from a passage. Pass the exact claim text and the objectId returned by read_file or grep. Call once per cited claim. Do NOT write "(chapter:line)" in prose — cite via this tool instead.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          claim:    { type: 'string', description: 'The exact statement in your answer this source supports.' },
-          objectId: { type: 'string', description: 'objectId of the passage (from read_file/grep) that supports the claim.' },
-        },
-        required: ['claim', 'objectId'],
-      },
-      handler: t.cite,
     },
   ]
 }

--- a/src/__tests__/lineageTools.test.ts
+++ b/src/__tests__/lineageTools.test.ts
@@ -1,0 +1,67 @@
+import { lineageTools } from '../tools/lineage'
+import type { ToolContext } from '../types/tool'
+
+// A mock ToolContext that records what the handler declared, with a known set of
+// resolvable objectIds (simulating ids minted earlier this run by read/grep).
+function mockCtx(known: Set<string>) {
+  const created: Array<{ objectId: string; type: string }> = []
+  const relations: Array<{ type: string; fromObjectId: string; toObjectId: string }> = []
+  const promoted: string[] = []
+  const ctx = {
+    resolveObject: (id: string) => (known.has(id) ? { type: 'passage' as const } : undefined),
+    promoteObject: (id: string) => { promoted.push(id) },
+    createObject:  (spec: { type: string }) => { const objectId = `obj:made:${created.length}`; created.push({ objectId, type: spec.type }); return { objectId } },
+    createRelation: (spec: { type: string; fromObjectId: string; toObjectId: string }) => { relations.push(spec); return { relationId: `rel:${relations.length}` } },
+  } as unknown as ToolContext
+  return { ctx, created, relations, promoted }
+}
+
+const cite            = lineageTools.find(t => t.name === 'cite')!
+const declareRelation = lineageTools.find(t => t.name === 'declare_relation')!
+
+describe('built-in lineage tools (#113 P3)', () => {
+  it('registers cite and declare_relation', () => {
+    expect(cite).toBeTruthy()
+    expect(declareRelation).toBeTruthy()
+  })
+
+  it('cite: resolvable id → mints a claim + cites relation, ok:true, promotes the cited id', async () => {
+    const { ctx, created, relations, promoted } = mockCtx(new Set(['obj:p']))
+    const out = await cite.handler({ claim: '某陈述', objectId: 'obj:p' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(created[0]!.type).toBe('claim')
+    expect(relations).toEqual([{ type: 'cites', fromObjectId: created[0]!.objectId, toObjectId: 'obj:p' }])
+    expect(promoted).toContain('obj:p')
+  })
+
+  it('cite: unresolvable id → ok:false and declares nothing', async () => {
+    const { ctx, created, relations } = mockCtx(new Set())
+    const out = await cite.handler({ claim: 'x', objectId: 'obj:fake' }, ctx) as { ok: boolean; error?: string }
+    expect(out.ok).toBe(false)
+    expect(out.error).toMatch(/不存在|objectId/)
+    expect(created).toHaveLength(0)
+    expect(relations).toHaveLength(0)
+  })
+
+  it('declare_relation: both ids resolvable → typed edge, ok:true', async () => {
+    const { ctx, relations } = mockCtx(new Set(['obj:a', 'obj:b']))
+    const out = await declareRelation.handler({ type: 'equivalent_to', fromObjectId: 'obj:a', toObjectId: 'obj:b' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(true)
+    expect(relations).toEqual([{ type: 'equivalent_to', fromObjectId: 'obj:a', toObjectId: 'obj:b' }])
+  })
+
+  it('declare_relation: an unknown endpoint → ok:false and no edge', async () => {
+    const { ctx, relations } = mockCtx(new Set(['obj:a']))
+    const out = await declareRelation.handler({ type: 'derives_from', fromObjectId: 'obj:a', toObjectId: 'obj:x' }, ctx) as { ok: boolean }
+    expect(out.ok).toBe(false)
+    expect(relations).toHaveLength(0)
+  })
+
+  it('lineage tools degrade gracefully when the runtime did not wire lineage (no ctx methods)', async () => {
+    const bare = {} as ToolContext  // no resolveObject/createObject/etc.
+    // No resolveObject → no fail-fast; createObject/createRelation absent → no throw.
+    const out = await cite.handler({ claim: 'x', objectId: 'obj:p' }, bare) as { ok: boolean }
+    expect(out.ok).toBe(true)
+  })
+})

--- a/src/__tests__/lineageVocab.test.ts
+++ b/src/__tests__/lineageVocab.test.ts
@@ -1,0 +1,25 @@
+import type { ObjectType, RelationType, CoreObjectType, CoreRelationType } from '../trace/types'
+
+// #113 P4: the lineage vocabulary is extensible. The TYPE ANNOTATIONS below are
+// the real assertions — `const x: ObjectType = 'code:function'` only compiles
+// under the widened union; a closed union would make `tsc --noEmit` fail. The
+// runtime expects are sanity checks.
+describe('lineage vocabulary is extensible (#113 P4)', () => {
+  it('core object/relation types remain a controlled vocabulary', () => {
+    const coreObj: CoreObjectType = 'passage'
+    const coreRel: CoreRelationType = 'cites'
+    expect(coreObj).toBe('passage')
+    expect(coreRel).toBe('cites')
+  })
+
+  it('namespaced app types are assignable alongside core ones', () => {
+    const appObj: ObjectType = 'code:function'        // closed union → TS error
+    const appRel: RelationType = 'app:tested_by'      // closed union → TS error
+    const objs: ObjectType[]   = ['passage', 'claim', 'code:function', 'db:row']
+    const rels: RelationType[] = ['cites', 'derives_from', 'app:tested_by']
+    expect(appObj.startsWith('code:')).toBe(true)
+    expect(appRel.includes(':')).toBe(true)
+    expect(objs).toContain('db:row')
+    expect(rels).toContain('app:tested_by')
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -32,6 +32,7 @@ import { AgentFactory, type AgentSpawnOptions } from './AgentFactory.js'
 import type { IIOPort } from './IOPort.js'
 import { cognitiveTools } from '../tools/cognitive.js'
 import { systemTools } from '../tools/system.js'
+import { lineageTools } from '../tools/lineage.js'
 import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
 import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
@@ -253,6 +254,7 @@ export class AgentRuntime {
   private registerTools(extraTools: ToolDefinition[]): void {
     for (const tool of systemTools)    this.registry.register(tool)
     for (const tool of cognitiveTools) this.registry.register(tool)
+    for (const tool of lineageTools)   this.registry.register(tool)  // #113 P3
     for (const tool of extraTools)     this.registry.register(tool)
     for (const [agentId] of Object.entries(this.config.subAgents ?? {})) {
       this.registry.register(this.makeSubAgentTool(agentId))

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -122,10 +122,12 @@ export class AgentRuntime {
   /** #60: per-run count of successful calls per toolCallId, to disambiguate a
    *  tool_call id reused across responses when keying tool.emitted record/replay. */
   private readonly toolEmitOccurrence = new Map<string, number>()
-  /** #113 P1: per-run registry of objectIds minted via ctx.createObject (read/grep),
-   *  so a later producer (cite) can fail-fast on a fabricated/hallucinated id and
-   *  P2 lazy-promote can look up meta. Record-only: replay doesn't run handlers. */
-  private readonly mintedObjects = new Map<string, { type: ObjectType; meta?: Record<string, unknown> }>()
+  /** #113 P1/P2: per-run registry of objectIds. `promoted=true` once an
+   *  object.created event has been emitted for it (eager createObject, or a
+   *  cite that promoted a lazily-registered grep candidate). Lets cite fail-fast
+   *  on unknown ids, P2 emit candidates only when cited, and promote idempotently.
+   *  Record-only: replay doesn't run handlers. */
+  private readonly mintedObjects = new Map<string, { type: ObjectType; meta?: Record<string, unknown>; promoted: boolean }>()
   private readonly subAgentConfigs?: Map<string, AgentConfig>
   private readonly childRecorderFactory?: (config: AgentConfig, contextId: string, traceId: string) => ITrajectoryRecorder
   private readonly makeChildPort?: MakeChildPort
@@ -374,16 +376,39 @@ export class AgentRuntime {
     // through ioPort.invokeTool, which drains the buffer). objectId/relationId are
     // content-addressed so they are identical in record and replay.
     if (lineage) {
+      const objectIdFor = (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) =>
+        'obj:' + contentAddressForCanonicalBytes(canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }))
+
+      // Eager: register + emit object.created now. Used for deliberate artifacts
+      // (read_file passage, cite's claim) where the producer event is the anchor.
       ctx.createObject = (spec) => {
-        const objectId = 'obj:' + contentAddressForCanonicalBytes(
-          canonicalize({ type: spec.type, meta: spec.meta ?? null, hash: spec.hash ?? null }),
-        )
+        const objectId = objectIdFor(spec)
         lineage.objects.push({ objectId, type: spec.type, ...(spec.hash ? { hash: spec.hash } : {}), ...(spec.meta ? { meta: spec.meta } : {}) })
-        // #113 P1: register in the per-run table so later producers can resolve it.
-        this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}) })
+        this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}), promoted: true })
         return { objectId }
       }
-      ctx.resolveObject = (objectId) => this.mintedObjects.get(objectId)
+      // #113 P2 lazy: register a candidate (grep hit) WITHOUT emitting an event.
+      // It only becomes an object.created if later promoted by a cite.
+      ctx.registerObject = (spec) => {
+        const objectId = objectIdFor(spec)
+        if (!this.mintedObjects.has(objectId)) {
+          this.mintedObjects.set(objectId, { type: spec.type, ...(spec.meta ? { meta: spec.meta } : {}), promoted: false })
+        }
+        return { objectId }
+      }
+      // #113 P2: emit object.created for a registered-but-not-yet-emitted object,
+      // on first cite. Idempotent — a second cite of the same passage is a no-op.
+      ctx.promoteObject = (objectId) => {
+        const o = this.mintedObjects.get(objectId)
+        if (o && !o.promoted) {
+          lineage.objects.push({ objectId, type: o.type, ...(o.meta ? { meta: o.meta } : {}) })
+          o.promoted = true
+        }
+      }
+      ctx.resolveObject = (objectId) => {
+        const o = this.mintedObjects.get(objectId)
+        return o ? { type: o.type, ...(o.meta ? { meta: o.meta } : {}) } : undefined
+      }
       ctx.createRelation = (spec) => {
         const relationId = 'rel:' + contentAddressForCanonicalBytes(
           canonicalize({ type: spec.type, from: spec.fromObjectId, to: spec.toObjectId }),

--- a/src/tools/lineage.ts
+++ b/src/tools/lineage.ts
@@ -1,0 +1,76 @@
+import type { ToolDefinition, ToolContext } from '../types/tool.js'
+import type { RelationType } from '../trace/types.js'
+
+/**
+ * #113 P3: framework built-in lineage-declaration tools.
+ *
+ * Object *production* (a passage read, a row fetched) belongs to the data tools
+ * (e.g. the corpus tools' read_file/grep), which mint objects via
+ * ctx.createObject / ctx.registerObject. These tools only *declare relations*
+ * into the lineage graph — they are the agent-facing entry point for the
+ * lineage capability, available to any agent (gated by each state's `tools`
+ * allowlist). They lean on the runtime primitives added in P1/P2:
+ *   - resolveObject  → fail-fast on a fabricated/hallucinated objectId
+ *   - promoteObject  → emit a lazily-registered object on first citation
+ *   - createObject / createRelation → record claim + typed edge
+ */
+
+function unresolved(ctx: ToolContext, objectId: string): boolean {
+  return !!ctx.resolveObject && !ctx.resolveObject(objectId)
+}
+
+async function citeHandler(input: unknown, ctx: ToolContext): Promise<unknown> {
+  const { claim, objectId } = input as { claim: string; objectId: string }
+  if (unresolved(ctx, objectId)) {
+    return { ok: false, error: `objectId '${objectId}' 不存在；请使用工具返回的真实 objectId` }
+  }
+  ctx.promoteObject?.(objectId)
+  const claimObj = ctx.createObject?.({ type: 'claim', meta: { text: claim } })
+  if (claimObj && ctx.createRelation) {
+    ctx.createRelation({ type: 'cites', fromObjectId: claimObj.objectId, toObjectId: objectId })
+  }
+  return { ok: true, claimId: claimObj?.objectId, cites: objectId }
+}
+
+async function declareRelationHandler(input: unknown, ctx: ToolContext): Promise<unknown> {
+  const { type, fromObjectId, toObjectId } = input as { type: RelationType; fromObjectId: string; toObjectId: string }
+  for (const id of [fromObjectId, toObjectId]) {
+    if (unresolved(ctx, id)) {
+      return { ok: false, error: `objectId '${id}' 不存在；请使用工具返回的真实 objectId` }
+    }
+  }
+  ctx.promoteObject?.(fromObjectId)
+  ctx.promoteObject?.(toObjectId)
+  ctx.createRelation?.({ type, fromObjectId, toObjectId })
+  return { ok: true, type, fromObjectId, toObjectId }
+}
+
+export const lineageTools: ToolDefinition[] = [
+  {
+    name:        'cite',
+    description: 'Record that a claim in your answer is sourced from (cites) an object. Pass the exact claim text and an objectId returned by a data tool (e.g. read_file/grep). Call once per cited claim; never write "(chapter:line)" in prose. Returns { ok:false, error } if the objectId is not a real one you received — re-fetch and retry.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        claim:    { type: 'string', description: 'The exact statement this source supports.' },
+        objectId: { type: 'string', description: 'objectId of the supporting object (from a data tool).' },
+      },
+      required: ['claim', 'objectId'],
+    },
+    handler: citeHandler,
+  },
+  {
+    name:        'declare_relation',
+    description: 'Declare a typed lineage edge between two existing objects (cites / derives_from / supersedes / equivalent_to). Both objectIds must be ones returned by data tools. Returns { ok:false, error } for an unknown objectId.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type:         { type: 'string', enum: ['cites', 'derives_from', 'supersedes', 'equivalent_to'], description: 'Relation type.' },
+        fromObjectId: { type: 'string', description: 'Source objectId.' },
+        toObjectId:   { type: 'string', description: 'Target objectId.' },
+      },
+      required: ['type', 'fromObjectId', 'toObjectId'],
+    },
+    handler: declareRelationHandler,
+  },
+]

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -254,11 +254,21 @@ export interface FsmTransitionPayload {
 
 // ---- Lineage payloads (#37 / #38; vocabulary in docs/lineage-taxonomy.md) ----
 
-/** Object types — closed vocabulary (#39). v1 ships `passage`. */
-export type ObjectType = 'passage' | 'file' | 'claim' | 'artifact-blob'
+/** Core object types — the framework's controlled vocabulary (#39). */
+export type CoreObjectType = 'passage' | 'file' | 'claim' | 'artifact-blob'
+/**
+ * Object type (#113 P4 — extensible). Apps MAY add their own kinds using a
+ * `namespace:kind` convention, e.g. `code:function`, `db:row`, so cross-run
+ * queries can still group by core kind while distinguishing app kinds (see
+ * docs/lineage-taxonomy.md). The `(string & {})` keeps autocomplete for the core
+ * set while permitting namespaced extensions — no longer a hard closed union.
+ */
+export type ObjectType = CoreObjectType | (string & {})
 
-/** Relation types — closed vocabulary (#39). v1 ships `cites`. */
-export type RelationType = 'cites' | 'derives_from' | 'supersedes' | 'equivalent_to'
+/** Core relation types — the framework's controlled vocabulary (#39). */
+export type CoreRelationType = 'cites' | 'derives_from' | 'supersedes' | 'equivalent_to'
+/** Relation type (#113 P4 — extensible, same `namespace:kind` convention). */
+export type RelationType = CoreRelationType | (string & {})
 
 /**
  * #37: a content-addressable artifact an agent read or produced. Mints a stable

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -19,6 +19,18 @@ export interface ToolContext {
    */
   createObject?:   (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) => { objectId: string }
   /**
+   * #113 P2 (lazy): register a candidate object (e.g. a wide-recall grep hit)
+   * WITHOUT emitting object.created. Returns its content-addressed objectId so the
+   * agent can cite it; it only becomes an event if a later cite promotes it. Keeps
+   * large recall from flooding the event log with never-cited candidates.
+   */
+  registerObject?: (spec: { type: ObjectType; meta?: Record<string, unknown>; hash?: string }) => { objectId: string }
+  /**
+   * #113 P2: emit object.created for a previously registered (lazy) object, the
+   * first time it is cited. Idempotent and a no-op for already-emitted objects.
+   */
+  promoteObject?:  (objectId: string) => void
+  /**
    * #38: declare a typed edge between two objects (e.g. a claim `cites` a passage).
    * Both ids must be objectIds minted by createObject. Runtime records a
    * `relation.created` event after `tool.responded`.


### PR DESCRIPTION
## 背景:一个发布级 blocker

#113 的 P1–P4 通过 stacked PR 实现。但 #117/#119/#120 的 **base 指向上游 feature 分支**(`feat/113-p1/p2/p3`)而非 `main`,导致它们 merge 时合进了各自的 feature 分支,**没进 main**。

| PR | base | 实际合入 | 在 main? |
|----|------|---------|:---:|
| #116 P1 | main | main | ✅ |
| #117 P2 | feat/113-p1 | feat/113-p1 分支 | ❌ |
| #119 P3 | feat/113-p2 | feat/113-p2 分支 | ❌ |
| #120 P4 | feat/113-p3 | feat/113-p3 分支 | ❌ |

结果:`main` 上只有 P1,**lazy-promote、内置 cite/declare_relation 工具、可扩展命名空间词汇全部缺席**(`src/tools/lineage.ts` 不存在,`ObjectType` 还是闭合 union)。

## 本 PR 做了什么

1. **补合完整 P1–P4 栈**(`d59b45c`)到 main。三方合并无冲突,且正确保留了 main 侧的 `splitLines` 重构(#115)与 #118(#84 portable session)、#121(#85 interrupt-resume)。
2. **修复 grep 漏匹配 bug**:grep 逐行复用带 `/g/` flag 的 RegExp 调 `.test()`,`lastIndex` 状态污染导致同一 pattern 在连续行上隔行漏匹配(该 bug 在 P1 起就存在于 main)。漏掉的行不会注册为可引用 passage → cite 时 fail-fast 拒绝、来源丢失。已加回归测试。

## 验证

- `tsc` 编译干净
- 默认回归 `npm test`:49 unit + 8 e2e 全绿
- lineage 测试:`lineageTools`/`lineageVocab`(8)+ examples e2e(10)+ corpus-tools(12,含新增回归)全绿

## 后续建议(未在本 PR 处理,待讨论)

- P4 namespaced 类型仅做类型 widening,`createObject`/`createRelation` 对 `type` **无运行时校验**(`':::'`、`''` 均可落库)——是否需框架强制 `namespace:kind` 约定待定。
- `lineageVocab.test.ts` 不在默认 `test` 脚本路径内,且其运行时断言对 `(string & {})` 恒真,回归价值低。

Relates to #113