### PR TITLE
feat(tools): run_command 内建 shell/exec 工具(#134)

### DIFF
--- a/src/__tests__/execTools.replay.test.ts
+++ b/src/__tests__/execTools.replay.test.ts
@@ -1,0 +1,68 @@
+// #134: a run that uses the side-effectful run_command tool must replay from
+// cache WITHOUT re-executing the subprocess. Proven directly: run_command appends
+// one byte to a file at record time; replay must NOT append again (handler is
+// served from CacheIndex, never re-run — see ReplayingIOPort / ExplodingInnerPort).
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { AgentConfig } from '../types/agent'
+
+function toolResp(id: string, name: string, input: unknown): ModelResponse {
+  return { content: [{ type: 'tool_use', id, name, input }], toolCalls: [{ id, name, input }], finishReason: 'tool_use' }
+}
+
+class ScriptedGateway implements IModelGateway {
+  private n = 0
+  constructor(private readonly command: string) {}
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    this.n++
+    if (this.n === 1) return toolResp('c1', 'run_command', { command: this.command })
+    return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async *stream(_r: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+
+const agent: AgentConfig = {
+  agentId: 'shell-runner', version: '1.0.0',
+  systemPrompt: 'run the command then answer',
+  fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 10 }] },
+  model: { provider: 'test', model: 'test', adapter: 'test' },
+}
+
+describe('determinism: run_command (#134) replays from cache without re-executing the subprocess', () => {
+  it('side effect happens exactly once at record time; replay does not re-fork', async () => {
+    const dir  = await mkdtemp(join(tmpdir(), 'milkie-exec-replay-'))
+    const file = join(dir, 'side-effect.log')
+    // append one byte + emit stdout; if replay re-ran the handler the file would grow.
+    const command = `printf X >> '${file}'; echo ran-ok`
+
+    try {
+      const milkie = new Milkie({
+        stateStore: new MemoryStore(),
+        eventStore: new MemoryEventStore(),
+        gateway:    new ScriptedGateway(command),
+      })
+      milkie.registerAgent(agent)
+
+      const run = await milkie.invoke({ agentId: 'shell-runner', goal: 'g', input: 'go', contextId: 'exec-replay' })
+      expect(run.status).toBe('completed')
+      expect(await readFile(file, 'utf8')).toBe('X') // ran exactly once at record time
+
+      // Replay the recorded run. The script still exists, but the point is the
+      // handler must NOT run at all — so the file must stay at one byte.
+      const replayed = await milkie.replay(run.agentRunId)
+      expect(replayed.output).toBe(run.output)
+      expect(await readFile(file, 'utf8')).toBe('X') // STILL one byte → handler not re-run
+
+      // Replaying again must remain stable (idempotent, no accumulation).
+      await milkie.replay(run.agentRunId)
+      expect(await readFile(file, 'utf8')).toBe('X')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/execTools.test.ts
+++ b/src/__tests__/execTools.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execTools, runCommand, type RunCommandOutput } from '../tools/exec'
+import type { ToolContext } from '../types/tool'
+
+const runCmd = execTools.find(t => t.name === 'run_command')!
+const NODE = process.execPath
+
+describe('built-in run_command tool (#134)', () => {
+  it('registers run_command', () => {
+    expect(runCmd).toBeTruthy()
+    expect(runCmd.name).toBe('run_command')
+  })
+
+  it('runs a command and captures stdout + exitCode 0', async () => {
+    const out = await runCommand({ command: 'echo hello-milkie' })
+    expect(out.stdout).toContain('hello-milkie')
+    expect(out.exitCode).toBe(0)
+    expect(out.timedOut).toBe(false)
+    expect(out.truncated).toBe(false)
+  })
+
+  it('propagates a non-zero exit code', async () => {
+    const out = await runCommand({ command: 'exit 3' })
+    expect(out.exitCode).toBe(3)
+    expect(out.timedOut).toBe(false)
+  })
+
+  it('captures stderr separately from stdout', async () => {
+    const out = await runCommand({ command: 'echo oops 1>&2' })
+    expect(out.stderr).toContain('oops')
+    expect(out.stdout).toBe('')
+    expect(out.exitCode).toBe(0)
+  })
+
+  it('honors cwd', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'milkie-exec-'))
+    try {
+      await writeFile(join(dir, 'marker.txt'), 'present')
+      const out = await runCommand({ command: 'cat marker.txt', cwd: dir })
+      expect(out.stdout).toContain('present')
+      expect(out.exitCode).toBe(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('kills the process on timeout and reports timedOut', async () => {
+    const start = Date.now()
+    const out = await runCommand({ command: `${NODE} -e "setTimeout(()=>{}, 10000)"`, timeoutMs: 200 })
+    expect(out.timedOut).toBe(true)
+    expect(out.exitCode).not.toBe(0) // SIGKILLed → null or non-zero, never clean 0
+    expect(Date.now() - start).toBeLessThan(5000) // proves it was killed, not waited out
+  })
+
+  it('surfaces spawn errors (bad cwd) without throwing', async () => {
+    const out = await runCommand({ command: 'echo x', cwd: '/no/such/dir/at/all' })
+    expect(out.exitCode).toBeNull()
+    expect(out.stderr.length).toBeGreaterThan(0)
+  })
+
+  it('truncates very large output (head+tail kept, both ends visible)', async () => {
+    const out = await runCommand({
+      command: `${NODE} -e "process.stdout.write('A'.repeat(50)+'B'.repeat(100000)+'Z'.repeat(50))"`,
+    })
+    expect(out.truncated).toBe(true)
+    expect(out.stdout.length).toBeLessThan(40_000)
+    expect(out.stdout.startsWith('AAAAA')).toBe(true)   // head kept
+    expect(out.stdout.endsWith('ZZZZZ')).toBe(true)     // tail kept
+    expect(out.stdout).toContain('chars dropped')
+  })
+
+  it('handler is invokable as a ToolDefinition (ctx not required)', async () => {
+    const out = (await runCmd.handler({ command: 'echo viahandler' }, {} as ToolContext)) as RunCommandOutput
+    expect(out.stdout).toContain('viahandler')
+  })
+})

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -33,6 +33,7 @@ import type { IIOPort } from './IOPort.js'
 import { cognitiveTools } from '../tools/cognitive.js'
 import { systemTools } from '../tools/system.js'
 import { lineageTools } from '../tools/lineage.js'
+import { execTools } from '../tools/exec.js'
 import type { InMemoryRecorder } from '../trajectory/InMemoryRecorder.js'
 import type { ITraceObjectStore } from '../trace/TraceObjectStore.js'
 import { canonicalize, contentAddressForCanonicalBytes } from '../trace/hash.js'
@@ -255,6 +256,7 @@ export class AgentRuntime {
     for (const tool of systemTools)    this.registry.register(tool)
     for (const tool of cognitiveTools) this.registry.register(tool)
     for (const tool of lineageTools)   this.registry.register(tool)  // #113 P3
+    for (const tool of execTools)      this.registry.register(tool)  // #134 shell/exec
     for (const tool of extraTools)     this.registry.register(tool)
     for (const [agentId] of Object.entries(this.config.subAgents ?? {})) {
       this.registry.register(this.makeSubAgentTool(agentId))

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -1,0 +1,98 @@
+import { spawn } from 'node:child_process'
+import type { ToolDefinition } from '../types/tool.js'
+
+// Built-in shell/exec tool (#134). Lets an agent run subprocess commands —
+// skill scripts (`python skills/.../scripts/x.py`), CLIs (`inv`, `codex-cli`), etc.
+//
+// Replay safety: this is an ordinary ToolDefinition. milkie records the handler's
+// return on `tool.responded` and serves it from cache on replay (handler never
+// re-runs — see ReplayingIOPort / ExplodingInnerPort). So the subprocess forks
+// only at record time; replay reproduces the captured stdout/exit without side
+// effects. No "non-replayable" contract is needed (mirrors create_plan).
+
+const DEFAULT_TIMEOUT_MS = 120_000
+
+// Per-stream capture cap. Capping inside the handler (rather than only via
+// resultStrategy, which shapes the context view but not the event log) bounds
+// BOTH the LLM context AND the persisted event log / CacheIndex. Head+tail is
+// kept so the agent sees how the command started and ended.
+const MAX_STREAM_CHARS = 30_000
+
+export interface RunCommandInput {
+  command:    string
+  cwd?:       string
+  timeoutMs?: number
+}
+
+export interface RunCommandOutput {
+  stdout:    string
+  stderr:    string
+  exitCode:  number | null
+  timedOut:  boolean
+  truncated: boolean
+}
+
+function capStream(s: string): { text: string; truncated: boolean } {
+  if (s.length <= MAX_STREAM_CHARS) return { text: s, truncated: false }
+  const half    = Math.floor(MAX_STREAM_CHARS / 2)
+  const dropped = s.length - MAX_STREAM_CHARS
+  const text    = `${s.slice(0, half)}\n[...${dropped} chars dropped...]\n${s.slice(-half)}`
+  return { text, truncated: true }
+}
+
+export function runCommand(input: RunCommandInput): Promise<RunCommandOutput> {
+  const { command, cwd, timeoutMs = DEFAULT_TIMEOUT_MS } = input
+  return new Promise((resolve) => {
+    const child = spawn(command, { shell: true, cwd })
+    let rawOut  = ''
+    let rawErr  = ''
+    let timedOut = false
+    let settled  = false
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, timeoutMs)
+
+    const finish = (exitCode: number | null, errSuffix = '') => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      const out = capStream(rawOut)
+      const err = capStream(rawErr + errSuffix)
+      resolve({
+        stdout:    out.text,
+        stderr:    err.text,
+        exitCode,
+        timedOut,
+        truncated: out.truncated || err.truncated,
+      })
+    }
+
+    child.stdout?.on('data', (d) => { rawOut += d.toString() })
+    child.stderr?.on('data', (d) => { rawErr += d.toString() })
+    // spawn failures (e.g. cwd does not exist) surface here, not via 'close'.
+    child.on('error', (e: Error) => finish(null, (rawErr ? '\n' : '') + e.message))
+    child.on('close', (code) => finish(code))
+  })
+}
+
+export const execTools: ToolDefinition[] = [
+  {
+    name:        'run_command',
+    description:
+      'Execute a shell command in a subprocess and return { stdout, stderr, exitCode, timedOut, truncated }. ' +
+      'Use this to run skill scripts (e.g. `python skills/<name>/scripts/x.py`), CLIs (`inv`, `codex-cli`), ' +
+      'and other tools. Output over 30000 chars per stream is truncated (head+tail kept).',
+    inputSchema: {
+      type:       'object',
+      properties: {
+        command:   { type: 'string', description: 'The shell command to run.' },
+        cwd:       { type: 'string', description: 'Working directory for the command (optional).' },
+        timeoutMs: { type: 'number', description: 'Timeout in ms (default 120000). On timeout the process is SIGKILLed and timedOut=true.' },
+      },
+      required:   ['command'],
+    },
+    handler: async (input) => runCommand(input as RunCommandInput),
+  },
+]


### PR DESCRIPTION
## 摘要

新增内建 `run_command` shell/exec 工具。milkie 此前**无任何 shell 执行能力**(内建工具只有 cognitive/lineage/trace/system),导致 alfred(xforce-io/alfred#38)迁移到 milkie 后,其 shell 型 skill(`python skills/.../scripts/x.py`、`inv`、`codex-cli`)"指令在、能力断"。

## 改动

- `src/tools/exec.ts`:`run_command`(`child_process.spawn` shell)→ `{stdout, stderr, exitCode, timedOut, truncated}`;支持 `cwd`/`timeoutMs`(超时 SIGKILL);handler 内按流截断(30k/流,head+tail),同时压住 LLM context 与 event log。
- 在 `AgentRuntime.registerTools` 注册(与 systemTools 同级;无 `tools` 白名单的 state 自动可用)。

## replay 安全(关键)

`run_command` 是普通 `ToolDefinition`。milkie record 真跑 / replay 全缓存、handler 在 replay 期**绝不执行**(`ReplayingIOPort` + `ExplodingInnerPort` 背书),故副作用 shell 工具**零改造即 replay 安全**(同 `create_plan`)。新增 `execTools.replay.test.ts` 用"副作用文件追加"直接证伪:录制期追加一次,replay 不重 fork。

## 测试

- `execTools.test.ts`:9 单测(执行/退出码/stderr/cwd/超时/spawn 错误/截断/ToolDefinition 调用)
- `execTools.replay.test.ts`:replay 安全证伪
- 全量 610 jest 绿,确定性 e2e 绿,tsc 干净

Closes #134 · 关联 xforce-io/alfred#38
