### PR TITLE
feat(#128): serve /session/history —— by-context 全量逐条 transcript 导出(含 tool chain)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,9 +161,11 @@ full per-turn transcript (assistant `tool_use` + `tool_result`, paired) survives
 **only** in each run's append-only event log. Reconstructing a session's
 complete history therefore means walking every run's events — an instance of
 "the event log is canonical, snapshots are derived" (see Event-sourced runtime
-state). Today only `context:<id>:checkpoint-run:latest` is persisted (the most
-recent run); enumerating *all* of a session's runs needs a by-context run index,
-which does not yet exist.
+state). The session's runs are enumerated from the log itself: each
+`agent.run.started` records the `previousRunId` it continued from, so a reader
+starts at `context:<id>:checkpoint-run:latest` and follows the chain backwards.
+That keeps enumeration event-derived — no separate by-context index to keep in
+sync — so it survives export/import and has no concurrent-append race.
 
 *Example:* a `contextId` chatted three times is one session = runs A→B→C; B
 restored A's checkpoint, C restored B's. A's tool chain lives in A's event log

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,6 +131,47 @@ written.
 *Not:* a span. Spans are intervals with start/end and parent/child; Events
 are points.
 
+### Run, Turn, Session
+
+Three nested units of execution, easy to conflate because in the common chat
+flow they line up one-to-one.
+
+A **run** is one `invoke()` — the agent executes from a starting input until it
+either reaches a terminal FSM state or pauses to wait for more user input. A run
+owns one `runId` and one Trace; `agent.run.started` / `agent.run.completed`
+bracket it. A run is *not* a single LLM call — one run contains many
+`llm.requested/responded` and `tool.requested/responded` effects across its FSM
+loop.
+
+A **turn** is one user-input → agent-response exchange. In the serve chat flow
+each turn is a fresh `invoke`, so **one turn = one run** (`/resume` is the
+exception: it continues an existing run under the same `runId`).
+
+A **session** is one continuous conversation, identified by a `contextId`. A
+session **spans many runs** — one per turn — chained by checkpoint restoration:
+each new run restores the previous run's checkpoint (regions / working memory)
+before continuing. The `contextId` is the only thread tying the runs together;
+each run still has its own independent `runId` and Trace.
+
+Carry-forward across runs is a **lossy projection**, by design. At turn end the
+lifecycle engine crystallizes the turn into a single `(user, final-answer)`
+history pair and drops the turn-local scratchpad — so the forward state a later
+run restores holds only those text pairs, **not** the turn's tool chain. The
+full per-turn transcript (assistant `tool_use` + `tool_result`, paired) survives
+**only** in each run's append-only event log. Reconstructing a session's
+complete history therefore means walking every run's events — an instance of
+"the event log is canonical, snapshots are derived" (see Event-sourced runtime
+state). Today only `context:<id>:checkpoint-run:latest` is persisted (the most
+recent run); enumerating *all* of a session's runs needs a by-context run index,
+which does not yet exist.
+
+*Example:* a `contextId` chatted three times is one session = runs A→B→C; B
+restored A's checkpoint, C restored B's. A's tool chain lives in A's event log
+alone; the context C restores only carries A's and B's crystallized text pairs.
+*Not:* a run is not a session, and a session is not a single Trace. Reading the
+latest run alone yields the current turn's tool chain plus prior turns as
+text-only — not the full transcript.
+
 ### Trace
 
 The ordered set of all Events belonging to one run, stored in an
@@ -344,6 +385,8 @@ subsystems (Agent Runtime, Agent Trace, Evolution) sit below them.
 | Pair | Key distinction |
 |---|---|
 | **Event** vs **Trace** | Event is one record. Trace is the ordered set of all Events in a run. |
