### PR TITLE
feat(#130): serve 支持持久化 store(SQLite+Jsonl)—— 重启后从 checkpoint 自动恢复

### DIFF
--- a/src/__tests__/BroadcastingEventStore.test.ts
+++ b/src/__tests__/BroadcastingEventStore.test.ts
@@ -75,6 +75,24 @@ describe('BroadcastingEventStore', () => {
     expect(b).toHaveLength(1)
   })
 
+  // #130: serve restart + /resume. resume() reuses a runId but does NOT emit a
+  // fresh agent.run.started, so a broadcaster created after restart never learns
+  // the mapping live. It must recover it from the persisted log, or the resumed
+  // run's trace/progress events silently never reach the contextId subscriber.
+  it('back-fills runId→contextId from the persisted log when the started event predates this instance', async () => {
+    const inner = new MemoryEventStore()
+    await inner.append(startedEvent('r1', 'ctx1'))   // persisted by a "previous process", not via this broadcaster
+
+    const store = new BroadcastingEventStore(inner)  // fresh instance: empty in-memory map (a restart)
+    const received: Event[] = []
+    store.subscribe('ctx1', e => { received.push(e) })
+
+    // A resumed run reuses r1 and appends trace events through the new broadcaster.
+    await store.append(llmEvent('r1', 'resumed-evt'))
+
+    expect(received.map(e => e.id)).toEqual(['resumed-evt'])
+  })
+
   it('forwards readByRunId / readRange to inner', async () => {
     const inner = new MemoryEventStore()
     const store = new BroadcastingEventStore(inner)

--- a/src/__tests__/serve-persistence.test.ts
+++ b/src/__tests__/serve-persistence.test.ts
@@ -90,6 +90,18 @@ describe('#130 buildServeStores — backend selection', () => {
   it('state-store=sqlite without data-dir is rejected', async () => {
     await expect(buildServeStores({ stateStore: 'sqlite' })).rejects.toThrow(/data-dir/)
   })
+
+  it('an unknown backend fails fast instead of silently falling back to memory', async () => {
+    // A typo (or an unsupported backend like redis) must NOT silently run in-memory:
+    // the user would think persistence is on and lose sessions on restart.
+    await expect(buildServeStores({ stateStore: 'sqltie' as 'sqlite', dataDir: tmpDir })).rejects.toThrow(/sqltie|state-store|backend/)
+    await expect(buildServeStores({ stateStore: 'redis' as 'sqlite', dataDir: tmpDir })).rejects.toThrow(/redis|state-store|backend/)
+  })
+
+  it('explicit memory and omitted both resolve to in-memory (the only non-throwing non-sqlite values)', async () => {
+    expect((await buildServeStores({ stateStore: 'memory' })).stateStore).toBeInstanceOf(MemoryStore)
+    expect((await buildServeStores({})).stateStore).toBeInstanceOf(MemoryStore)
+  })
 })
 
 describe('#130 restart recovery — same contextId continues from checkpoint after a fresh instance', () => {

--- a/src/__tests__/serve-persistence.test.ts
+++ b/src/__tests__/serve-persistence.test.ts
@@ -1,0 +1,149 @@
+// #130: serve can run on a persistent backend (SQLite state + Jsonl events) so a
+// restarted sidecar recovers a context from its event-sourced checkpoint — no
+// alfred-side import/replay. buildServeStores picks the backend; default stays
+// in-memory (backward compatible with #86/#124/#126/#128).
+import { buildServeStores } from '../cli/serve'
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { AgentConfig } from '../types/agent'
+import type { ToolDefinition } from '../types/tool'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+const recorderAgent: AgentConfig = {
+  agentId: 'recorder', version: '1.0.0', systemPrompt: 'answer',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 50 }] },
+  model: { provider: 'test', model: 'test', adapter: 'test' },
+}
+
+function factWriter(): ToolDefinition {
+  return {
+    name: 'record_fact', description: 'record a fact',
+    inputSchema: { type: 'object', properties: { key: { type: 'string' }, value: { type: 'string' } }, required: ['key', 'value'] },
+    handler: async (input: unknown, ctx) => {
+      const { key, value } = input as { key: string; value: string }
+      ctx.workingMemory.set(key, value)
+      return { recorded: key }
+    },
+  }
+}
+
+/** Each turn: first call records fact{n} (tool_use), second call completes. */
+function multiTurnRecorder(): IModelGateway {
+  let calls = 0, facts = 0
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      calls++
+      if (calls % 2 === 1) {
+        facts++
+        const input = { key: `fact${facts}`, value: `v${facts}` }
+        return { content: [{ type: 'tool_use', id: `c${facts}`, name: 'record_fact', input }], toolCalls: [{ id: `c${facts}`, name: 'record_fact', input }], finishReason: 'tool_use' }
+      }
+      return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+  }
+}
+
+function closeIfPossible(store: unknown): void {
+  if (store && typeof (store as { close?: unknown }).close === 'function') (store as { close(): void }).close()
+}
+
+let tmpDir: string
+beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-persist-')) })
+afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+describe('#130 buildServeStores — backend selection', () => {
+  it('defaults to in-memory stores (no data-dir, no files written)', async () => {
+    const { stateStore } = await buildServeStores({})
+    expect(stateStore).toBeInstanceOf(MemoryStore)
+    await stateStore.set('k', 'v')
+    expect(await stateStore.get('k')).toBe('v')
+  })
+
+  it('state-store=sqlite persists state to disk across fresh store instances (restart)', async () => {
+    const first = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    await first.stateStore.set('context:C:checkpoint-run:latest', 'run-1')
+    closeIfPossible(first.stateStore)
+    expect(fs.existsSync(path.join(tmpDir, 'state.sqlite'))).toBe(true)
+
+    // A brand-new store instance over the same data-dir reads the persisted value.
+    const second = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    expect(await second.stateStore.get('context:C:checkpoint-run:latest')).toBe('run-1')
+    closeIfPossible(second.stateStore)
+  })
+
+  it('state-store=sqlite persists events to disk (one jsonl file per run)', async () => {
+    const { stateStore, eventStore } = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    await eventStore.append({ id: 'e1', runId: 'run-1', type: 'agent.run.started', actor: 'a', timestamp: 1, payload: { agentId: 'a', goal: 'g', input: 'hi', contextId: 'C' } })
+    closeIfPossible(stateStore)
+
+    const re = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const events = await re.eventStore.readByRunId('run-1')
+    expect(events).toHaveLength(1)
+    expect(events[0]!.runId).toBe('run-1')
+    closeIfPossible(re.stateStore)
+  })
+
+  it('state-store=sqlite without data-dir is rejected', async () => {
+    await expect(buildServeStores({ stateStore: 'sqlite' })).rejects.toThrow(/data-dir/)
+  })
+})
+
+describe('#130 restart recovery — same contextId continues from checkpoint after a fresh instance', () => {
+  it('a new Milkie over the same data-dir sees the prior turns\' context', async () => {
+    const contextId = 'C'
+
+    // Instance 1: persistent stores, two turns that record facts into working memory.
+    const s1 = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const m1 = new Milkie({ stateStore: s1.stateStore, eventStore: s1.eventStore, gateway: multiTurnRecorder(), tools: [factWriter()] })
+    m1.registerAgent(recorderAgent)
+    await m1.invoke({ agentId: 'recorder', goal: 'g', input: 'turn1', contextId })  // → fact1
+    await m1.invoke({ agentId: 'recorder', goal: 'g', input: 'turn2', contextId })  // → fact2
+    closeIfPossible(s1.stateStore)   // simulate shutdown: release the SQLite handle
+
+    // Instance 2: brand-new stores over the SAME data-dir (a "restart"). A capturing
+    // gateway records the prompt the recovered turn assembles.
+    let captured: ModelRequest | undefined
+    const capturing: IModelGateway = {
+      async complete(req: ModelRequest): Promise<ModelResponse> {
+        captured ??= req
+        return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' }
+      },
+      async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+    }
+    const s2 = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const m2 = new Milkie({ stateStore: s2.stateStore, eventStore: s2.eventStore, gateway: capturing, tools: [factWriter()] })
+    m2.registerAgent(recorderAgent)
+    await m2.invoke({ agentId: 'recorder', goal: 'g', input: 'turn3', contextId })
+    closeIfPossible(s2.stateStore)
+
+    // The recovered turn's prompt carries the prior turns' working memory — restored
+    // from the on-disk checkpoint event + pointer, no import/replay.
+    const prompt = JSON.stringify(captured)
+    expect(prompt).toContain('fact1')
+    expect(prompt).toContain('fact2')
+  })
+
+  it('default (memory) does NOT recover across instances — confirms persistence is what enables recovery', async () => {
+    const contextId = 'C'
+    const s1 = await buildServeStores({})
+    const m1 = new Milkie({ stateStore: s1.stateStore, eventStore: s1.eventStore, gateway: multiTurnRecorder(), tools: [factWriter()] })
+    m1.registerAgent(recorderAgent)
+    await m1.invoke({ agentId: 'recorder', goal: 'g', input: 'turn1', contextId })
+
+    let captured: ModelRequest | undefined
+    const capturing: IModelGateway = {
+      async complete(req: ModelRequest): Promise<ModelResponse> { captured ??= req; return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' } },
+      async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] },
+    }
+    const s2 = await buildServeStores({})   // fresh in-memory stores: nothing carried over
+    const m2 = new Milkie({ stateStore: s2.stateStore, eventStore: s2.eventStore, gateway: capturing, tools: [factWriter()] })
+    m2.registerAgent(recorderAgent)
+    await m2.invoke({ agentId: 'recorder', goal: 'g', input: 'turn2', contextId })
+
+    expect(JSON.stringify(captured)).not.toContain('fact1')
+  })
+})

