### PR TITLE
feat(#124): serve 端点增补 — /llm + /session/export·import(含 /context 落地)

### DIFF
--- a/docs/design/124-serve-endpoints.md
+++ b/docs/design/124-serve-endpoints.md
@@ -1,0 +1,104 @@
+# #124 serve 端点增补:一次性 LLM + portable session
+
+> SSOT。需求评估见 issue #124;前置能力见 #84(portable session 库)、#86(serve 最小版)。
+
+## 1. 背景与原则
+
+alfred 用 milkie 替换 dolphin provider,在 #86(serve 最小版)之上还需要两项跨进程能力:
+
+1. **一次性 LLM**(对应 dolphin `call_llm`):memory/compressor 要直接发一枪 LLM 做摘要/压缩,**不跑完整 agent turn**。
+2. **portable session 导出/导入**(对应 alfred 会话持久化):#84 已提供库能力,但 serve 没把它接成 HTTP 端点。
+
+统一原则(与 #86 一脉相承):
+
+> **能力在 Milkie 库层,serve 只补薄 HTTP 投影,CLI 命令暂不做。**
+
+serve 与 CLI 是 Milkie 库的两个并列投影(传输不同、store 接线不同),谁都不"拥有"能力。`serve.ts` 的每个 handler 至今都只调 `milkie.*`、从不直接碰 gateway —— 本次新增保持这一不变量。
+
+serve 当前**单 agent**(`serveMain` 只吃一个 `--agent`,`agentId` 在建 server 时钉死),且 **model 配置只存在于 agent 定义里**(`GatewayFactory` 从 agent 的 `model` 字段建 gateway,没有 server 级独立 model)。
+
+## 2. 一次性 LLM
+
+### 2.1 库层(实质改动)
+
+新增 `Milkie.complete`,镜像既有 `DefaultIOPort.invokeLLM` 的语义,复用 `resolveGateway` / `resolveModel` / `aggregateStream`:
+
+```ts
+async complete(
+  agentId: string,
+  request: { system?: string; messages: Message[] },
+  onEvent?: (e: ModelEvent) => void,
+): Promise<ModelResponse>
+```
+
+- 用 `agentId` 解析该 agent 的 gateway 与 model(`config.model.model`),组装 `ModelRequest`。
+- 无 `onEvent` → `gateway.complete(req)`(非流式)。
+- 有 `onEvent` → `aggregateStream(gateway.stream(req), onEvent)`(逐 token 回调 + 聚合成 `ModelResponse`)。
+- **不进 FSM、不产生 agent run、不写事件流**——纯一次性 completion。
+- agent 不存在 → 抛错(与 `invoke`/`resume` 一致的报错文案)。
+
+> 为何是一个带可选 `onEvent` 的方法而非 `complete`+`stream` 两个:这正是 milkie 既有的 I/O 抽象(`invokeLLM`)形态,避免重复。
+
+### 2.2 serve 投影
+
+```
+POST /llm  { system?, messages, stream? }
+```
+
+- `messages` 必传(canonical `Message[]`,content 为数组);`system` 可选。
+- 借**已加载的唯一 agent** 的 model 配置,**不传 agentId**(单 agent)。
+- `stream` 省略 / false → JSON `{ output, usage? }`,`output` 为响应中 `text` 内容拼接。
+- `stream` = true → `text/event-stream`:逐 `message_delta` 帧 + 终态 `done { usage }`;异常走 `error` 帧 + `done`(不裸断,语义对齐 `/chat`)。
+- `messages` 缺失 → 400。
+
+多 agent 是后续产品决策(#86 刻意单 agent);届时给 `/llm` 加**可选** `agentId` 即可,向后兼容,现在不预留(YAGNI)。
+
+## 3. portable session 导出/导入
+
+### 3.1 库层:已就绪(#84)
+
+```ts
+exportSession(contextId: string): Promise<PortableSession>
+importSession(session: PortableSession): Promise<{ contextId: string }>
+```
+
+无需改动。
+
+### 3.2 serve 投影(纯薄壳)
+
+```
+POST /session/export  { contextId }   → 200 PortableSession JSON
+POST /session/import  { session }      → 200 { contextId }
+```
+
+- `/session/export`:`contextId` 缺失 → 400;无可导 session(库抛 `No session to export`)→ 404。
+- `/session/import`:`session` 缺失 → 400;schemaVersion 不符(库抛 `Unsupported … schemaVersion`)→ 400。
+- 库层抛错经 handler 映射为对应 4xx(默认 500 兜底)。
+
+### 3.3 语义提醒(给 alfred,非本期实现)
+
+export 是「最新 run + 子孙 run 的**前向状态快照**」,**非完整逐轮 transcript**(#84 决策 1)。若 compressor 需要全量历史原文,需补 by-context run 索引——单列 follow-up,本期不做。
+
+## 4. 附带:落地孤儿提交
+
+本地 `05c2169`(serve `/context/set·get·list` 端点 + 测试,#83 相关)此前从未合入 main,随本 PR 一并落地。
+
+## 5. 不做
+
+- #87 跨语言工具桥(P2):维持挂起,等 alfred 给出明确的 Python skill 复用清单再评估。
+- CLI 的 `milkie llm` / `milkie session`:抽象已支持,YAGNI,有需求再加(~10 行投影)。
+
+## 6. 测试(TDD)
+
+库层(`milkie-complete.test.ts`):
+- 非流式返回聚合 `output`;
+- 流式逐 token 回调 `onEvent` 且聚合结果与非流式一致;
+- agent 不存在抛错。
+
+serve(`serve.test.ts` 增补):
+- `/llm` 非流式返回 `{ output }`;
+- `/llm` `stream=true` 收到 ≥2 个 `message_delta` + 终态 `done`;
+- `/llm` 错误 gateway → `error` 帧 + `done`;
+- `/llm` 缺 `messages` → 400;
+- `/session/export` 在一次 `/chat` 后返回带 manifest/events/variables 的载荷;无 session → 404;
+- `/session/import` 接受导出载荷返回 `{ contextId }`;schemaVersion 不符 → 400。

--- a/src/__tests__/milkie-complete.test.ts
+++ b/src/__tests__/milkie-complete.test.ts
@@ -1,0 +1,61 @@
+// #124: Milkie.complete — a one-shot LLM completion that bypasses the FSM.
+// It resolves an agent's gateway/model and calls it directly (no agent run, no
+// event log), mirroring DefaultIOPort.invokeLLM: non-streaming when onEvent is
+// omitted, streaming + aggregation when provided.
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+import type { AgentConfig } from '../types/agent'
+import type { Message } from '../types/common'
+
+function textGateway(deltas: string[]): IModelGateway {
+  const full = deltas.join('')
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text: full }], toolCalls: [], usage: { inputTokens: 3, outputTokens: 5 }, finishReason: 'end_turn' }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> {
+      for (const d of deltas) yield { type: 'message_delta', data: { text: d } }
+      yield { type: 'usage', data: { inputTokens: 3, outputTokens: 5 } }
+    },
+  }
+}
+
+const agent: AgentConfig = {
+  agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+  fsm: { states: [{ name: 'react', type: 'llm' }] },
+  model: { provider: 'stub', model: 'stub-model', adapter: 'stub' },
+}
+
+function buildMilkie(gw: IModelGateway): Milkie {
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: gw })
+  milkie.registerAgent(agent)
+  return milkie
+}
+
+const msgs: Message[] = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]
+
+describe('#124 Milkie.complete', () => {
+  it('non-streaming: returns the aggregated response', async () => {
+    const milkie = buildMilkie(textGateway(['Hello, ', 'world!']))
+    const res = await milkie.complete('echo', { messages: msgs })
+    expect(res.content).toEqual([{ type: 'text', text: 'Hello, world!' }])
+    expect(res.usage).toMatchObject({ outputTokens: 5 })
+  })
+
+  it('streaming: forwards token deltas to onEvent and aggregates the same result', async () => {
+    const milkie = buildMilkie(textGateway(['Hel', 'lo']))
+    const deltas: string[] = []
+    const res = await milkie.complete('echo', { messages: msgs }, e => {
+      if (e.type === 'message_delta') deltas.push(e.data.text)
+    })
+    expect(deltas).toEqual(['Hel', 'lo'])
+    expect(res.content).toEqual([{ type: 'text', text: 'Hello' }])
+  })
+
+  it('throws when the agent is unknown', async () => {
+    const milkie = buildMilkie(textGateway(['x']))
+    await expect(milkie.complete('nope', { messages: msgs })).rejects.toThrow(/nope/)
+  })
+})

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -258,4 +258,38 @@ describe('createServeServer', () => {
     expect(res.status).toBe(200)
     expect(res.json).toEqual({ ok: true })
   })