+| **Run** vs **Session** | A run is one `invoke` — one `runId`, one Trace. A session is a conversation — one `contextId` spanning many runs, chained by checkpoint restore. |
+| **Session history** vs **forward state** | The full per-turn transcript (incl. tool chain) lives only in each run's event log; forward state (checkpoint / regions) carries only crystallized `(user, final-answer)` pairs across turns. |
 | **Trace** vs **Trajectory** | Trace is flat, append-only, replay-canonical. Trajectory is a hierarchical span tree, derivable, currently a peer view (will be unified). |
 | **IOPort** vs **Event** | IOPort is the nondet boundary. Events are its recorded outputs. |
 | **Region** vs **`region.added` Event** | The Region is context state. The Event is the record that the state changed. |

--- a/src/__tests__/milkie-session-history.test.ts
+++ b/src/__tests__/milkie-session-history.test.ts
@@ -27,6 +27,16 @@ function factWriter(): ToolDefinition {
   }
 }
 
+/** Answers immediately (end_turn) with the given text. */
+function endTurnGateway(text: string): IModelGateway {
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+  }
+}
+
 /** Each turn: first call records fact{n} (tool_use), second call completes. */
 function multiTurnRecorder(): IModelGateway {
   let calls = 0, facts = 0
@@ -81,5 +91,25 @@ describe('#128 Milkie.getSessionHistory', () => {
     const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: multiTurnRecorder(), tools: [factWriter()] })
     milkie.registerAgent(recorderAgent)
     await expect(milkie.getSessionHistory('never')).rejects.toThrow(/never/)
+  })
+
+  // P1 regression: getSessionHistory is derived from the event log (the run chain
+  // via agent.run.started.previousRunId), not a separate index importSession would
+  // have to remember to restore. So an exported→imported session's transcript is
+  // reconstructable in a fresh instance — no 404, no lost history.
+  it('reconstructs an imported session\'s transcript (no separate index to restore)', async () => {
+    const src = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: endTurnGateway('answer'), tools: [factWriter()] })
+    src.registerAgent(recorderAgent)
+    const contextId = 'ctx-imp'
+    await src.invoke({ agentId: 'recorder', goal: 'g', input: 'only turn', contextId })
+    const session = await src.exportSession(contextId)
+
+    const dst = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: endTurnGateway('x'), tools: [factWriter()] })
+    dst.registerAgent(recorderAgent)
+    await dst.importSession(session)
+
+    const messages = await dst.getSessionHistory(contextId)
+    expect(userTexts(messages)).toEqual(['only turn'])
+    expect(messages.some(m => m.role === 'assistant' && m.content.some(c => (c as { text?: string }).text === 'answer'))).toBe(true)
   })
 })

