### PR TITLE
feat(#140): serve 终止帧 agent.run.completed 回传 runId

### DIFF
--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -1,5 +1,8 @@
 import http from 'http'
-import { createServeServer } from '../cli/serve'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { createServeServer, buildServeStores } from '../cli/serve'
 import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
 import { MemoryEventStore } from '../trace/MemoryEventStore'
@@ -270,6 +273,96 @@ describe('createServeServer', () => {
     const terminal = events.find(e => e.event === 'agent.run.completed')
     expect(terminal).toBeDefined()
     expect((terminal!.data as { status: string }).status).toBe('error')
+  })
+
+  // ─────────────────────── #140 terminal frame carries runId ───────────────────────
+  // The completed terminal frame must expose the run's runId so an external
+  // (alfred) provider can locate the recorded trace (`<dataDir>/runs/<runId>.jsonl`,
+  // read by `milkie trace <runId>`). Assertion strength: the emitted runId, fed
+  // back into readByRunId (what `trace` does), resolves to this run's events.
+
+  it('POST /chat completed terminal frame carries a runId that resolves to the recorded run', async () => {
+    const { milkie, agentId, broadcaster } = buildTextMilkie(['Hello, ', 'world!'])
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const events = await sse(port, 'POST', '/chat', { contextId: 'rid-chat', input: 'hi' }).done
+
+    const terminal = events.find(e => e.event === 'agent.run.completed')!
+    const runId = (terminal.data as { runId?: string }).runId
+    expect(typeof runId).toBe('string')
+    expect(runId!.length).toBeGreaterThan(0)
+
+    const recorded = await broadcaster.readByRunId(runId!)
+    expect(recorded.length).toBeGreaterThan(0)
+    expect(recorded.some(ev => ev.type === 'agent.run.started')).toBe(true)
+  })
+
+  it('POST /chat error terminal frame still carries a runId (failed runs stay traceable)', async () => {
+    const { milkie, agentId, broadcaster } = buildErrorMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const events = await sse(port, 'POST', '/chat', { contextId: 'rid-err', input: 'go' }).done
+
+    const terminal = events.find(e => e.event === 'agent.run.completed')!
+    expect((terminal.data as { status: string }).status).toBe('error')
+    const runId = (terminal.data as { runId?: string }).runId
+    expect(typeof runId).toBe('string')
+    expect(runId!.length).toBeGreaterThan(0)
+
+    const recorded = await broadcaster.readByRunId(runId!)
+    expect(recorded.length).toBeGreaterThan(0)
+  })
+
+  it('POST /resume completed terminal frame carries a runId that resolves to the run', async () => {
+    const { milkie, agentId, broadcaster } = buildSteppingMilkie({ totalSteps: 4, stepMs: 40 })
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+
+    const { done: chatDone } = sse(port, 'POST', '/chat', { contextId: 'rid-res', input: 'go' })
+    await new Promise(r => setTimeout(r, 70))
+    await request(port, 'POST', '/interrupt', { contextId: 'rid-res' })
+    await chatDone
+
+    const resumeEvents = await sse(port, 'POST', '/resume', { contextId: 'rid-res' }).done
+    const terminal = resumeEvents.find(e => e.event === 'agent.run.completed')!
+    expect((terminal.data as { status: string }).status).toBe('completed')
+    const runId = (terminal.data as { runId?: string }).runId
+    expect(typeof runId).toBe('string')
+    expect(runId!.length).toBeGreaterThan(0)
+
+    const recorded = await broadcaster.readByRunId(runId!)
+    expect(recorded.length).toBeGreaterThan(0)
+  })
+
+  it('POST /chat terminal frame runId names the on-disk trace file (end-to-end: what `milkie trace <runId>` reads)', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-runid-'))
+    try {
+      const { stateStore, eventStore } = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+      const broadcaster = new BroadcastingEventStore(eventStore)
+      const gateway: IModelGateway = {
+        async complete(_req: ModelRequest): Promise<ModelResponse> {
+          return { content: [{ type: 'text', text: 'hi' }], toolCalls: [], finishReason: 'end_turn' }
+        },
+        async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> { yield { type: 'message_delta', data: { text: 'hi' } } },
+      }
+      const agent: AgentConfig = {
+        agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+        fsm: { states: [{ name: 'react', type: 'llm' }] },
+        model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+      }
+      const milkie = new Milkie({ stateStore, eventStore: broadcaster, gateway })
+      milkie.registerAgent(agent)
+      const port = await listen(createServeServer({ milkie, agentId: 'echo', broadcaster }))
+
+      const events = await sse(port, 'POST', '/chat', { contextId: 'disk', input: 'hi' }).done
+      const terminal = events.find(e => e.event === 'agent.run.completed')!
+      const runId = (terminal.data as { runId?: string }).runId
+      expect(typeof runId).toBe('string')
+
+      // The exact file `milkie trace report <runId>` opens — proves the cross-process contract.
+      expect(fs.existsSync(path.join(tmpDir, 'runs', `${runId}.jsonl`))).toBe(true)
+      const maybeClose = (stateStore as unknown as { close?: () => void }).close
+      if (typeof maybeClose === 'function') maybeClose.call(stateStore)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 
   it('a client disconnecting mid-stream does not crash the server', async () => {

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -92,7 +92,13 @@ export function createServeServer(opts: ServeOptions): Server {
       'cache-control': 'no-cache',
       'connection':    'keep-alive',
     })
+    // #140: the run's id, so alfred can locate the recorded trace
+    // (`<dataDir>/runs/<runId>.jsonl`). Success reads it from the AgentResult;
+    // a failed run has no result, so capture it from the first broadcast event
+    // (the top-level run's `agent.run.started` fires before any sub-agent).
+    let capturedRunId: string | undefined
     const unsub = broadcaster.subscribe(contextId, ev => {
+      capturedRunId ??= ev.runId
       if (STREAM_EVENT_WHITELIST.has(ev.type)) writeSSE(res, ev.type, ev.payload)
     })
     // If the client disconnects mid-run, release the subscription immediately
@@ -104,11 +110,11 @@ export function createServeServer(opts: ServeOptions): Server {
       const result = await run(e => {
         if (e.type === 'message_delta') writeSSE(res, 'message_delta', e.data)
       })
-      writeSSE(res, 'agent.run.completed', { status: result.status, output: result.output })
+      writeSSE(res, 'agent.run.completed', { status: result.status, output: result.output, runId: result.agentRunId })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       writeSSE(res, 'error', { message })
-      writeSSE(res, 'agent.run.completed', { status: 'error', output: '', error: message })
+      writeSSE(res, 'agent.run.completed', { status: 'error', output: '', error: message, runId: capturedRunId })
     } finally {
       unsub()
       if (!res.writableEnded && !res.destroyed) res.end()


### PR DESCRIPTION
## 目的

让 `agent.run.completed` 终止帧携带本轮 `runId`,使外部(alfred,xforce-io/alfred#47)能据此定位落盘 trace(`<dataDir>/runs/<runId>.jsonl`,由 `milkie trace <runId>` 读取)。此前 alfred 只持有 contextId、拿不到 runId,是其整条 trace 接入链的总开关。

## 改动(`src/cli/serve.ts` `streamTurn`,共用于 `/chat` 与 `/resume`)

- **成功帧**:`runId: result.agentRunId`。
- **错误帧**:run 抛异常无 `result`,改从首个广播事件(top-level `agent.run.started`,早于任何子 agent)捕获 `ev.runId` —— 失败 run 同样可被留证。
- 接口面最小:不动 SSE 中间事件转发;不新增端点。

## 测试(TDD,先 RED 后 GREEN)

- 3 单元:`/chat` 成功、`/chat` 错误、`/resume` —— 断言 runId 经 `readByRunId` 解析回本轮记录的事件(`milkie trace` 同款操作)。
- 1 端到端:sqlite/jsonl 落盘,断言 `runs/<runId>.jsonl` 文件**真实存在**(即 `milkie trace report <runId>` 实际打开的文件)。
- 全 34 条 serve 测试 + `tsc --noEmit` + 单元套件无回归。

## 验收对照(#140)

1. ✅ `/chat` 与 `/resume` 终止帧含非空 runId。
2. ✅ runId 等于落盘文件名(端到端测试断言 `runs/<runId>.jsonl` 存在)。
3. ✅ error 分支终止帧也带 runId。

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)