### PR TITLE
feat(#137): serve 暴露 contextId 运行态(/context/state),支撑用户介入 resume

### DIFF
--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -322,6 +322,44 @@ describe('createServeServer', () => {
     expect(res.status).toBe(400)
   })
 
+  // ─────────────────────── #137 /context/state ───────────────────────
+
+  it('POST /context/state for a never-run context reports not paused / not resumable', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/context/state', { contextId: 'never' })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ contextId: 'never', exists: false, paused: false, resumable: false })
+  })
+
+  it('POST /context/state after a completed chat reports exists but not paused', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['ok'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    await (await sse(port, 'POST', '/chat', { contextId: 'cs', input: 'hi' }).done)
+    const res = await request(port, 'POST', '/context/state', { contextId: 'cs' })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ contextId: 'cs', exists: true, paused: false, resumable: false })
+  })
+
+  it('POST /context/state after an interrupt reports paused + resumable', async () => {
+    const { milkie, agentId, broadcaster } = buildSteppingMilkie({ totalSteps: 30, stepMs: 40 })
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const { done } = sse(port, 'POST', '/chat', { contextId: 'ps', input: 'go' })
+    await new Promise(r => setTimeout(r, 120))   // let a few steps run
+    await request(port, 'POST', '/interrupt', { contextId: 'ps' })
+    await done                                    // interrupted terminal ⇒ checkpoint persisted
+    const res = await request(port, 'POST', '/context/state', { contextId: 'ps' })
+    expect(res.status).toBe(200)
+    expect(res.json).toMatchObject({ contextId: 'ps', exists: true, paused: true, resumable: true, currentState: 'paused' })
+  })
+
+  it('POST /context/state without contextId returns 400', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['x'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const res = await request(port, 'POST', '/context/state', {})
+    expect(res.status).toBe(400)
+  })
+
   // ─────────────────────────── #124 /llm ───────────────────────────
 
   const userMsg = [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -161,6 +161,15 @@ export function createServeServer(opts: ServeOptions): Server {
     sendJson(res, 200, { vars })
   }
 
+  // #137: read-only run-state of a context (is it interrupt-paused / resumable),
+  // projected from the latest checkpoint. Lets an external provider gate
+  // resume-vs-stop without driving a turn.
+  async function handleContextState(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { contextId } = JSON.parse(await readBody(req)) as { contextId?: string }
+    if (!contextId) return sendJson(res, 400, { error: 'contextId is required' })
+    sendJson(res, 200, await milkie.getContextState(contextId))
+  }
+
   // #124: one-shot LLM completion (alfred's call_llm). Borrows the single loaded
   // agent's model config; bypasses the FSM. stream=true → SSE message_delta… +
   // a `done` terminal (errors as an `error` frame + `done`, never a bare
@@ -238,6 +247,7 @@ export function createServeServer(opts: ServeOptions): Server {
         if (req.method === 'POST' && route === '/context/set')  return await handleContextSet(req, res)
         if (req.method === 'POST' && route === '/context/get')  return await handleContextGet(req, res)
         if (req.method === 'POST' && route === '/context/list') return await handleContextList(req, res)
+        if (req.method === 'POST' && route === '/context/state') return await handleContextState(req, res)
         if (req.method === 'POST' && route === '/llm')            return await handleLlm(req, res)
         if (req.method === 'POST' && route === '/session/history') return await handleSessionHistory(req, res)
         if (req.method === 'POST' && route === '/session/export') return await handleSessionExport(req, res)

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -34,6 +34,22 @@ import {
   collectRunTree,
 } from './PortableSession.js'
 
+/**
+ * #137: read-only run-state of a context, projected from its latest checkpoint.
+ * `paused` ⇔ the FSM stopped in the reserved `paused` state (entered only via
+ * interrupt); `resumable` ⇔ a paused checkpoint exists to /resume from.
+ * `interruptSignaled` is the transient `context:{id}:interrupt` flag — set the
+ * moment interrupt is requested, before the turn has yielded to `paused`.
+ */
+export interface ContextRunState {
+  contextId:         string
+  exists:            boolean
+  paused:            boolean
+  resumable:         boolean
+  currentState:      string | null
+  interruptSignaled: boolean
+}
+
 export interface MilkieOptions {
   /**
    * #99: required — no silent in-memory fallback. Choose the backend explicitly:
@@ -712,6 +728,24 @@ export class Milkie {
         await this.stateStore.set(`context:${child.contextId}:interrupt`, true)
       }
     }
+  }
+
+  /**
+   * #137: read-only run-state query for a context. Projects the latest
+   * checkpoint (event-sourced, via resolveCheckpoint) and reports whether the
+   * context is interrupt-paused and resumable — letting an external provider
+   * decide resume-vs-stop without driving a turn. A completed or never-run
+   * context is not paused (`paused` ⇔ FSM stopped in the reserved `paused` state).
+   */
+  async getContextState(contextId: string): Promise<ContextRunState> {
+    const interruptSignaled = (await this.stateStore.get(`context:${contextId}:interrupt`)) === true
+    const checkpoint = await this.resolveCheckpoint(`context:${contextId}:checkpoint:latest`)
+    if (!checkpoint) {
+      return { contextId, exists: false, paused: false, resumable: false, currentState: null, interruptSignaled }
+    }
+    const currentState = checkpoint.fsm.currentState
+    const paused = currentState === 'paused'
+    return { contextId, exists: true, paused, resumable: paused, currentState, interruptSignaled }
   }
 
   // ---- #83: session context variables (key contract: context:{id}:var:{name}) ----


### PR DESCRIPTION
## 摘要

serve 新增只读端点 `POST /context/state { contextId }`,暴露 context 运行态,支撑外部 provider(alfred)判断 resume-vs-stop。

- `Milkie.getContextState()` 复用 `resolveCheckpoint`(#73 事件溯源)投影最新 checkpoint
- `paused ⇔ checkpoint.fsm.currentState === 'paused'`(仅 `/interrupt` 进入的 FSM 保留态);无 checkpoint → `exists:false`
- 纯只读,不驱动 turn、不改运行时机制
- 返回 `{ contextId, exists, paused, resumable, currentState, interruptSignaled }`

## 背景

此前 serve 不透出运行态,alfred 的 `is_user_interrupt_paused` 只能恒 `False` → 用户介入后的 resume 续跑路径成死分支(只能 stop+interrupt)。详见 issue。

## 测试

- 4 个端点测试:never-run / completed / interrupted / 缺 contextId→400
- 全量 `serve.test.ts` **30/30 绿**,`tsc --noEmit` 干净

下游接入:xforce-io/alfred#34(`MilkieProvider.is_user_interrupt_paused` 已实接此端点)。

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
