### PR TITLE
feat(#144): trace 命令支持 --data-dir(与 serve --data-dir 对称)

### DIFF
--- a/src/__tests__/CliTrace.test.ts
+++ b/src/__tests__/CliTrace.test.ts
@@ -93,6 +93,34 @@ sys`
     }
   })
 
+  it('trace replay --data-dir <dir> replays from <dir>/runs/ (alfred sidecar layout, no .milkie)', async () => {
+    // alfred sidecar layout: runs + agents.json sit directly under the data-dir,
+    // not under a .milkie/. --data-dir points replay at that root.
+    writeAgentMd('router.md', 'router')
+    fs.writeFileSync(
+      path.join(tmpDir, 'agents.json'),
+      JSON.stringify({ agents: [{ id: 'router', file: 'agents/router.md' }] }),
+    )
+
+    const gateway = new SequentialGateway([text('hello')])
+    const eventStore = new JsonlEventStore(path.join(tmpDir, 'runs'))
+    const recordMilkie = new Milkie({ stateStore: new MemoryStore(), gateway, eventStore })
+    recordMilkie.loadAgentFile(path.join(tmpDir, 'agents', 'router.md'))
+    const original = await recordMilkie.invoke({ agentId: 'router', goal: 'g', input: 'i' })
+    expect(original.status).toBe('completed')
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(os.tmpdir())
+    try {
+      const result = await main(['trace', 'replay', '--data-dir', tmpDir, original.agentRunId])
+      expect(result.exitCode).toBe(0)
+      const out = JSON.parse(result.stdout.trim()) as { status: string; newRunId: string }
+      expect(out.status).toBe('completed')
+      expect(out.newRunId).toBe(original.agentRunId)
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
+
   it('inspect outputs JSONL of every event in the run', async () => {
     const runId = 'demo-run-1'
     const events = [

--- a/src/__tests__/CliTraceExecution.test.ts
+++ b/src/__tests__/CliTraceExecution.test.ts
@@ -46,4 +46,32 @@ describe('CLI: trace execution', () => {
       cwdSpy.mockRestore()
     }
   })
+
+  it('trace execution --data-dir <dir> projects from <dir>/runs/ (alfred sidecar layout)', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'runs'), { recursive: true })
+    const runId = 'exec-dd-run'
+    const events = [
+      { id: 's', runId, type: 'agent.run.started', actor: 'runtime', timestamp: 1,
+        payload: { agentId: 'echo', goal: 'g', input: 'i', contextId: runId } },
+      { id: 'q', runId, type: 'llm.requested', actor: 'echo', timestamp: 3,
+        payload: { request: { model: 'm', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }, requestHash: 'h1' } },
+      { id: 'a', runId, type: 'llm.responded', actor: 'echo', timestamp: 4, causedBy: 'q',
+        payload: { response: { content: [{ type: 'text', text: 'hi' }], toolCalls: [], finishReason: 'end_turn' }, requestHash: 'h1' } },
+      { id: 'c', runId, type: 'agent.run.completed', actor: 'runtime', timestamp: 9,
+        payload: { status: 'completed', lastTextOutput: 'hi' } },
+    ]
+    fs.writeFileSync(
+      path.join(tmpDir, 'runs', `${runId}.jsonl`),
+      events.map(e => JSON.stringify(e)).join('\n') + '\n',
+    )
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(os.tmpdir())
+    try {
+      const result = await main(['trace', 'execution', '--data-dir', tmpDir, runId])
+      expect(result.exitCode).toBe(0)
+      const proj = JSON.parse(result.stdout) as { steps: Array<{ kind: string }> }
+      expect(proj.steps.some(s => s.kind === 'llm')).toBe(true)
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
 })

--- a/src/__tests__/CliTraceReport.test.ts
+++ b/src/__tests__/CliTraceReport.test.ts
@@ -67,6 +67,54 @@ describe('CLI: trace render-html', () => {
     }
   })
 
+  it('trace report --data-dir <dir> reads <dir>/runs/ directly (alfred sidecar layout, no .milkie, cwd-independent)', async () => {
+    // alfred's sidecar persists to `<data-dir>/runs/` (serve --data-dir), NOT under
+    // a `.milkie/`. --data-dir lets trace read that layout without findMilkieDir.
+    fs.mkdirSync(path.join(tmpDir, 'runs'), { recursive: true })
+    const runId = 'sidecar-run'
+    const events = [
+      { id: 's', runId, type: 'agent.run.started', actor: 'runtime', timestamp: 1,
+        payload: { agentId: 'echo', goal: 'g', input: 'i', contextId: runId } },
+      { id: 'c', runId, type: 'agent.run.completed', actor: 'runtime', timestamp: 9,
+        payload: { status: 'completed', lastTextOutput: 'hi' } },
+    ]
+    fs.writeFileSync(
+      path.join(tmpDir, 'runs', `${runId}.jsonl`),
+      events.map(e => JSON.stringify(e)).join('\n') + '\n',
+    )
+
+    // No .milkie/ anywhere; cwd points somewhere irrelevant (os.tmpdir, not tmpDir).
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(os.tmpdir())
+    try {
+      const result = await main(['trace', 'report', '--data-dir', tmpDir, runId])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.startsWith('<!doctype html>')).toBe(true)
+      expect(result.stdout).toContain(runId)
+      expect(result.stdout).toContain('echo')
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
+
+  it('trace inspect --data-dir <dir> emits the run events from <dir>/runs/', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'runs'), { recursive: true })
+    const runId = 'insp-run'
+    fs.writeFileSync(
+      path.join(tmpDir, 'runs', `${runId}.jsonl`),
+      JSON.stringify({ id: 's', runId, type: 'agent.run.started', actor: 'runtime', timestamp: 1,
+        payload: { agentId: 'echo', goal: 'g', input: 'i', contextId: runId } }) + '\n',
+    )
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(os.tmpdir())
+    try {
+      const result = await main(['trace', 'inspect', '--data-dir', tmpDir, runId])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('agent.run.started')
+      expect(result.stdout).toContain(runId)
+    } finally {
+      cwdSpy.mockRestore()
+    }
+  })
+
   it('trace report includes descendant sub-agent runs in one HTML', async () => {
     fs.mkdirSync(path.join(tmpDir, '.milkie', 'runs'), { recursive: true })
     const parent = 'parent-run'

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -22,6 +22,21 @@ function findMilkieDir(startDir: string): string | undefined {
 }
 
 /**
+ * #144: resolve the trace root holding `runs/` (and `objects/`). An explicit
+ * `--data-dir` — the same directory passed to `serve --data-dir`, where the
+ * sidecar persisted `<dir>/runs/<runId>.jsonl` — takes precedence and bypasses
+ * findMilkieDir (alfred's data-dir is not named `.milkie/`). Otherwise discover
+ * the nearest `.milkie/` upward from cwd, preserving the original CLI behavior.
+ */
+function resolveTraceDir(dataDir: string | undefined): string {
+  const dir = dataDir ? path.resolve(dataDir) : findMilkieDir(process.cwd())
+  if (!dir) {
+    throw new Error('no .milkie/ directory found upward from cwd (or pass --data-dir)')
+  }
+  return dir
+}
+
+/**
  * Build a Milkie instance with CLI defaults: persistent SQLite stateStore
  * (interrupt / resume survive across CLI processes), JsonlEventStore on
  * `.milkie/runs/`, and manifest auto-loaded.
@@ -146,11 +161,9 @@ export async function main(argv: string[]): Promise<MainResult> {
     .command('inspect <runId>')
     .description('Print every event in a recorded run as JSONL')
     .option('--include-children', 'also emit events from descendant sub-agent runs')
-    .action(async (runId: string, opts: { includeChildren?: boolean }) => {
-      const milkieDir = findMilkieDir(process.cwd())
-      if (!milkieDir) {
-        throw new Error('no .milkie/ directory found upward from cwd')
-      }
+    .option('--data-dir <path>', 'read trace from <path>/runs (e.g. a serve --data-dir); else find .milkie/ upward from cwd')
+    .action(async (runId: string, opts: { includeChildren?: boolean; dataDir?: string }) => {
+      const milkieDir = resolveTraceDir(opts.dataDir)
       const runsDir = path.join(milkieDir, 'runs')
       const eventStore = new JsonlEventStore(runsDir)
 
@@ -182,11 +195,9 @@ export async function main(argv: string[]): Promise<MainResult> {
   trace
     .command('report <runId>')
     .description('Render <runId> (and any descendant sub-agent runs) as a self-contained HTML report to stdout')
-    .action(async (runId: string) => {
-      const milkieDir = findMilkieDir(process.cwd())
-      if (!milkieDir) {
-        throw new Error('no .milkie/ directory found upward from cwd')
-      }
+    .option('--data-dir <path>', 'read trace from <path>/runs (e.g. a serve --data-dir); else find .milkie/ upward from cwd')
+    .action(async (runId: string, opts: { dataDir?: string }) => {
+      const milkieDir = resolveTraceDir(opts.dataDir)
       const runsDir = path.join(milkieDir, 'runs')
       const eventStore = new JsonlEventStore(runsDir)
       const { findDescendantRuns } = await import('../trace/render/children.js')
@@ -209,11 +220,9 @@ export async function main(argv: string[]): Promise<MainResult> {
   trace
     .command('execution <runId>')
     .description('Project <runId> into execution-timeline JSON (steps with cache health + region composition) to stdout')
-    .action(async (runId: string) => {
-      const milkieDir = findMilkieDir(process.cwd())
-      if (!milkieDir) {
-        throw new Error('no .milkie/ directory found upward from cwd')
-      }
+    .option('--data-dir <path>', 'read trace from <path>/runs (e.g. a serve --data-dir); else find .milkie/ upward from cwd')
+    .action(async (runId: string, opts: { dataDir?: string }) => {
+      const milkieDir = resolveTraceDir(opts.dataDir)
       const runsDir = path.join(milkieDir, 'runs')
       const eventStore = new JsonlEventStore(runsDir)
       const { buildExecutionProjection } = await import('../trace/diagnostics/buildExecutionProjection.js')
@@ -232,12 +241,10 @@ export async function main(argv: string[]): Promise<MainResult> {
 
   trace
     .command('replay <runId>')
-    .description('Replay a recorded run from .milkie/runs/<runId>.jsonl')
-    .action(async (runId: string) => {
-      const milkieDir = findMilkieDir(process.cwd())
-      if (!milkieDir) {
-        throw new Error('no .milkie/ directory found upward from cwd')
-      }
+    .description('Replay a recorded run from <data-dir or .milkie>/runs/<runId>.jsonl')
+    .option('--data-dir <path>', 'read trace from <path>/runs (e.g. a serve --data-dir); else find .milkie/ upward from cwd')
+    .action(async (runId: string, opts: { dataDir?: string }) => {
+      const milkieDir = resolveTraceDir(opts.dataDir)
       const eventStore = new JsonlEventStore(path.join(milkieDir, 'runs'))
       const traceObjectStore = new FileTraceObjectStore(path.join(milkieDir, 'objects'))
       // ephemeral: replay is deterministic from the event log, no persistent state needed.


### PR DESCRIPTION
## 目的

让 `milkie trace report/inspect/execution/replay` 能读外部(alfred,xforce-io/alfred#47)sidecar 的落盘 trace。`serve --data-dir <D>` 把事件写到 `<D>/runs/`,但 trace 读类命令此前只靠 `findMilkieDir(cwd)` 找 `.milkie/` 目录;alfred 的 data-dir 不叫 `.milkie`,于是读不到。

## 改动(`src/cli/main.ts`)

- 新增共享 `resolveTraceDir(dataDir)`:给了 `--data-dir <D>` → 以 `<D>` 为 trace 根(`<D>/runs`、`<D>/objects`),**绕过** findMilkieDir;否则维持 `findMilkieDir(cwd)` 原行为。
- `inspect` / `report` / `execution` / `replay` 四个读命令均加 `--data-dir <path>` 选项。
- 与 `serve --data-dir` 对称:alfred 把给 serve 的同一个 data-dir 传给 trace 即可,零额外耦合。

## 测试(TDD)

- 四条新测试:report / inspect / execution / replay 各一条 `--data-dir`,数据直挂 `<dir>/runs/`、**无 `.milkie/`**、cwd 指向无关目录。
- stash 生产改动验证 4 条 RED→GREEN(无 main.ts 改动 4 failed,有则 4 passed)。
- `findMilkieDir` 原行为回归不变;`tsc --noEmit` + CLI trace 18 + 单元 49 全过。

## 验收(#144)

1. ✅ `report --data-dir <D> <runId>` 在 `<D>/runs/` 存在、无 `.milkie/`、cwd 任意时成功渲染。
2. ✅ inspect / execution / replay 同样支持 `--data-dir`。
3. ✅ 不传 `--data-dir` 维持 findMilkieDir 原行为。

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)