### PR TITLE
feat(#126): /llm 支持 model tier(具名档) + temperature —— 保留 dolphin fast/default 模型分级

### DIFF
--- a/src/__tests__/AnthropicAdapter.test.ts
+++ b/src/__tests__/AnthropicAdapter.test.ts
@@ -48,6 +48,25 @@ describe('AnthropicAdapter — cacheBreakpoint translation', () => {
     expect(params['system']).toBeUndefined()
   })
 
+  // #126: temperature passthrough — alfred's compressor calls with fast=True at a
+  // fixed temperature; the adapter must forward it to Anthropic's messages.create.
+  test('temperature is forwarded into params when set', () => {
+    const params = buildParamsOf(adapter, {
+      model:       'claude-sonnet-4-6',
+      messages:    [],
+      temperature: 0.2,
+    })
+    expect(params['temperature']).toBe(0.2)
+  })
+
+  test('temperature absent → no temperature field emitted (provider default)', () => {
+    const params = buildParamsOf(adapter, {
+      model:    'claude-sonnet-4-6',
+      messages: [],
+    })
+    expect(params['temperature']).toBeUndefined()
+  })
+
   test('cacheBreakpoint plays nicely with tools (both fields emitted)', () => {
     const params = buildParamsOf(adapter, {
       model:           'claude-sonnet-4-6',

--- a/src/__tests__/OpenAICompatibleAdapter.test.ts
+++ b/src/__tests__/OpenAICompatibleAdapter.test.ts
@@ -1,9 +1,22 @@
 import { OpenAICompatibleAdapter } from '../gateway/OpenAICompatibleAdapter'
-import type { ModelResponse } from '../types/model'
+import type { ModelRequest, ModelResponse } from '../types/model'
 
 // parseResponse is private; we exercise it via cast — no network call.
 function parseResponseOf(adapter: OpenAICompatibleAdapter, raw: unknown): ModelResponse {
   return (adapter as unknown as { parseResponse(r: unknown): ModelResponse }).parseResponse(raw)
+}
+
+// Stub the underlying OpenAI client's chat.completions.create to capture the
+// params the adapter builds — no network. Returns a minimal completion shape.
+function stubCreate(adapter: OpenAICompatibleAdapter): { calls: unknown[] } {
+  const calls: unknown[] = []
+  const create = async (params: unknown): Promise<unknown> => {
+    calls.push(params)
+    return { choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }] }
+  }
+  ;(adapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+    .client.chat.completions.create = create
+  return { calls }
 }
 
 describe('OpenAICompatibleAdapter — cache stats extraction', () => {
@@ -55,5 +68,39 @@ describe('OpenAICompatibleAdapter — cache stats extraction', () => {
     }
     const out = parseResponseOf(adapter, raw)
     expect(out.usage?.cacheReadTokens).toBe(0)
+  })
+})
+
+describe('OpenAICompatibleAdapter — temperature passthrough (#126)', () => {
+  const baseReq: ModelRequest = {
+    model:    'qwen-turbo',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+  }
+
+  test('complete forwards temperature to chat.completions.create when set', async () => {
+    const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test' })
+    const { calls } = stubCreate(adapter)
+    await adapter.complete({ ...baseReq, temperature: 0.2 })
+    expect((calls[0] as { temperature?: number }).temperature).toBe(0.2)
+  })
+
+  test('complete omits temperature when not set (provider default)', async () => {
+    const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test' })
+    const { calls } = stubCreate(adapter)
+    await adapter.complete(baseReq)
+    expect((calls[0] as { temperature?: number }).temperature).toBeUndefined()
+  })
+
+  test('stream forwards temperature to chat.completions.create when set', async () => {
+    const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test' })
+    const calls: unknown[] = []
+    const create = async (params: unknown): Promise<AsyncIterable<never>> => {
+      calls.push(params)
+      return (async function* () { /* no chunks */ })()
+    }
+    ;(adapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+      .client.chat.completions.create = create
+    for await (const _e of adapter.stream({ ...baseReq, temperature: 0.7 })) { void _e }
+    expect((calls[0] as { temperature?: number }).temperature).toBe(0.7)
   })
 })

--- a/src/__tests__/milkie-complete.test.ts
+++ b/src/__tests__/milkie-complete.test.ts
@@ -36,6 +36,66 @@ function buildMilkie(gw: IModelGateway): Milkie {
 
 const msgs: Message[] = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]
 
+// #126: a gateway that records every ModelRequest it receives, so tests can
+// assert which model/tier was resolved and whether temperature was forwarded.
+function capturingGateway(): { gw: IModelGateway; reqs: ModelRequest[] } {
+  const reqs: ModelRequest[] = []
+  const gw: IModelGateway = {
+    async complete(req: ModelRequest): Promise<ModelResponse> {
+      reqs.push(req)
+      return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(req: ModelRequest): AsyncIterable<ModelEvent> {
+      reqs.push(req)
+      yield { type: 'message_delta', data: { text: 'ok' } }
+    },
+  }
+  return { gw, reqs }
+}
+
+// Agent with a default tier plus a named `fast` tier (alfred's compressor档).
+const tieredAgent: AgentConfig = {
+  agentId: 'tiered', version: '1.0.0', systemPrompt: 'sys',
+  fsm: { states: [{ name: 'react', type: 'llm' }] },
+  model:  { provider: 'stub', model: 'default-model', adapter: 'stub' },
+  models: { fast: { provider: 'stub', model: 'fast-model', adapter: 'stub' } },
+}
+
+function buildTieredMilkie(gw: IModelGateway): Milkie {
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: gw })
+  milkie.registerAgent(tieredAgent)
+  return milkie
+}
+
+describe('#126 Milkie.complete — tier + temperature', () => {
+  it('tier="fast" resolves the fast tier model into the ModelRequest', async () => {
+    const { gw, reqs } = capturingGateway()
+    await buildTieredMilkie(gw).complete('tiered', { messages: msgs, tier: 'fast' })
+    expect(reqs[0]!.model).toBe('fast-model')
+  })
+
+  it('omitted tier resolves the default model', async () => {
+    const { gw, reqs } = capturingGateway()
+    await buildTieredMilkie(gw).complete('tiered', { messages: msgs })
+    expect(reqs[0]!.model).toBe('default-model')
+  })
+
+  it('unknown tier falls back to the default model (does not throw)', async () => {
+    const { gw, reqs } = capturingGateway()
+    await buildTieredMilkie(gw).complete('tiered', { messages: msgs, tier: 'nonexistent' })
+    expect(reqs[0]!.model).toBe('default-model')
+  })
+
+  it('temperature flows into the ModelRequest; omitted leaves it undefined', async () => {
+    const { gw, reqs } = capturingGateway()
+    const milkie = buildTieredMilkie(gw)
+    await milkie.complete('tiered', { messages: msgs, temperature: 0.2 })
+    await milkie.complete('tiered', { messages: msgs })
+    expect(reqs[0]!.temperature).toBe(0.2)
+    expect(reqs[1]!.temperature).toBeUndefined()
+  })
+})
+
 describe('#124 Milkie.complete', () => {
   it('non-streaming: returns the aggregated response', async () => {
     const milkie = buildMilkie(textGateway(['Hello, ', 'world!']))

--- a/src/__tests__/parseConfig.models.test.ts
+++ b/src/__tests__/parseConfig.models.test.ts
@@ -1,0 +1,78 @@
+// #126: AgentConfig gains an open `models` map of named tiers alongside the
+// default `model`. parseConfig must read a frontmatter `models:` block, validate
+// each tier like the default model, and stay backward-compatible (no `models`
+// block → undefined; unknown fields ignored).
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+let tmpDir: string
+beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-cfg-')) })
+afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+function writeAgent(body: string): string {
+  const file = path.join(tmpDir, 'agent.md')
+  fs.writeFileSync(file, body)
+  return file
+}
+
+function newMilkie(): Milkie {
+  return new Milkie({ stateStore: new MemoryStore() })
+}
+
+describe('#126 parseConfig — named model tiers', () => {
+  it('parses a models block into config.models alongside the default model', () => {
+    const file = writeAgent(`---
+agentId: tiered
+fsm:
+  states: []
+model:
+  provider: volcengine
+  model: default-model
+  adapter: openai
+models:
+  fast:
+    provider: volcengine
+    model: qwen-turbo
+    adapter: openai
+    baseUrl: https://fast.example
+---
+sys`)
+    const config = newMilkie().loadAgentFile(file)
+    expect(config.model).toMatchObject({ provider: 'volcengine', model: 'default-model', adapter: 'openai' })
+    expect(config.models).toEqual({
+      fast: { provider: 'volcengine', model: 'qwen-turbo', adapter: 'openai', baseUrl: 'https://fast.example' },
+    })
+  })
+
+  it('no models block → config.models is undefined (backward compatible)', () => {
+    const file = writeAgent(`---
+agentId: plain
+fsm:
+  states: []
+model:
+  provider: stub
+  model: stub
+  adapter: stub
+---
+sys`)
+    const config = newMilkie().loadAgentFile(file)
+    expect(config.models).toBeUndefined()
+  })
+
+  it('a tier missing provider/model/adapter is rejected, like the default model', () => {
+    const file = writeAgent(`---
+agentId: broken
+fsm:
+  states: []
+models:
+  fast:
+    provider: volcengine
+    adapter: openai
+---
+sys`)
+    expect(() => newMilkie().loadAgentFile(file)).toThrow(/provider, model, adapter/)
+  })
+})

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -87,6 +87,35 @@ function buildSteppingMilkie(opts: { totalSteps?: number; stepMs?: number } = {}
   return { milkie, agentId: 'stepper', broadcaster }
 }
 
+/**
+ * #126: a Milkie whose agent has a default model + a named `fast` tier, behind a
+ * gateway that records every ModelRequest. Lets /llm tests assert which tier's
+ * model was resolved and whether temperature was forwarded across the wire.
+ */
+function buildTieredMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore; reqs: ModelRequest[] } {
+  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
+  const reqs: ModelRequest[] = []
+  const gateway: IModelGateway = {
+    async complete(req: ModelRequest): Promise<ModelResponse> {
+      reqs.push(req)
+      return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(req: ModelRequest): AsyncIterable<ModelEvent> {
+      reqs.push(req)
+      yield { type: 'message_delta', data: { text: 'ok' } }
+    },
+  }
+  const agent: AgentConfig = {
+    agentId: 'tiered', version: '1.0.0', systemPrompt: 'sys',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model:  { provider: 'stub', model: 'default-model', adapter: 'stub' },
+    models: { fast: { provider: 'stub', model: 'fast-model', adapter: 'stub' } },
+  }
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
+  milkie.registerAgent(agent)
+  return { milkie, agentId: 'tiered', broadcaster, reqs }
+}
+
 /** A Milkie whose gateway throws, to exercise the error path (invoke rejects). */
 function buildErrorMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore } {
   const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
@@ -330,6 +359,30 @@ describe('createServeServer', () => {
     const events = await done
     expect(events.find(e => e.event === 'error')).toBeDefined()
     expect(events.find(e => e.event === 'done')).toBeDefined()
+  })
+
+  // ─────────────────────── #126 /llm tier + temperature ───────────────────────
+
+  it('POST /llm with tier="fast" resolves the fast tier model', async () => {
+    const { milkie, agentId, broadcaster, reqs } = buildTieredMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/llm', { messages: userMsg, tier: 'fast' })
+    expect(res.status).toBe(200)
+    expect(reqs[0]!.model).toBe('fast-model')
+  })
+
+  it('POST /llm without tier resolves the default model (regression)', async () => {
+    const { milkie, agentId, broadcaster, reqs } = buildTieredMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await request(port, 'POST', '/llm', { messages: userMsg })
+    expect(reqs[0]!.model).toBe('default-model')
+  })
+
+  it('POST /llm forwards temperature into the ModelRequest', async () => {
+    const { milkie, agentId, broadcaster, reqs } = buildTieredMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await request(port, 'POST', '/llm', { messages: userMsg, temperature: 0.2 })
+    expect(reqs[0]!.temperature).toBe(0.2)
   })
 
   // ──────────────────────── #124 /session ────────────────────────

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -160,16 +160,16 @@ export function createServeServer(opts: ServeOptions): Server {
   // a `done` terminal (errors as an `error` frame + `done`, never a bare
   // disconnect); otherwise a single JSON { output, usage }.
   async function handleLlm(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const { system, messages, stream } = JSON.parse(await readBody(req)) as { system?: string; messages?: Message[]; stream?: boolean }
+    const { system, messages, stream, tier, temperature } = JSON.parse(await readBody(req)) as { system?: string; messages?: Message[]; stream?: boolean; tier?: string; temperature?: number }
     if (!Array.isArray(messages) || messages.length === 0) return sendJson(res, 400, { error: 'messages is required' })
     if (!stream) {
-      const result = await milkie.complete(agentId, { system, messages })
+      const result = await milkie.complete(agentId, { system, messages, tier, temperature })
       return sendJson(res, 200, { output: outputText(result), usage: result.usage })
     }
     res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', 'connection': 'keep-alive' })
     res.on('error', () => { /* client disconnect; writes are guarded by writeSSE */ })
     try {
-      const result = await milkie.complete(agentId, { system, messages }, e => {
+      const result = await milkie.complete(agentId, { system, messages, tier, temperature }, e => {
         if (e.type === 'message_delta') writeSSE(res, 'message_delta', e.data)
       })
       writeSSE(res, 'done', { usage: result.usage })

--- a/src/gateway/AnthropicAdapter.ts
+++ b/src/gateway/AnthropicAdapter.ts
@@ -77,6 +77,11 @@ export class AnthropicAdapter implements IModelGateway {
       params['tool_choice'] = request.toolChoice
     }
 
+    // #126: forward sampling temperature when set; omit otherwise (provider default).
+    if (request.temperature !== undefined) {
+      params['temperature'] = request.temperature
+    }
+
     return params
   }
 

--- a/src/gateway/OpenAICompatibleAdapter.ts
+++ b/src/gateway/OpenAICompatibleAdapter.ts
@@ -31,6 +31,7 @@ export class OpenAICompatibleAdapter implements IModelGateway {
         },
       })),
       tool_choice: request.tools?.length ? 'auto' : undefined,
+      temperature: request.temperature,
     })
 
     return this.parseResponse(raw)
@@ -49,6 +50,7 @@ export class OpenAICompatibleAdapter implements IModelGateway {
         },
       })),
       tool_choice:    request.tools?.length ? 'auto' : undefined,
+      temperature:    request.temperature,
       stream:         true,
       stream_options: { include_usage: true },
     })

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -85,13 +85,17 @@ export class Milkie {
     this.traceObjectStore = opts.traceObjectStore ?? null
   }
 
-  private resolveModel(config: AgentConfig): ModelConfig | undefined {
+  private resolveModel(config: AgentConfig, tier?: string): ModelConfig | undefined {
+    // #126: a given+matched tier wins; otherwise fall back to the default model
+    // (no throw — serve configured with only a default stays usable for any tier).
+    if (tier && config.models?.[tier]) return config.models[tier]
+    if (tier) console.debug(`[milkie] tier "${tier}" not found for agent "${config.agentId}"; falling back to default model`)
     return config.model ?? this.defaultModel ?? undefined
   }
 
-  private resolveGateway(config: AgentConfig): IModelGateway {
+  private resolveGateway(config: AgentConfig, tier?: string): IModelGateway {
     if (this.gatewayOverride) return this.gatewayOverride
-    const model = this.resolveModel(config)
+    const model = this.resolveModel(config, tier)
     if (!model) {
       throw new Error(
         `Agent "${config.agentId}" has no model and Milkie has no gateway or defaultModel; ` +
@@ -173,18 +177,19 @@ export class Milkie {
    */
   async complete(
     agentId: string,
-    request: { system?: string; messages: Message[] },
+    request: { system?: string; messages: Message[]; tier?: string; temperature?: number },
     onEvent?: (e: ModelEvent) => void,
   ): Promise<ModelResponse> {
     const config = this.agents.get(agentId)
     if (!config) {
       throw new Error(`Agent not found: "${agentId}". Call registerAgent() or loadAgentFile() first.`)
     }
-    const gateway = this.resolveGateway(config)
+    const gateway = this.resolveGateway(config, request.tier)
     const req: ModelRequest = {
-      model:    this.resolveModel(config)?.model ?? '',
-      system:   request.system,
-      messages: request.messages,
+      model:       this.resolveModel(config, request.tier)?.model ?? '',
+      system:      request.system,
+      messages:    request.messages,
+      temperature: request.temperature,
     }
     return onEvent
       ? aggregateStream(gateway.stream(req), onEvent)
@@ -732,6 +737,22 @@ export class Milkie {
       throw new Error('Agent config model must have provider, model, adapter')
     }
 
+    // #126: open named model tiers. Each tier is validated like the default model.
+    const rawModels = data['models'] as Record<string, Record<string, string>> | undefined
+    const models = rawModels
+      ? Object.fromEntries(Object.entries(rawModels).map(([tier, m]) => {
+          if (!m || !m.provider || !m.model || !m.adapter) {
+            throw new Error(`Agent config models.${tier} must have provider, model, adapter`)
+          }
+          return [tier, {
+            provider: m['provider']!,
+            model:    m['model']!,
+            adapter:  m['adapter']!,
+            baseUrl:  m['baseUrl'] as string | undefined,
+          }]
+        }))
+      : undefined
+
     const agentId =
       (data['agentId'] as string | undefined) ??
       (data['id']      as string | undefined)
@@ -748,6 +769,7 @@ export class Milkie {
         adapter:  model['adapter']!,
         baseUrl:  model['baseUrl'] as string | undefined,
       } : undefined,
+      models,
       toolboxes:  data['toolboxes']  as Record<string, string> | undefined,
       skills:     data['skills']     as Record<string, string> | undefined,
       skillInstructions: data['skillInstructions'] as Record<string, string> | undefined,

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -27,6 +27,13 @@ export interface AgentConfig {
   systemPrompt: string
   fsm:          FSMDefinition
   model?:       ModelConfig
+  /**
+   * #126: open named model tiers. `model` stays the default tier; `models[tier]`
+   * lets a one-shot `complete({ tier })` pick a named model/gateway. Keys are
+   * arbitrary (milkie does not hardcode `default`/`fast`); an unknown or omitted
+   * tier falls back to `model`.
+   */
+  models?:      Record<string, ModelConfig>
   toolboxes?:   Record<string, string>
   skills?:      Record<string, string>
   skillInstructions?: Record<string, string>

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -17,6 +17,8 @@ export interface ModelRequest {
   responseFormat?: unknown
   reasoning?:      ReasoningOptions
   metadata?:       Record<string, unknown>
+  /** #126: sampling temperature. When set, adapters forward it to the provider; when omitted, the param is not sent (provider default). */
+  temperature?:    number
   /** PR-D Phase 1: when 'system-end', adapter wraps system block with cache_control. */
   cacheBreakpoint?: 'system-end'
 }


### PR DESCRIPTION
Closes #126

## 摘要
让 serve `POST /llm` 与库层 `Milkie.complete` 支持**具名 model 档(tier)+ temperature**,使 alfred 的「memory 抽取走高质量档 / 会话压缩走便宜快档 + 固定温度」分级语义切到 milkie 后跨进程完整保留。能力在库层,serve 只补薄投影;milkie **不绑死** `default`/`fast`,档位开放具名。**全程向后兼容**,#124 既有 23 测试逐字不破。

## 改动(承 issue 5 点设计)
1. `AgentConfig.models?: Record<string, ModelConfig>` 开放具名档,`model?` 保留为默认档;`parseConfig` 解析 `models` 块,每档复用现有 provider/model/adapter 校验。
2. `resolveModel(config, tier?)` / `resolveGateway(config, tier?)`:给定且命中 → 用该档建网关;未命中 / 未给 tier → **回落默认档(不报错,记一行 debug)**。
3. `ModelRequest.temperature?` + `OpenAICompatibleAdapter`(complete/stream)、`AnthropicAdapter`(buildParams)透传;不传则不下发该参数。
4. `Milkie.complete(agentId, { system, messages, tier?, temperature? }, onEvent?)`。
5. serve `POST /llm { system?, messages, stream?, tier?, temperature? }` 透传(流式+非流式)。

## 向后兼容(硬标准)
- 不传 `tier` → 默认档;不传 `temperature` → 不下发。两者与 #124 当前行为逐字一致。
- agent 文件无 `models` 块 → `config.models` 为 undefined,任意 `tier` 回落默认。

## 测试(TDD 先红后绿)
5 个增量逐个 RED→GREEN,新增 `parseConfig.models.test.ts`,adapter/库层(`milkie-complete`)/serve 测试增补。
- 本次相关 5 套件 **51/51 绿**;`tsc` 构建通过。
- 全量跑出现的 2 处失败与本改动**无关**且已对照 main 验证:`s-010` e2e 为 main 上既有 TS 错误;`Replay.test.ts` 仅全量并行下 `clock.read` 时序 flaky,单跑 17/17 绿。

## 不做(本 issue 边界)
- alfred 侧对接(`MilkieProvider.call_llm` 传 tier/temperature + spawn serve 写两档 model + 跨进程 e2e)是 alfred 仓库下一步,独立提交。
- CLI `milkie llm` 投影:YAGNI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)