--- a/src/__tests__/serve-persistence.test.ts
+++ b/src/__tests__/serve-persistence.test.ts
@@ -4,7 +4,9 @@
 // in-memory (backward compatible with #86/#124/#126/#128).
 import { buildServeStores } from '../cli/serve'
 import { Milkie } from '../runtime/Milkie'
+import { BroadcastingEventStore } from '../trace/BroadcastingEventStore'
 import { MemoryStore } from '../store/MemoryStore'
+import type { Event } from '../trace/types'
 import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
 import type { AgentConfig } from '../types/agent'
 import type { ToolDefinition } from '../types/tool'
@@ -137,6 +139,38 @@ describe('#130 restart recovery — same contextId continues from checkpoint aft
     const prompt = JSON.stringify(captured)
     expect(prompt).toContain('fact1')
     expect(prompt).toContain('fact2')
+  })
+
+  // The serve scenario: after a restart, /resume reuses the runId but emits no
+  // fresh agent.run.started, so a new BroadcastingEventStore must still fan the
+  // resumed run's trace/progress events out to the contextId SSE subscriber.
+  it('a fresh BroadcastingEventStore still delivers the resumed run\'s tool/trace events after restart', async () => {
+    const contextId = 'C'
+
+    // Instance 1 (persistent): one turn to completion → checkpoint + persisted started.
+    const s1 = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const b1 = new BroadcastingEventStore(s1.eventStore)
+    const m1 = new Milkie({ stateStore: s1.stateStore, eventStore: b1, gateway: multiTurnRecorder(), tools: [factWriter()] })
+    m1.registerAgent(recorderAgent)
+    await m1.invoke({ agentId: 'recorder', goal: 'g', input: 'turn1', contextId })
+    closeIfPossible(s1.stateStore)
+
+    // Instance 2 (restart): brand-new stores AND a brand-new broadcaster (empty map).
+    const s2 = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const b2 = new BroadcastingEventStore(s2.eventStore)
+    const m2 = new Milkie({ stateStore: s2.stateStore, eventStore: b2, gateway: multiTurnRecorder(), tools: [factWriter()] })
+    m2.registerAgent(recorderAgent)
+
+    const seen: Event[] = []
+    const unsub = b2.subscribe(contextId, e => { seen.push(e) })
+    await m2.resume(`context:${contextId}:checkpoint:latest`, 'recorder', 'continue', 'continue')
+    unsub()
+    closeIfPossible(s2.stateStore)
+
+    // The resumed run's tool chain reached the subscriber (would be empty before the
+    // back-fill fix — the new broadcaster never saw this runId's started event live).
+    expect(seen.some(e => e.type === 'tool.responded')).toBe(true)
+    expect(seen.length).toBeGreaterThan(0)
   })
 
   it('default (memory) does NOT recover across instances — confirms persistence is what enables recovery', async () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -257,8 +257,10 @@ export async function main(argv: string[]): Promise<MainResult> {
     .requiredOption('--agent <file>', 'agent definition file (.md with frontmatter)')
     .requiredOption('--port <port>', 'port to listen on (0 = OS-assigned)', v => parseInt(v, 10))
     .option('--host <host>', 'host/interface to bind', '127.0.0.1')
-    .action(async (opts: { agent: string; port: number; host: string }) => {
-      await serveMain({ agent: opts.agent, port: opts.port, host: opts.host })
+    .option('--state-store <kind>', 'persistence backend: memory (default) or sqlite (#130: restart-recoverable)', 'memory')
+    .option('--data-dir <path>', 'stable directory for sqlite state + jsonl events (required with --state-store sqlite)')
+    .action(async (opts: { agent: string; port: number; host: string; stateStore: 'memory' | 'sqlite'; dataDir?: string }) => {
+      await serveMain({ agent: opts.agent, port: opts.port, host: opts.host, stateStore: opts.stateStore, dataDir: opts.dataDir })
     })
 
   try {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import fs from 'fs'
 import path from 'path'
 import { Milkie } from '../runtime/Milkie.js'
@@ -257,7 +257,7 @@ export async function main(argv: string[]): Promise<MainResult> {
     .requiredOption('--agent <file>', 'agent definition file (.md with frontmatter)')
     .requiredOption('--port <port>', 'port to listen on (0 = OS-assigned)', v => parseInt(v, 10))
     .option('--host <host>', 'host/interface to bind', '127.0.0.1')
-    .option('--state-store <kind>', 'persistence backend: memory (default) or sqlite (#130: restart-recoverable)', 'memory')
+    .addOption(new Option('--state-store <kind>', 'persistence backend (#130: sqlite is restart-recoverable)').choices(['memory', 'sqlite']).default('memory'))
     .option('--data-dir <path>', 'stable directory for sqlite state + jsonl events (required with --state-store sqlite)')
     .action(async (opts: { agent: string; port: number; host: string; stateStore: 'memory' | 'sqlite'; dataDir?: string }) => {
       await serveMain({ agent: opts.agent, port: opts.port, host: opts.host, stateStore: opts.stateStore, dataDir: opts.dataDir })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -3,6 +3,11 @@ import { Milkie } from '../runtime/Milkie.js'
 import { BroadcastingEventStore } from '../trace/BroadcastingEventStore.js'
 import { MemoryStore } from '../store/MemoryStore.js'
 import { MemoryEventStore } from '../trace/MemoryEventStore.js'
+import { SQLiteStore } from '../store/SQLiteStore.js'
+import { JsonlEventStore } from '../trace/JsonlEventStore.js'
+import path from 'path'
+import type { IStateStore } from '../types/store.js'
+import type { IEventStore } from '../trace/EventStore.js'
 import type { AgentResult, JSONValue, Message } from '../types/common.js'
 import type { ModelEvent, ModelResponse } from '../types/model.js'
 import type { PortableSession } from '../runtime/PortableSession.js'
@@ -288,14 +293,34 @@ export function runServeServer(server: Server, opts: { port: number; host?: stri
 }
 
 /**
- * CLI entry for `milkie serve`: load the agent file, build a process-local
- * Milkie (MemoryStore + broadcasting MemoryEventStore — interrupt/resume live
- * in this process, D5), and serve until shut down. The gateway is resolved from
- * the agent's own model config.
+ * #130: pick serve's persistence backend. Default is in-memory (sessions live in
+ * this process only — the #86 behavior). `state-store=sqlite` uses a persistent
+ * SQLite stateStore + Jsonl eventStore under `data-dir`, so a restarted sidecar
+ * recovers a context from its event-sourced checkpoint (#73). The two stores are
+ * coupled on purpose: recovery needs both the checkpoint events (eventStore) and
+ * the `checkpoint-run:latest` pointer (stateStore), so they persist together.
  */
-export async function serveMain(opts: { agent: string; port: number; host?: string }): Promise<void> {
-  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
-  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster })
+export async function buildServeStores(opts: { stateStore?: 'memory' | 'sqlite'; dataDir?: string }): Promise<{ stateStore: IStateStore; eventStore: IEventStore }> {
+  if (opts.stateStore === 'sqlite') {
+    if (!opts.dataDir) throw new Error('--data-dir is required when --state-store=sqlite')
+    const stateStore = new SQLiteStore({ path: path.join(opts.dataDir, 'state.sqlite') })
+    await stateStore.init()
+    const eventStore = new JsonlEventStore(path.join(opts.dataDir, 'runs'))
+    return { stateStore, eventStore }
+  }
+  return { stateStore: new MemoryStore(), eventStore: new MemoryEventStore() }
+}
+
+/**
+ * CLI entry for `milkie serve`: load the agent file, build a process-local
+ * Milkie (in-memory by default, or persistent SQLite+Jsonl under `--data-dir` so
+ * the same contextId recovers from checkpoint after a restart — D5/#130), and
+ * serve until shut down. The gateway is resolved from the agent's own model config.
+ */
+export async function serveMain(opts: { agent: string; port: number; host?: string; stateStore?: 'memory' | 'sqlite'; dataDir?: string }): Promise<void> {
+  const { stateStore, eventStore } = await buildServeStores(opts)
+  const broadcaster = new BroadcastingEventStore(eventStore)
+  const milkie = new Milkie({ stateStore, eventStore: broadcaster })
   const config = milkie.loadAgentFile(opts.agent)
   const server = createServeServer({ milkie, agentId: config.agentId, broadcaster })
   await runServeServer(server, { port: opts.port, host: opts.host })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -301,14 +301,21 @@ export function runServeServer(server: Server, opts: { port: number; host?: stri
  * the `checkpoint-run:latest` pointer (stateStore), so they persist together.
  */
 export async function buildServeStores(opts: { stateStore?: 'memory' | 'sqlite'; dataDir?: string }): Promise<{ stateStore: IStateStore; eventStore: IEventStore }> {
-  if (opts.stateStore === 'sqlite') {
+  const kind = opts.stateStore ?? 'memory'
+  if (kind === 'memory') {
+    return { stateStore: new MemoryStore(), eventStore: new MemoryEventStore() }
+  }
+  if (kind === 'sqlite') {
     if (!opts.dataDir) throw new Error('--data-dir is required when --state-store=sqlite')
     const stateStore = new SQLiteStore({ path: path.join(opts.dataDir, 'state.sqlite') })
     await stateStore.init()
     const eventStore = new JsonlEventStore(path.join(opts.dataDir, 'runs'))
     return { stateStore, eventStore }
   }
-  return { stateStore: new MemoryStore(), eventStore: new MemoryEventStore() }
+  // Fail fast: an unknown backend (typo, or unsupported like redis) must NOT
+  // silently fall back to memory — the caller would think persistence is on and
+  // lose sessions on restart.
+  throw new Error(`unknown --state-store "${String(kind)}"; expected "memory" or "sqlite"`)
 }
 
 /**

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -824,7 +824,6 @@ export class Milkie {
       skills:     data['skills']     as Record<string, string> | undefined,
       skillInstructions: data['skillInstructions'] as Record<string, string> | undefined,
       subAgents:  (data['sub_agents'] ?? data['subAgents']) as Record<string, string> | undefined,
-      stateStore: data['state_store'] as 'memory' | 'sqlite' | 'redis' | undefined,
       dispatch:   data['dispatch']   as 'local' | 'queue' | undefined,
     }
   }

--- a/src/trace/BroadcastingEventStore.ts
+++ b/src/trace/BroadcastingEventStore.ts
@@ -34,11 +34,31 @@ export class BroadcastingEventStore implements IEventStore {
       this.contextIdByRunId.set(event.runId, payload.contextId)
     }
 
-    const contextId = this.contextIdByRunId.get(event.runId)
+    const contextId = await this.contextIdFor(event.runId)
     if (contextId) {
       const subs = this.subscribers.get(contextId)
       if (subs) for (const cb of subs) cb(event)
     }
+  }
+
+  /**
+   * The contextId owning a run. Normally learned live from the run's
+   * `agent.run.started` (cached). But `resume()` reuses a runId without emitting
+   * a fresh started event, so a broadcaster created after a serve restart never
+   * sees it live — recover the mapping from the persisted log (the started event
+   * is durable, e.g. in the JsonlEventStore) so the resumed run's trace/progress
+   * events still reach contextId subscribers. Cached so the lookup runs at most
+   * once per unknown run.
+   */
+  private async contextIdFor(runId: string): Promise<string | undefined> {
+    const cached = this.contextIdByRunId.get(runId)
+    if (cached !== undefined) return cached
+    const prior = await this.inner.readByRunId(runId)
+    const started = prior.find(e => e.type === 'agent.run.started')
+    if (!started) return undefined
+    const contextId = (started.payload as { contextId: string }).contextId
+    this.contextIdByRunId.set(runId, contextId)
+    return contextId
   }
 
   async readByRunId(runId: string): Promise<Event[]> {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -38,6 +38,5 @@ export interface AgentConfig {
   skills?:      Record<string, string>
   skillInstructions?: Record<string, string>
   subAgents?:   Record<string, string>
-  stateStore?:  'memory' | 'sqlite' | 'redis'
   dispatch?:    'local' | 'queue'
 }


### PR DESCRIPTION
Closes #130

## 摘要
`milkie serve` 此前硬编内存 store(`MemoryStore`+`MemoryEventStore`),重启即丢会话。milkie 库层本就具备**事件溯源 checkpoint 恢复**(#73),只是 serve 没接。本 PR 把持久化 store(SQLite + Jsonl)接进 serve:**同一 `contextId` 的 `/chat` 在 sidecar 重启后从 checkpoint 自动续接**,alfred 无需 import/灌回历史。承 #86(serve)、#73(events 即真相源)、#99(stateStore 必传)、#128(history)。

## 真相源澄清(为什么两 store 都要持久化)
checkpoint **本体在 events**(`agent.checkpoint` 事件 = #73 单一真相源);stateStore 只存**路由指针** `context:{id}:checkpoint-run:latest`(「哪个 run 是这个 context 最新的」——无法只从 events 反查,`IEventStore` 无 by-context 查询)+ context vars(#83)。所以恢复需要 **eventStore(Jsonl)存 checkpoint + stateStore(SQLite)存指针**,两者必须一起持久化。

## 改动
- **`buildServeStores({ stateStore, dataDir })`**(`src/cli/serve.ts`):默认 `memory`(向后兼容 #86/#124/#126/#128);`sqlite` → `SQLiteStore(<dataDir>/state.sqlite)` + `JsonlEventStore(<dataDir>/runs/)`,`sqlite` 缺 `data-dir` 报错。两 store **故意耦合**——不设独立 `--event-store` flag,避免「sqlite state + memory events」这种恢复不了的错配。
- **`serveMain`** 用 `buildServeStores` 构造后端。
- **CLI**:`milkie serve --state-store <memory|sqlite> --data-dir <stable-path>`(main.ts)。
- **死代码清理**:移除 `AgentConfig.stateStore`(frontmatter `state_store`)—— parseConfig 解析了但全代码无人消费;本 issue 选 CLI flag 路径,该字段确定不用。

## 测试(TDD)
- `serve-persistence.test`:后端选择 4 例(默认 memory 不落盘 / `sqlite` **跨新实例落盘恢复** state 与 events / 缺 `data-dir` 报错);重启恢复验收(新 Milkie 同 `data-dir` 看到前两轮 WM `fact1`/`fact2`,纯 on-disk checkpoint 恢复)+ memory 不跨实例对照。
- 既有 `serve.test`(memory,26)回归不破。
- `tsc` 通过;全量 **738 passed 零回归**(唯一失败 s-010 e2e 为 main 既有 TS 错误,与本改动无关)。

## 不过度工程
HTTP `/chat` 路径与 store 后端无关、已被 `serve.test` 覆盖,故重启恢复在 **Milkie 级**证(用 `buildServeStores` 的持久化 store + 新实例同 dir),不 spawn 子进程做重型 e2e。

## 不做(承 issue 边界)
- RedisStore / 跨主机生产化(本期只需 SQLite+Jsonl 满足同主机 sidecar 重启)。
- alfred 侧:传稳定 `data-dir` + 重启接线 + 去 dolphin import → alfred 仓库独立工作。

## 关联
- 设计提案:[#130 评论](https://github.com/xforce-io/milkie/issues/130#issuecomment-4609423753)。前置 #86/#73/#99/#128。消费方:alfred `feat/34-milkie-provider-poc`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)