+
+  it('POST /context/set then /context/get round-trips a variable', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const setRes = await request(port, 'POST', '/context/set', { contextId: 'cv', name: 'model_name', value: 'claude' })
+    expect(setRes.status).toBe(200)
+    expect(setRes.json).toMatchObject({ ok: true })
+    const getRes = await request(port, 'POST', '/context/get', { contextId: 'cv', name: 'model_name' })
+    expect(getRes.json).toMatchObject({ value: 'claude' })
+  })
+
+  it('POST /context/get returns null for a missing variable', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/context/get', { contextId: 'cv', name: 'nope' })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ value: null })
+  })
+
+  it('POST /context/list returns all variables for a context', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await request(port, 'POST', '/context/set', { contextId: 'cv', name: 'a', value: '1' })
+    await request(port, 'POST', '/context/set', { contextId: 'cv', name: 'b', value: '2' })
+    const res = await request(port, 'POST', '/context/list', { contextId: 'cv' })
+    expect(res.json).toMatchObject({ vars: { a: '1', b: '2' } })
+  })
+
+  it('POST /context/set without contextId returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/context/set', { name: 'k', value: 'v' })
+    expect(res.status).toBe(400)
+  })
 })

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -292,4 +292,90 @@ describe('createServeServer', () => {
     const res = await request(port, 'POST', '/context/set', { name: 'k', value: 'v' })
     expect(res.status).toBe(400)
   })
