### PR TITLE
feat(#139): skill_list 默认实现去 stub 化(读 MILKIE_SKILL_MANIFEST)

### DIFF
--- a/src/__tests__/skillListManifest.test.ts
+++ b/src/__tests__/skillListManifest.test.ts
@@ -1,0 +1,96 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { systemTools } from '../tools/system'
+import type { ToolContext } from '../types/tool'
+
+// #139 提议1: skill_list 默认 handler 读 MILKIE_SKILL_MANIFEST 指向的本地 manifest
+// → 返回真实完整技能列表；未配置 / 读失败 → degrade（行为软）+ WARNING（日志硬）。
+
+const skillList = systemTools.find(t => t.name === 'skill_list')!
+const ctx = {} as unknown as ToolContext
+
+let tmpDir: string
+const ENV_KEY = 'MILKIE_SKILL_MANIFEST'
+let savedEnv: string | undefined
+let warnSpy: jest.SpyInstance
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-skill-manifest-'))
+})
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+beforeEach(() => {
+  savedEnv = process.env[ENV_KEY]
+  delete process.env[ENV_KEY]
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env[ENV_KEY]
+  else process.env[ENV_KEY] = savedEnv
+  warnSpy.mockRestore()
+})
+
+function writeManifest(name: string, content: string): string {
+  const p = path.join(tmpDir, name)
+  fs.writeFileSync(p, content, 'utf-8')
+  return p
+}
+
+describe('skill_list 默认 handler 读 manifest (#139)', () => {
+  it('env 未设 → degrade 安静：{skills:[], registryConfigured:false}，不 WARNING', async () => {
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('env 已设、manifest 有效 → 返回完整列表，原样透传宿主附加字段（dir/version 不投影）', async () => {
+    const p = writeManifest('ok.json', JSON.stringify({
+      skills: [
+        { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+        { name: 'agent-docs-qa', description: '文档问答', dir: '/abs/agent-docs-qa' },
+      ],
+    }))
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: Array<Record<string, unknown>>; registryConfigured: boolean }
+    expect(out.registryConfigured).toBe(true)
+    expect(out.skills).toHaveLength(2)
+    expect(out.skills[0]).toEqual({ name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' })
+    expect(out.skills[1]).toEqual({ name: 'agent-docs-qa', description: '文档问答', dir: '/abs/agent-docs-qa' })
+  })
+
+  it('env 已设、文件缺失 → degrade {skills:[], registryConfigured:false} + WARNING', async () => {
+    process.env[ENV_KEY] = path.join(tmpDir, 'does-not-exist.json')
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('env 已设、JSON 损坏 → degrade + WARNING', async () => {
+    const p = writeManifest('broken.json', '{ not valid json')
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('单条目 malformed（缺 name/description）→ 跳过该条 + WARNING，其余正常返回', async () => {
+    const p = writeManifest('partial.json', JSON.stringify({
+      skills: [
+        { name: 'good', description: '有效' },
+        { name: 'no-desc' },                       // 缺 description → 跳过
+        { description: 'no-name' },                // 缺 name → 跳过
+        { name: 'also-good', description: '也有效', dir: '/abs/x' },
+      ],
+    }))
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: Array<Record<string, unknown>>; registryConfigured: boolean }
+    expect(out.registryConfigured).toBe(true)
+    expect(out.skills.map(s => s.name)).toEqual(['good', 'also-good'])
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,15 +1,57 @@
+import fs from 'fs'
 import type { ToolDefinition } from '../types/tool.js'
 
 // skill_list and skill_request are system-injected tools.
-// In v1 they are stubs; the Skill Registry (Section 6) is wired in v2.
+//
+// #139 提议1 — skill_list 默认 handler 读宿主经 MILKIE_SKILL_MANIFEST 注入的本地
+// manifest，返回真实完整技能列表。这是个 thin v1 bridge（非 §6 / s-010 完整 Skill
+// Registry）：只读「宿主配置好的 manifest 文件路径」，不碰发现规则。设计取舍是
+// 「最小契约（name+description）+ 开放透传」——milkie 只消费 name/description，宿主
+// 附加字段（dir/version/…）原样透传给 LLM，不投影、不解释。
+//
+// 错误策略「行为软、日志硬」：未配置 / 读失败 / 单条目 malformed 一律 degrade 成安全
+// 结果（绝不抛给 turn loop 里的 LLM），但已配置却读失败 / 跳过坏条目时 log WARNING，
+// 避免 degrade 掩盖 misconfig。
+const SKILL_MANIFEST_ENV = 'MILKIE_SKILL_MANIFEST'
+
+interface SkillEntry { name: string; description: string; [k: string]: unknown }
+
+function isValidSkill(s: unknown): s is SkillEntry {
+  return !!s && typeof s === 'object'
+    && typeof (s as Record<string, unknown>).name === 'string'
+    && typeof (s as Record<string, unknown>).description === 'string'
+}
+
+function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolean } {
+  const manifestPath = process.env[SKILL_MANIFEST_ENV]
+  if (!manifestPath) return { skills: [], registryConfigured: false }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+  } catch (e) {
+    // env 已设却读不到/解析失败 — 大概率 misconfig：行为 degrade，日志响亮。
+    console.warn(`[milkie] skill_list: failed to read ${SKILL_MANIFEST_ENV}=${manifestPath}: ${(e as Error).message}`)
+    return { skills: [], registryConfigured: false }
+  }
+
+  const raw = (parsed as { skills?: unknown }).skills
+  const entries = Array.isArray(raw) ? raw : []
+  const skills: SkillEntry[] = []
+  for (const s of entries) {
+    if (isValidSkill(s)) skills.push(s)               // 原样透传，含 dir/version 等附加字段
+    else console.warn(`[milkie] skill_list: skipping malformed skill entry (missing name/description): ${JSON.stringify(s)}`)
+  }
+  return { skills, registryConfigured: true }
+}
+
 export const systemTools: ToolDefinition[] = [
   {
     name:        'skill_list',
     description: 'List all available skills with their names and brief descriptions.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     handler: async (_input, _ctx) => {
-      // v1 stub — no remote registry
-      return { skills: [] }
+      return loadSkillManifest()
     },
   },
 


### PR DESCRIPTION
## 范围

**仅交付 #139 的提议1（读数据源版本）。** 提议2（system 工具 override 契约 + subAgent 顺序固定 + 测试）单独排期，故本 PR **不 Closes #139**。

Part of #139

## 改动

`skill_list` 默认 handler 从「会误导 LLM 的成功空 stub」`{skills:[]}` 改为**读宿主经 `MILKIE_SKILL_MANIFEST` 注入的本地 manifest → 返回真实完整技能列表**。

- **最小契约 + 开放透传**：milkie 只消费 `name`/`description`，宿主附加字段（`dir`/`version`/…）原样透传、不投影、不解释。
- **错误策略「行为软、日志硬」**：
  | 情况 | 行为 | 可观测性 |
  |---|---|---|
  | env 未设 | `{skills:[], registryConfigured:false}` | 安静 |
  | env 已设、文件缺失 / JSON 损坏 | 同样 degrade（不抛给 LLM） | `console.warn` |
  | 单条目缺 `name`/`description` | 跳过该条，其余正常返回 | `console.warn` |

## 为什么独立可交付

「成功空返回」比「工具不存在」更有害——会让 agent 判定「我确实没技能」、转而照 system prompt prose 手抄并漏条目（实测 alfred 漏掉 `twitter-watch`）。本改动跨进程也成立（**传数据非闭包**），独立修好该症状，**与 #87 无关**。

这是 **thin v1 bridge**，非 §6 / s-010 完整 Skill Registry：只读宿主配好的 manifest 路径，不碰发现规则；未来 registry 落地时纳入或替换。

## 测试

`src/__tests__/skillListManifest.test.ts` 5 用例 TDD（env 未设 / 有效透传 / 文件缺失 / JSON 损坏 / 单条 malformed），全绿。curated 单测 gate 49/49 ✓，AgentRuntime 22/22 ✓，src `tsc --noEmit` 干净 ✓。

> 注：s-010 e2e 有一处 TS strict-null 报错，经核实为 main 既有、与本改动无关。

## 配套

alfred 侧做 producer（spawn 时 `discover_skills` 写 `MILKIE_SKILL_MANIFEST` 指向的 manifest，与 prompt 技能段同源），并行进行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