--- a/src/__tests__/milkie-session-history.test.ts
+++ b/src/__tests__/milkie-session-history.test.ts
@@ -1,0 +1,85 @@
+// #128: Milkie.getSessionHistory(contextId) — the full, per-message transcript
+// of a whole session (every run/turn under one contextId), with tool chains
+// intact, projected from each run's event log and concatenated in turn order.
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { AgentConfig } from '../types/agent'
+import type { ToolDefinition } from '../types/tool'
+import type { Message, MessageContent } from '../types/common'
+
+const recorderAgent: AgentConfig = {
+  agentId: 'recorder', version: '1.0.0', systemPrompt: 'answer',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 50 }] },
+  model: { provider: 'test', model: 'test', adapter: 'test' },
+}
+
+function factWriter(): ToolDefinition {
+  return {
+    name: 'record_fact', description: 'record a fact',
+    inputSchema: { type: 'object', properties: { key: { type: 'string' }, value: { type: 'string' } }, required: ['key', 'value'] },
+    handler: async (input: unknown, ctx) => {
+      const { key, value } = input as { key: string; value: string }
+      ctx.workingMemory.set(key, value)
+      return { recorded: key }
+    },
+  }
+}
+
+/** Each turn: first call records fact{n} (tool_use), second call completes. */
+function multiTurnRecorder(): IModelGateway {
+  let calls = 0, facts = 0
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      calls++
+      if (calls % 2 === 1) {
+        facts++
+        const input = { key: `fact${facts}`, value: `v${facts}` }
+        return { content: [{ type: 'tool_use', id: `c${facts}`, name: 'record_fact', input }], toolCalls: [{ id: `c${facts}`, name: 'record_fact', input }], finishReason: 'tool_use' }
+      }
+      return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+  }
+}
+
+const userTexts = (msgs: Message[]): string[] =>
+  msgs.filter(m => m.role === 'user').map(m => (m.content[0] as { type: 'text'; text: string }).text)
+
+describe('#128 Milkie.getSessionHistory', () => {
+  it('returns the full per-turn transcript across runs, tool chains intact, no duplication', async () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: multiTurnRecorder(), tools: [factWriter()] })
+    milkie.registerAgent(recorderAgent)
+    const contextId = 'ctx-hist'
+
+    await milkie.invoke({ agentId: 'recorder', goal: 'g', input: 'turn1', contextId })  // run A → fact1
+    await milkie.invoke({ agentId: 'recorder', goal: 'g', input: 'turn2', contextId })  // run B → fact2
+
+    const messages = await milkie.getSessionHistory(contextId)
+
+    // Both turns present, in order, each exactly once (no restored-prefix dup).
+    expect(userTexts(messages)).toEqual(['turn1', 'turn2'])
+
+    // Per turn: user, assistant(tool_use), tool_result, assistant(final) = 4 × 2.
+    expect(messages).toHaveLength(8)
+
+    // Turn 1's tool chain is paired and complete.
+    const toolUse1 = messages[1]!.content[0] as Extract<MessageContent, { type: 'tool_use' }>
+    expect(messages[1]!.role).toBe('assistant')
+    expect(toolUse1).toMatchObject({ type: 'tool_use', id: 'c1', name: 'record_fact', input: { key: 'fact1' } })
+    expect(messages[2]!).toEqual({ role: 'tool', content: [{ type: 'tool_result', tool_use_id: 'c1', content: '{"recorded":"fact1"}' }] })
+    expect(messages[3]!).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'done' }] })
+
+    // Turn 2's tool_use pairs with turn 2's tool_result (fact2 / c2), not turn 1's.
+    const toolUse2 = messages[5]!.content[0] as Extract<MessageContent, { type: 'tool_use' }>
+    expect(toolUse2).toMatchObject({ type: 'tool_use', id: 'c2', name: 'record_fact', input: { key: 'fact2' } })
+    expect(messages[6]!).toEqual({ role: 'tool', content: [{ type: 'tool_result', tool_use_id: 'c2', content: '{"recorded":"fact2"}' }] })
+  })
+
+  it('throws for an unknown contextId (no session)', async () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), gateway: multiTurnRecorder(), tools: [factWriter()] })
+    milkie.registerAgent(recorderAgent)
+    await expect(milkie.getSessionHistory('never')).rejects.toThrow(/never/)
+  })
+})

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -397,6 +397,33 @@ describe('createServeServer', () => {
     expect(Array.isArray((res.json as { events: unknown[] }).events)).toBe(true)
   })
 