+
+  // ─────────────────────────── #124 /llm ───────────────────────────
+
+  const userMsg = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]
+
+  it('POST /llm (non-streaming) returns the aggregated output as JSON', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['Sum', 'mary'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/llm', { messages: userMsg })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ output: 'Summary' })
+  })
+
+  it('POST /llm with stream=true streams token-level message_delta then a done terminal', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['a', 'b', 'c'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const { done } = sse(port, 'POST', '/llm', { messages: userMsg, stream: true })
+    const events = await done
+    const deltas = events.filter(e => e.event === 'message_delta')
+    expect(deltas.map(e => (e.data as { text: string }).text)).toEqual(['a', 'b', 'c'])
+    expect(events.find(e => e.event === 'done')).toBeDefined()
+  })
+
+  it('POST /llm without messages returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/llm', { system: 'only' })
+    expect(res.status).toBe(400)
+    expect(res.json).toMatchObject({ error: expect.stringContaining('messages') })
+  })
+
+  it('POST /llm with stream=true surfaces a failing gateway as an error frame + done', async () => {
+    const { milkie, agentId, broadcaster } = buildErrorMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const { done } = sse(port, 'POST', '/llm', { messages: userMsg, stream: true })
+    const events = await done
+    expect(events.find(e => e.event === 'error')).toBeDefined()
+    expect(events.find(e => e.event === 'done')).toBeDefined()
+  })
+
+  // ──────────────────────── #124 /session ────────────────────────
+
+  it('POST /session/export returns a portable session after a chat', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['ok'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await (await sse(port, 'POST', '/chat', { contextId: 'se', input: 'hi' }).done)
+    const res = await request(port, 'POST', '/session/export', { contextId: 'se' })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ manifest: { schemaVersion: 1, contextId: 'se', agentId } })
+    expect(Array.isArray((res.json as { events: unknown[] }).events)).toBe(true)
+  })
+
+  it('POST /session/export without contextId returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/session/export', {})
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /session/export for an unknown context returns 404', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/session/export', { contextId: 'never' })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST /session/import round-trips an exported session into a fresh server', async () => {
+    const a = buildTextMilkie(['ok'])
+    const portA = await listen(createServeServer(a))
+    await (await sse(portA, 'POST', '/chat', { contextId: 'rt', input: 'hi' }).done)
+    const exported = (await request(portA, 'POST', '/session/export', { contextId: 'rt' })).json
+
+    const b = buildTextMilkie(['ok'])
+    const portB = await listen(createServeServer(b))
+    const res = await request(portB, 'POST', '/session/import', { session: exported })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ contextId: 'rt' })
+  })
+
+  it('POST /session/import with an unsupported schemaVersion returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const bogus = { manifest: { schemaVersion: 999, contextId: 'x', agentId: 'echo', latestRunId: 'r', exportedAt: 0 }, events: [], variables: {} }
+    const res = await request(port, 'POST', '/session/import', { session: bogus })
+    expect(res.status).toBe(400)
+  })
 })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -3,7 +3,7 @@ import { Milkie } from '../runtime/Milkie.js'
 import { BroadcastingEventStore } from '../trace/BroadcastingEventStore.js'
 import { MemoryStore } from '../store/MemoryStore.js'
 import { MemoryEventStore } from '../trace/MemoryEventStore.js'
