### PR TITLE
fix(#139): skill_list 顶层结构容错 + 工具覆盖顺序回归测试

### DIFF
--- a/src/__tests__/skillListManifest.test.ts
+++ b/src/__tests__/skillListManifest.test.ts
@@ -78,6 +78,43 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     expect(warnSpy).toHaveBeenCalled()
   })
 
+  it('合法 JSON 但顶层为 null → 不抛、degrade false + WARNING（契约点2：绝不抛给 LLM）', async () => {
+    const p = writeManifest('null.json', 'null')
+    process.env[ENV_KEY] = p
+    // 关键：handler 必须 resolve（不能 reject/throw），否则会成为 tool-call error 丢给 turn loop
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('合法 JSON 但缺 skills 键（{}）→ degrade false + WARNING（不静默 true 空表，避免重新引入误导性空）', async () => {
+    const p = writeManifest('noskills.json', JSON.stringify({}))
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('skills 非数组（{"skills":"x"}）→ degrade false + WARNING', async () => {
+    const p = writeManifest('nonarray.json', JSON.stringify({ skills: 'x' }))
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('合法空数组（{"skills":[]}）→ registryConfigured:true，宿主显式声明零技能，不 WARNING', async () => {
+    const p = writeManifest('empty.json', JSON.stringify({ skills: [] }))
+    process.env[ENV_KEY] = p
+    const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
+    expect(out.skills).toEqual([])
+    expect(out.registryConfigured).toBe(true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
   it('单条目 malformed（缺 name/description）→ 跳过该条 + WARNING，其余正常返回', async () => {
     const p = writeManifest('partial.json', JSON.stringify({
       skills: [

--- a/src/__tests__/toolOverrideContract.test.ts
+++ b/src/__tests__/toolOverrideContract.test.ts
@@ -1,0 +1,76 @@
+import { AgentRuntime } from '../runtime/AgentRuntime'
+import { DefaultIOPort } from '../runtime/IOPort'
+import { MemoryStore } from '../store/MemoryStore'
+import { InMemoryRecorder } from '../trajectory/InMemoryRecorder'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { ToolDefinition } from '../types/tool'
+
+// #139 提议2（最小版）：把工具注册顺序的覆盖语义钉成回归测试。
+//
+// AgentRuntime.registerTools 的顺序是 systemTools → cognitive → lineage → extraTools
+// → subAgents，配合 ToolRegistry 的 Map last-wins。这两条特性决定了：
+//   1. 宿主 extraTools 可覆盖同名 system 工具（这是进程内 host 替换 skill_list 的口子）。
+//   2. subAgent 在 extraTools 之后注册 → 同名时 subAgent 反覆盖 extraTool（footgun）。
+//
+// 它们目前是隐式行为、无测试保障。这里不写文档契约那套仪式，只用一条 characterization
+// 测试锁住现状：日后若有人重构 registerTools 改了顺序，本测试会立刻 surface。
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    agentId:      'override-test',
+    version:      '1.0.0',
+    systemPrompt: 'test',
+    fsm:          { states: [{ name: 'react', type: 'llm' }] },   // 无 tools 限制 → 暴露全部已注册工具
+    model:        { provider: 'test', model: 'test-model', adapter: 'test' },
+    ...overrides,
+  }
+}
+
+function fakeTool(name: string, description: string): ToolDefinition {
+  return { name, description, inputSchema: { type: 'object', properties: {}, required: [] }, handler: async () => ({}) }
+}
+
+// 捕获暴露给模型的工具 schema（name/description 来自实际注册的 winner），随即终止本轮。
+class CapturingGateway implements IModelGateway {
+  public lastTools: Array<{ name: string; description: string }> = []
+  async complete(req: ModelRequest): Promise<ModelResponse> {
+    this.lastTools = (req.tools ?? []).map(t => ({ name: t.name, description: t.description }))
+    return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+  }
+  async *stream(): AsyncIterable<never> { yield* [] }
+}
+
+function runWith(opts: { config?: AgentConfig; extraTools?: ToolDefinition[] }): Promise<CapturingGateway> {
+  const gw = new CapturingGateway()
+  const runtime = new AgentRuntime({
+    config:     opts.config ?? makeConfig(),
+    goal:       'g',
+    input:      'i',
+    stateStore: new MemoryStore(),
+    recorder:   new InMemoryRecorder(undefined, 'override-test'),
+    ioPort:     new DefaultIOPort(gw),
+    ...(opts.extraTools ? { extraTools: opts.extraTools } : {}),
+  })
+  return runtime.run('i').then(() => gw)
+}
+
+describe('tool 注册覆盖契约 (#139 提议2)', () => {
+  it('extraTools 覆盖同名 system 工具（last-wins）— skill_list 可被宿主替换', async () => {
+    const gw = await runWith({ extraTools: [fakeTool('skill_list', 'OVERRIDDEN_SKILL_LIST')] })
+    const sl = gw.lastTools.find(t => t.name === 'skill_list')
+    expect(sl).toBeDefined()
+    expect(sl!.description).toBe('OVERRIDDEN_SKILL_LIST')   // 默认 system stub 被 extraTool 覆盖
+  })
+
+  it('subAgent 在 extraTools 之后注册 → 同名 extraTool 被 subAgent 反覆盖（已知 footgun，锁住现状）', async () => {
+    const gw = await runWith({
+      config:     makeConfig({ subAgents: { worker: '1.0.0' } }),
+      extraTools: [fakeTool('worker', 'OVERRIDDEN_WORKER')],
+    })
+    const w = gw.lastTools.find(t => t.name === 'worker')
+    expect(w).toBeDefined()
+    // subAgent 后注册 → 它赢；若哪天改成 extraTool 赢，这条会失败、强制重新审视顺序契约。
+    expect(w!.description).toBe('Invoke the worker sub-agent.')
+  })
+})

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -35,10 +35,19 @@ function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolea
     return { skills: [], registryConfigured: false }
   }
 
-  const raw = (parsed as { skills?: unknown }).skills
-  const entries = Array.isArray(raw) ? raw : []
+  // 顶层结构访问必须容错：JSON.parse('null') 返回 null、文件可能是数组/标量。
+  // 任何取不出合法 skills 数组的情况都 degrade 成 registryConfigured:false（而非
+  // true+空表）—— 后者会让 LLM 读成「registry 说我零技能」，正是 #139 要消灭的误导性空。
+  const skillsRaw = (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+    ? (parsed as { skills?: unknown }).skills
+    : undefined
+  if (!Array.isArray(skillsRaw)) {
+    console.warn(`[milkie] skill_list: ${SKILL_MANIFEST_ENV}=${manifestPath} parsed but has no valid 'skills' array; treating as unconfigured`)
+    return { skills: [], registryConfigured: false }
+  }
+
   const skills: SkillEntry[] = []
-  for (const s of entries) {
+  for (const s of skillsRaw) {
     if (isValidSkill(s)) skills.push(s)               // 原样透传，含 dir/version 等附加字段
     else console.warn(`[milkie] skill_list: skipping malformed skill entry (missing name/description): ${JSON.stringify(s)}`)
   }


### PR DESCRIPTION
跟进 PR #142（提议1）的 review 发现 + 落提议2 最小版回归测试。Closes #139。

## 修复

### Finding 1（真实）：null 顶层 manifest 违反「绝不抛」契约
`JSON.parse('null')` 返回 `null`，原代码 `(parsed as {skills?}).skills` 在 try **之外** → `null.skills` 抛 `TypeError` 未捕获 → 成为 tool-call error 丢进 turn loop，正是契约点2「行为软、绝不抛给 LLM」要避免的。可达性低（alfred 永远写 `{skills:[...]}`），但是对已明确约定的真实偏离，且原测试未覆盖。

### Finding 2：合法 JSON 但 skills 缺失/非数组 → 重新引入误导性空
原先 `{}` / `{"skills":"x"}` 静默返回 `{skills:[], registryConfigured:true}`，会让 LLM 读成「registry 说我零技能」——正是 #139 要消灭的误导性空。

**统一修复**：任何取不出合法 `skills` 数组的情况（null / 非对象 / 顶层数组 / skills 缺失或非数组）→ degrade `registryConfigured:false` + WARNING；**仅**合法空数组 `{"skills":[]}`（宿主显式声明零技能）保留 `true`。

## 提议2（最小版）

`src/__tests__/toolOverrideContract.test.ts` 用 characterization 测试锁住 `registerTools` 覆盖顺序：

- extraTools 覆盖同名 system 工具（last-wins）—— 进程内 host 替换 `skill_list` 的口子；
- subAgent 在 extraTools **之后**注册 → 同名时反覆盖 extraTool（**已知 footgun**，锁住现状，日后重构改顺序会立刻 surface）。

不写文档契约那套仪式（无当前消费者），只防重构悄悄改坏。

## 测试

- `skillListManifest`：9 用例（新增 null / 缺键 / 非数组 / 合法空数组 4 例）
- `toolOverrideContract`：2 用例
- 全绿；curated 单测 49/49；`tsc` build 干净。

## ⚠️ 部署提醒（非本 PR 代码）

`milkie serve` 跑的是 `dist/`（`tsc` 产物，gitignored）。**合并后需在 serve 宿主重建 dist + 重启**，否则运行中的 serve 仍是旧空 stub —— 这是 #142 提议1 真正在 alfred 生效（修 `twitter-watch` 漏列）的前提，与本 PR 一并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)