+  // ──────────────────────── #128 /session/history ────────────────────────
+
+  it('POST /session/history returns the full per-message transcript after a chat', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['ok'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await (await sse(port, 'POST', '/chat', { contextId: 'sh', input: 'hi' }).done)
+    const res = await request(port, 'POST', '/session/history', { contextId: 'sh' })
+    expect(res.status).toBe(200)
+    const messages = (res.json as { messages: Array<{ role: string; content: Array<{ type: string; text?: string }> }> }).messages
+    expect(messages[0]).toEqual({ role: 'user', content: [{ type: 'text', text: 'hi' }] })
+    expect(messages.some(m => m.role === 'assistant' && m.content.some(c => c.text === 'ok'))).toBe(true)
+  })
+
+  it('POST /session/history without contextId returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/session/history', {})
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /session/history for an unknown context returns 404', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/session/history', { contextId: 'never' })
+    expect(res.status).toBe(404)
+  })
+
   it('POST /session/export without contextId returns 400', async () => {
     const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
     const port = await listen(createServeServer({ milkie, agentId, broadcaster }))

--- a/src/__tests__/sessionHistory.test.ts
+++ b/src/__tests__/sessionHistory.test.ts
@@ -1,0 +1,86 @@
+// #128: project one run's events into a canonical Message[] transcript.
+// user ← agent.run.started.input; assistant ← llm.responded.response.content;
+// tool ← tool.responded (paired by toolCallId). Events are walked in append
+// order, which is the correct transcript order (assistant tool_use → tool_result
+// → assistant final). Uses only discrete I/O events, so a run contributes only
+// its own turn — no restored-prefix duplication when runs are concatenated.
+import { runEventsToMessages } from '../trace/diagnostics/sessionHistory'
+import type { Event } from '../trace/types'
+import type { Message } from '../types/common'
+
+let seq = 0
+function ev<P>(type: Event['type'], payload: P): Event<P> {
+  seq += 1
+  return { id: `e${seq}`, runId: 'rA', type, actor: 'agent', timestamp: seq, payload }
+}
+
+describe('#128 runEventsToMessages — one run → Message[]', () => {
+  it('projects a tool-using turn into user / assistant(tool_use) / tool_result / assistant(final)', () => {
+    const events: Event[] = [
+      ev('agent.run.started', { agentId: 'a', goal: 'g', input: 'hi', contextId: 'X' }),
+      ev('llm.requested', { request: { model: 'm', messages: [] }, requestHash: 'h1' }),
+      ev('llm.responded', {
+        response: {
+          content: [
+            { type: 'text', text: 'let me check' },
+            { type: 'tool_use', id: 't1', name: 'search', input: { q: 'x' } },
+          ],
+          toolCalls: [{ id: 't1', name: 'search', input: { q: 'x' } }],
+          finishReason: 'tool_use',
+        },
+        requestHash: 'h1',
+      }),
+      ev('tool.requested', { toolName: 'search', input: { q: 'x' }, toolCallId: 't1', requestHash: 'h2' }),
+      ev('tool.responded', { toolName: 'search', toolCallId: 't1', status: 'ok', output: { r: 'found' }, requestHash: 'h2' }),
+      ev('llm.requested', { request: { model: 'm', messages: [] }, requestHash: 'h3' }),
+      ev('llm.responded', {
+        response: { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' },
+        requestHash: 'h3',
+      }),
+      ev('agent.run.completed', { status: 'completed', lastTextOutput: 'done' }),
+    ]
+
+    const messages = runEventsToMessages(events)
+
+    const expected: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [
+        { type: 'text', text: 'let me check' },
+        { type: 'tool_use', id: 't1', name: 'search', input: { q: 'x' } },
+      ] },
+      { role: 'tool', content: [{ type: 'tool_result', tool_use_id: 't1', content: '{"r":"found"}' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+    ]
+    expect(messages).toEqual(expected)
+  })
+
+  it('marks an errored tool result with is_error and uses the error message', () => {
+    const events: Event[] = [
+      ev('agent.run.started', { agentId: 'a', goal: 'g', input: 'go', contextId: 'X' }),
+      ev('llm.responded', {
+        response: { content: [{ type: 'tool_use', id: 't9', name: 'boom', input: {} }], toolCalls: [{ id: 't9', name: 'boom', input: {} }], finishReason: 'tool_use' },
+        requestHash: 'h1',
+      }),
+      ev('tool.responded', { toolName: 'boom', toolCallId: 't9', status: 'error', error: { message: 'kaboom' }, requestHash: 'h2' }),
+    ]
+
+    const messages = runEventsToMessages(events)
+
+    expect(messages[messages.length - 1]).toEqual({
+      role: 'tool',
+      content: [{ type: 'tool_result', tool_use_id: 't9', content: 'kaboom', is_error: true }],
+    })
+  })
+
+  it('passes a string tool output through without JSON-encoding', () => {
+    const events: Event[] = [
+      ev('agent.run.started', { agentId: 'a', goal: 'g', input: 'go', contextId: 'X' }),
+      ev('tool.responded', { toolName: 't', toolCallId: 'c1', status: 'ok', output: 'plain text', requestHash: 'h' }),
+    ]
+    const messages = runEventsToMessages(events)
+    expect(messages[messages.length - 1]).toEqual({
+      role: 'tool',
+      content: [{ type: 'tool_result', tool_use_id: 'c1', content: 'plain text' }],
+    })
+  })
+})

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -21,6 +21,7 @@ import type { PortableSession } from '../runtime/PortableSession.js'
  *   POST /llm { system?, messages, stream? }  → JSON (or SSE when stream) (#124)
  *   POST /session/export { contextId }        → PortableSession JSON (#124)
  *   POST /session/import { session }          → { contextId } (#124)
+ *   POST /session/history { contextId }       → { messages: Message[] } full transcript (#128)
  */
 export interface ServeOptions {
   milkie:      Milkie
@@ -195,6 +196,20 @@ export function createServeServer(opts: ServeOptions): Server {
     }
   }
 
+  // #128: project Milkie.getSessionHistory onto HTTP — the full per-message
+  // transcript (every run/turn under the context, tool chains intact). No session
+  // → 404, else 500.
+  async function handleSessionHistory(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId } = JSON.parse(await readBody(req)) as { contextId?: string }
+    if (!contextId) return sendJson(res, 400, { error: 'contextId is required' })
+    try {
+      sendJson(res, 200, { messages: await milkie.getSessionHistory(contextId) })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      sendJson(res, /No session/.test(message) ? 404 : 500, { error: message })
+    }
+  }
+
   async function handleSessionImport(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const { session } = JSON.parse(await readBody(req)) as { session?: PortableSession }
     if (!session) return sendJson(res, 400, { error: 'session is required' })
@@ -219,6 +234,7 @@ export function createServeServer(opts: ServeOptions): Server {
         if (req.method === 'POST' && route === '/context/get')  return await handleContextGet(req, res)
         if (req.method === 'POST' && route === '/context/list') return await handleContextList(req, res)
         if (req.method === 'POST' && route === '/llm')            return await handleLlm(req, res)
+        if (req.method === 'POST' && route === '/session/history') return await handleSessionHistory(req, res)
         if (req.method === 'POST' && route === '/session/export') return await handleSessionExport(req, res)
         if (req.method === 'POST' && route === '/session/import') return await handleSessionImport(req, res)
         sendJson(res, 404, { error: `no route ${req.method} ${route}` })

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -26,7 +26,7 @@ import { ReplayingIOPort } from '../trace/ReplayingIOPort.js'
 import { ReplayError } from '../trace/ReplayError.js'
 import { ReplayDivergenceError } from '../trace/ReplayDivergenceError.js'
 import { extractRunSnapshot } from '../trace/RunSnapshot.js'
-import type { ToolEmittedPayload, AgentRunStartedPayload } from '../trace/types.js'
+import type { Event, ToolEmittedPayload, AgentRunStartedPayload } from '../trace/types.js'
 import { makeTraceTools } from '../tools/trace.js'
 import {
   type PortableSession,
@@ -277,11 +277,14 @@ export class Milkie {
     // #73: the event log is the source of truth for resume state — read the
     // context's latest checkpointed run via the routing pointer and project the
     // checkpoint from its events; fall back to the legacy stateStore blob.
+    // #128: the run this turn continues from (= the session's previous run). Used
+    // both to restore the checkpoint and to chain runs for getSessionHistory.
     let restoredCheckpoint: AgentCheckpoint | null = null
+    let previousRunId: string | undefined
     if (request.contextId) {
-      const runPtr = await this.stateStore.get(`context:${request.contextId}:checkpoint-run:latest`) as string | undefined
-      if (runPtr && this.eventStore) {
-        restoredCheckpoint = checkpointFromEvents(await this.eventStore.readByRunId(runPtr))
+      previousRunId = await this.stateStore.get(`context:${request.contextId}:checkpoint-run:latest`) as string | undefined
+      if (previousRunId && this.eventStore) {
+        restoredCheckpoint = checkpointFromEvents(await this.eventStore.readByRunId(previousRunId))
       }
       if (!restoredCheckpoint) {
         restoredCheckpoint = (await this.stateStore.get(`context:${request.contextId}:checkpoint:latest`) as AgentCheckpoint | null) ?? null
@@ -289,17 +292,6 @@ export class Milkie {
     }
 
     const agentRunId = uuid()
-
-    // #128: by-context run index. The checkpoint pointer only retains the latest
-    // run; append every turn's runId so getSessionHistory can enumerate the whole
-    // session. Only top-level invokes pass through here (spawned children go via
-    // makeChildPort, resume reuses the runId), so the list is exactly the turns.
-    if (request.contextId) {
-      const runs = (await this.stateStore.get(`context:${request.contextId}:runs`) as string[] | undefined) ?? []
-      runs.push(agentRunId)
-      await this.stateStore.set(`context:${request.contextId}:runs`, runs)
-    }
-
     const runtimeConfig = { ...config, model: this.resolveModel(config) }
     const childRecorderFactory = this.trajectoryStore
       ? (childConfig: AgentConfig, childContextId: string, childTraceId: string) =>
@@ -358,6 +350,7 @@ export class Milkie {
       goal:      request.goal,
       input:     request.input,
       contextId,
+      ...(previousRunId ? { previousRunId } : {}),
     })
 
     try {
@@ -672,18 +665,41 @@ export class Milkie {
    * forward state snapshot, this walks each run's event log (the only place the
    * inter-turn-dropped tool chain survives) and concatenates the per-run
    * projections. Throws when the context has no runs.
+   *
+   * The session's runs are enumerated from the event log itself: start at the
+   * latest run (`checkpoint-run:latest`) and walk backwards via each run's
+   * `agent.run.started.previousRunId`. This needs no separate, non-atomic
+   * by-context index, so it survives export/import (the latest pointer is the only
+   * thing import must set, which it already does) and has no concurrent-append
+   * lost-update. The walk stops where events are absent (e.g. an imported session
+   * carries only the latest run-tree), degrading gracefully rather than failing.
    */
   async getSessionHistory(contextId: string): Promise<Message[]> {
     if (!this.eventStore) {
       throw new Error('Milkie has no eventStore; cannot read session history')
     }
-    const runIds = (await this.stateStore.get(`context:${contextId}:runs`) as string[] | undefined) ?? []
-    if (runIds.length === 0) {
+    const latest = await this.stateStore.get(`context:${contextId}:checkpoint-run:latest`) as string | undefined
+    if (!latest) {
       throw new Error(`No session for contextId "${contextId}"`)
     }
+
+    // Walk the run chain newest→oldest, collecting each run's events, then reverse
+    // to chronological order. Guard against cycles and missing runs.
+    const chain: Event[][] = []
+    const seen = new Set<string>()
+    let runId: string | undefined = latest
+    while (runId && !seen.has(runId)) {
+      seen.add(runId)
+      const events = await this.eventStore.readByRunId(runId)
+      if (events.length === 0) break
+      chain.push(events)
+      const started = events.find(e => e.type === 'agent.run.started')
+      runId = (started?.payload as AgentRunStartedPayload | undefined)?.previousRunId
+    }
+
     const messages: Message[] = []
-    for (const runId of runIds) {
-      messages.push(...runEventsToMessages(await this.eventStore.readByRunId(runId)))
+    for (const events of chain.reverse()) {
+      messages.push(...runEventsToMessages(events))
     }
     return messages
   }

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
+import { runEventsToMessages } from '../trace/diagnostics/sessionHistory.js'
 import matter from 'gray-matter'
 import fs from 'fs'
 import path from 'path'
@@ -288,6 +289,17 @@ export class Milkie {
     }
 
     const agentRunId = uuid()
+
+    // #128: by-context run index. The checkpoint pointer only retains the latest
+    // run; append every turn's runId so getSessionHistory can enumerate the whole
+    // session. Only top-level invokes pass through here (spawned children go via
+    // makeChildPort, resume reuses the runId), so the list is exactly the turns.
+    if (request.contextId) {
+      const runs = (await this.stateStore.get(`context:${request.contextId}:runs`) as string[] | undefined) ?? []
+      runs.push(agentRunId)
+      await this.stateStore.set(`context:${request.contextId}:runs`, runs)
+    }
+
     const runtimeConfig = { ...config, model: this.resolveModel(config) }
     const childRecorderFactory = this.trajectoryStore
       ? (childConfig: AgentConfig, childContextId: string, childTraceId: string) =>
@@ -652,6 +664,28 @@ export class Milkie {
       await this.setContextVar(contextId, name, value)
     }
     return { contextId }
+  }
+
+  /**
+   * #128: the full per-message transcript of a whole session — every run/turn
+   * under `contextId`, tool chains intact, in turn order. Unlike exportSession's
+   * forward state snapshot, this walks each run's event log (the only place the
+   * inter-turn-dropped tool chain survives) and concatenates the per-run
+   * projections. Throws when the context has no runs.
+   */
+  async getSessionHistory(contextId: string): Promise<Message[]> {
+    if (!this.eventStore) {
+      throw new Error('Milkie has no eventStore; cannot read session history')
+    }
+    const runIds = (await this.stateStore.get(`context:${contextId}:runs`) as string[] | undefined) ?? []
+    if (runIds.length === 0) {
+      throw new Error(`No session for contextId "${contextId}"`)
+    }
+    const messages: Message[] = []
+    for (const runId of runIds) {
+      messages.push(...runEventsToMessages(await this.eventStore.readByRunId(runId)))
+    }
+    return messages
   }
 
   async interrupt(contextId: string): Promise<void> {

--- a/src/trace/diagnostics/sessionHistory.ts
+++ b/src/trace/diagnostics/sessionHistory.ts
@@ -1,0 +1,57 @@
+import type { Event, LlmRespondedPayload, ToolRespondedPayload, AgentRunStartedPayload } from '../types.js'
+import type { Message, MessageContent } from '../../types/common.js'
+
+/**
+ * #128: project ONE run's events into a canonical `Message[]` transcript.
+ *
+ * Walks the run's events in append order (which is the correct transcript order:
+ * assistant `tool_use` → `tool_result` → assistant final) and emits, from the
+ * discrete I/O events only:
+ *   - `agent.run.started.input`        → a user message
+ *   - `llm.responded.response.content` → an assistant message (text + tool_use)
+ *   - `tool.responded`                 → a tool message (tool_result, paired by toolCallId)
+ *
+ * Using responded events (not the `llm.requested.messages` snapshot) means a run
+ * contributes only its own turn — the restored prior-turn prefix is never
+ * re-emitted as events — so concatenating per-run projections does not duplicate.
+ */
+export function runEventsToMessages(events: Event[]): Message[] {
+  const messages: Message[] = []
+
+  for (const e of events) {
+    switch (e.type) {
+      case 'agent.run.started': {
+        const { input } = e.payload as AgentRunStartedPayload
+        messages.push({ role: 'user', content: [{ type: 'text', text: input }] })
+        break
+      }
+      case 'llm.responded': {
+        const { response } = e.payload as LlmRespondedPayload
+        const content = response.content ?? []
+        if (content.length > 0) messages.push({ role: 'assistant', content })
+        break
+      }
+      case 'tool.responded': {
+        messages.push({ role: 'tool', content: [toolResult(e.payload as ToolRespondedPayload)] })
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return messages
+}
+
+function toolResult(p: ToolRespondedPayload): MessageContent {
+  const isError = p.status === 'error' || (p.status === undefined && p.error !== undefined)
+  const text = isError
+    ? (p.error?.message ?? 'error')
+    : (typeof p.output === 'string' ? p.output : JSON.stringify(p.output))
+  return {
+    type:        'tool_result',
+    tool_use_id: p.toolCallId ?? '',
+    content:     text,
+    ...(isError ? { is_error: true } : {}),
+  }
+}

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -112,6 +112,13 @@ export interface AgentRunStartedPayload {
   input:      string
   contextId:  string
   parentId?:  string
+  /**
+   * #128: the run this turn continued from (the checkpoint it restored), i.e. the
+   * previous run of the same session. Unset on a session's first turn. This links
+   * a session's runs into a chain so getSessionHistory can enumerate every turn
+   * from the event log alone — no separate, non-atomic by-context index.
+   */
+  previousRunId?: string
 }
 
 export interface AgentRunCompletedPayload {


### PR DESCRIPTION
Closes #128

## 摘要
库层 `Milkie.getSessionHistory(contextId)` + serve `POST /session/history`,返回一个 session 跨**所有 run/turn** 的 canonical `Message[]`(含 tool chain、`tool_use`/`tool_result` 成对、按轮序连续)。alfred 会话持久化(替换 dolphin `history_messages`)的前置端点能力。承 #124(serve `/session`)、#84(portable session)。

## 为什么不能只读最新 run / `/session/export`
milkie 的跨轮 carry-forward 是**有损投影**:轮末 crystallization 把整轮归约成一个 `(user, final-answer)` 文本对、**drop 掉 turn-local 的 tool chain**——只存活于**各 run 自己的原始事件日志**。`/session/export` 是「最新 run 的前向状态快照」,拿不到历史各轮的 tool chain。故全量含 tool chain 的 transcript **必须遍历该 session 的每个 run 的原始事件**重建。

(已把 `Run/Turn/Session` 概念模型 + 跨轮有损投影沉淀进 `ARCHITECTURE.md`,见独立 docs commit。)

## 改动
- **`runEventsToMessages(events)`**(`src/trace/diagnostics/sessionHistory.ts`):逐 run **离散事件**投影 —— user ← `agent.run.started.input`、assistant ← `llm.responded.response.content`、tool_result ← `tool.responded`(按 `toolCallId` 配对,error 标 `is_error`)。只用 `responded` 事件 → 每个 run 只贡献自己这轮(恢复的前缀不会被重新 emit)→ 跨 run 拼接**天然不重复**。
- **事件派生的 run 链**:`agent.run.started` 增 `previousRunId`(本轮恢复的上一 run)。`Milkie.invoke` 把恢复的 `checkpoint-run:latest` 作为 `previousRunId` 写入 attach,把一个 session 的 run 链起来。**无独立 by-context 索引** → 不需 import 额外恢复、无并发 `get→push→set` 丢更新。
- **`Milkie.getSessionHistory(contextId)`**:从 `checkpoint-run:latest` 起沿 `previousRunId` 往回走、收集各 run 事件,反转成时序后逐 run 投影拼接;有环/缺失即停(graceful)。无 session 抛(serve 映 404)。
- **serve `POST /session/history { contextId }`**:缺 `contextId`→400,无 session→404,否则 `{ messages }`。不并入 `/session/export`(语义不同)。

> 注:初版用过一个独立的 `context:{id}:runs` stateStore 列表,review 指出会在 import 后失效(P1)、并发同 context 丢 runId(P2);已改为上述事件派生链修复 —— 见 [review 回应评论](https://github.com/xforce-io/milkie/pull/129#issuecomment-4609221650)。

## 测试(TDD 先红后绿)
- `sessionHistory.test.ts` ×3:工具轮投影顺序/成对、error→`is_error`、string output 不 JSON 编码。
- `milkie-session-history.test.ts` ×3:多轮带工具集成(逐条完整、顺序、跨 run **不重复**)、未知 context 抛、**导出→导入→重建 transcript 不 404**(P1 回归)。
- `serve.test.ts` +3:`/session/history` 返回完整序列、缺 `contextId`→400、未知 context→404。

相关套件全绿;`tsc` 通过;全量 **732 passed 零回归**(唯一失败 s-010 e2e 为 main 既有 TS 错误,与本改动无关)。

## 不做(承 issue 边界)
- alfred 侧把 canonical `Message[]` 翻成 history_messages + restore 接线 → alfred 仓库。
- import 方向「导入前全量历史」:`exportSession` 仍只导最新 run-tree,跨进程全量历史需扩 export contract → 独立 follow-up(issue #128 已把 import 划在边界外)。

## 关联
- 设计提案:#128 评论(评审在本 PR 完成,批准后 promote 进 issue body)。
- 前置:#124、#84。消费方:alfred `feat/34-milkie-provider-poc`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)