-import type { AgentResult } from '../types/common.js'
+import type { AgentResult, JSONValue } from '../types/common.js'
 import type { ModelEvent } from '../types/model.js'
 
 /**
@@ -123,6 +123,29 @@ export function createServeServer(opts: ServeOptions): Server {
     )
   }
 
+  // #83: expose session context variables over HTTP so an external (Python)
+  // provider can set/get/list them across the process boundary.
+  async function handleContextSet(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId, name, value } = JSON.parse(await readBody(req)) as { contextId?: string; name?: string; value?: JSONValue }
+    if (!contextId || !name) return sendJson(res, 400, { error: 'contextId and name are required' })
+    await milkie.setContextVar(contextId, name, value as JSONValue)
+    sendJson(res, 200, { ok: true })
+  }
+
+  async function handleContextGet(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId, name } = JSON.parse(await readBody(req)) as { contextId?: string; name?: string }
+    if (!contextId || !name) return sendJson(res, 400, { error: 'contextId and name are required' })
+    const value = await milkie.getContextVar(contextId, name)
+    sendJson(res, 200, { value: value ?? null })
+  }
+
+  async function handleContextList(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId } = JSON.parse(await readBody(req)) as { contextId?: string }
+    if (!contextId) return sendJson(res, 400, { error: 'contextId is required' })
+    const vars = await milkie.listContextVars(contextId)
+    sendJson(res, 200, { vars })
+  }
+
   return http.createServer((req, res) => {
     void (async () => {
       try {
@@ -132,6 +155,9 @@ export function createServeServer(opts: ServeOptions): Server {
         if (req.method === 'POST' && route === '/chat')      return await handleChat(req, res)
         if (req.method === 'POST' && route === '/interrupt') return await handleInterrupt(req, res)
         if (req.method === 'POST' && route === '/resume')    return await handleResume(req, res)
+        if (req.method === 'POST' && route === '/context/set')  return await handleContextSet(req, res)
+        if (req.method === 'POST' && route === '/context/get')  return await handleContextGet(req, res)
+        if (req.method === 'POST' && route === '/context/list') return await handleContextList(req, res)
         sendJson(res, 404, { error: `no route ${req.method} ${route}` })
       } catch (err) {
         sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -3,8 +3,9 @@ import { Milkie } from '../runtime/Milkie.js'
 import { BroadcastingEventStore } from '../trace/BroadcastingEventStore.js'
 import { MemoryStore } from '../store/MemoryStore.js'
 import { MemoryEventStore } from '../trace/MemoryEventStore.js'
-import type { AgentResult, JSONValue } from '../types/common.js'
-import type { ModelEvent } from '../types/model.js'
+import type { AgentResult, JSONValue, Message } from '../types/common.js'
+import type { ModelEvent, ModelResponse } from '../types/model.js'
+import type { PortableSession } from '../runtime/PortableSession.js'
 
 /**
  * #86: `milkie serve` HTTP + SSE sidecar. Built (not started) by this factory so
@@ -17,6 +18,9 @@ import type { ModelEvent } from '../types/model.js'
  *   POST /chat   { contextId, goal?, input }  → text/event-stream (D2)
  *   POST /interrupt { contextId }             → { signaled: true }
  *   POST /resume { contextId, input? }        → text/event-stream
+ *   POST /llm { system?, messages, stream? }  → JSON (or SSE when stream) (#124)
+ *   POST /session/export { contextId }        → PortableSession JSON (#124)
+ *   POST /session/import { session }          → { contextId } (#124)
  */
 export interface ServeOptions {
   milkie:      Milkie
@@ -56,6 +60,11 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 function writeSSE(res: ServerResponse, event: string, data: unknown): void {
   if (res.writableEnded || res.destroyed) return
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+}
+
+/** Concatenate the text content of a model response (#124 /llm output). */
+function outputText(result: ModelResponse): string {
+  return result.content.filter((c): c is { type: 'text'; text: string } => c.type === 'text').map(c => c.text).join('')
 }
 
 export function createServeServer(opts: ServeOptions): Server {
@@ -146,6 +155,57 @@ export function createServeServer(opts: ServeOptions): Server {
     sendJson(res, 200, { vars })
   }
 
+  // #124: one-shot LLM completion (alfred's call_llm). Borrows the single loaded
+  // agent's model config; bypasses the FSM. stream=true → SSE message_delta… +
+  // a `done` terminal (errors as an `error` frame + `done`, never a bare
+  // disconnect); otherwise a single JSON { output, usage }.
+  async function handleLlm(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { system, messages, stream } = JSON.parse(await readBody(req)) as { system?: string; messages?: Message[]; stream?: boolean }
+    if (!Array.isArray(messages) || messages.length === 0) return sendJson(res, 400, { error: 'messages is required' })
+    if (!stream) {
+      const result = await milkie.complete(agentId, { system, messages })
+      return sendJson(res, 200, { output: outputText(result), usage: result.usage })
+    }
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', 'connection': 'keep-alive' })
+    res.on('error', () => { /* client disconnect; writes are guarded by writeSSE */ })
+    try {
+      const result = await milkie.complete(agentId, { system, messages }, e => {
+        if (e.type === 'message_delta') writeSSE(res, 'message_delta', e.data)
+      })
+      writeSSE(res, 'done', { usage: result.usage })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      writeSSE(res, 'error', { message })
+      writeSSE(res, 'done', { error: message })
+    } finally {
+      if (!res.writableEnded && !res.destroyed) res.end()
+    }
+  }
+
+  // #124: project the #84 portable-session library API onto HTTP. Library errors
+  // map to 4xx (no session → 404; unsupported schemaVersion → 400), else 500.
+  async function handleSessionExport(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId } = JSON.parse(await readBody(req)) as { contextId?: string }
+    if (!contextId) return sendJson(res, 400, { error: 'contextId is required' })
+    try {
+      sendJson(res, 200, await milkie.exportSession(contextId))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      sendJson(res, /No session to export/.test(message) ? 404 : 500, { error: message })
+    }
+  }
+
+  async function handleSessionImport(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { session } = JSON.parse(await readBody(req)) as { session?: PortableSession }
+    if (!session) return sendJson(res, 400, { error: 'session is required' })
+    try {
+      sendJson(res, 200, await milkie.importSession(session))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      sendJson(res, /schemaVersion/.test(message) ? 400 : 500, { error: message })
+    }
+  }
+
   return http.createServer((req, res) => {
     void (async () => {
       try {
@@ -158,6 +218,9 @@ export function createServeServer(opts: ServeOptions): Server {
         if (req.method === 'POST' && route === '/context/set')  return await handleContextSet(req, res)
         if (req.method === 'POST' && route === '/context/get')  return await handleContextGet(req, res)
         if (req.method === 'POST' && route === '/context/list') return await handleContextList(req, res)
+        if (req.method === 'POST' && route === '/llm')            return await handleLlm(req, res)
+        if (req.method === 'POST' && route === '/session/export') return await handleSessionExport(req, res)
+        if (req.method === 'POST' && route === '/session/import') return await handleSessionImport(req, res)
         sendJson(res, 404, { error: `no route ${req.method} ${route}` })
       } catch (err) {
         sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -4,10 +4,11 @@ import matter from 'gray-matter'
 import fs from 'fs'
 import path from 'path'
 import type { AgentConfig, FSMDefinition, ModelConfig } from '../types/agent.js'
-import type { AgentInvokeRequest, AgentResult, JSONValue } from '../types/common.js'
+import type { AgentInvokeRequest, AgentResult, JSONValue, Message } from '../types/common.js'
 import type { ChildAgentRecord, IStateStore, AgentCheckpoint } from '../types/store.js'
 import type { ToolDefinition } from '../types/tool.js'
-import type { IModelGateway, ModelEvent } from '../types/model.js'
+import type { IModelGateway, ModelEvent, ModelRequest, ModelResponse } from '../types/model.js'
+import { aggregateStream } from '../gateway/StreamAggregator.js'
 import type { ResolvedManifest } from '../types/trajectory.js'
 import { MemoryStore } from '../store/MemoryStore.js'
 import { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
@@ -161,6 +162,33 @@ export class Milkie {
 
   listAgents(): string[] {
     return Array.from(this.agents.keys())
+  }
+
+  /**
+   * #124: one-shot LLM completion that bypasses the FSM — no agent run, no event
+   * log. Resolves the agent's own gateway/model (the only place model config
+   * lives) and calls it directly, mirroring DefaultIOPort.invokeLLM: streaming +
+   * aggregation when `onEvent` is provided, a single non-streaming call when not.
+   * Exposed over HTTP as serve's `POST /llm` (alfred's `call_llm` equivalent).
+   */
+  async complete(
+    agentId: string,
+    request: { system?: string; messages: Message[] },
+    onEvent?: (e: ModelEvent) => void,
+  ): Promise<ModelResponse> {
+    const config = this.agents.get(agentId)
+    if (!config) {
+      throw new Error(`Agent not found: "${agentId}". Call registerAgent() or loadAgentFile() first.`)
+    }
+    const gateway = this.resolveGateway(config)
+    const req: ModelRequest = {
+      model:    this.resolveModel(config)?.model ?? '',
+      system:   request.system,
+      messages: request.messages,
+    }
+    return onEvent
+      ? aggregateStream(gateway.stream(req), onEvent)
+      : gateway.complete(req)
   }
 
   /**


### PR DESCRIPTION
Closes #124

## 做了什么

在 #86(serve 最小版)之上,为 alfred 替换 dolphin 补两项跨进程能力,统一遵循「能力在库层、serve 只补薄投影、CLI 暂不做」原则。

### 1. 一次性 LLM(alfred call_llm)
- **库层新增** `Milkie.complete(agentId, { system?, messages }, onEvent?)`:绕过 FSM 的一次性 completion,复用 `resolveGateway/resolveModel/aggregateStream`,镜像 `DefaultIOPort.invokeLLM`(无 `onEvent` 非流式;有则流式聚合)。
- **serve 投影** `POST /llm { system?, messages, stream? }`:借单 agent 的 model 配置;`stream=true` → SSE `message_delta` + `done` 终态,错误走 `error` 帧 + `done`(不裸断);否则 JSON `{ output, usage }`。

### 2. portable session(alfred 会话持久化)
- **serve 投影** `POST /session/export { contextId }` / `POST /session/import { session }`:接出 #84 已有的 `exportSession/importSession`。库层错误映射 4xx(无 session→404、schemaVersion 不符→400)。
- ⚠️ export 是「前向状态快照」非完整 transcript(#84 决策 1);若 compressor 需全量历史另起 follow-up。

### 3. 附带:落地孤儿提交
`05c2169`(serve `/context/set·get·list` + 测试,#83 相关)此前从未合入 main,随本 PR 一并落地。

## 不做
- #87 跨语言工具桥(P2):挂起,等 alfred 给出明确 Python skill 复用清单。
- CLI `milkie llm`/`milkie session`:YAGNI,抽象已支持。

## 测试(TDD)
- `milkie-complete.test.ts`(3):非流式聚合 / 流式逐 token 回调 / 未知 agent 报错。
- `serve.test.ts` 增补(8):`/llm` 非流式·流式·缺 messages 400·错误帧;`/session` 导出·导入往返·400/404。
- 全量 **566 单测 + 确定性 e2e 通过**,`tsc --noEmit` 干净。

## 设计文档(SSOT)
`docs/design/124-serve-endpoints.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)