### PR TITLE
feat(#148): run_command 为 stdout lazy-register 可 cite 对象 —— 所有 shell skill 取数可溯源

### DIFF
--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -854,3 +854,46 @@ describe('#83 session-context variables', () => {
     expect(req.system ?? '').not.toContain('workspace_instructions')
   })
 })
+
+// #148 e2e:agent 经 run_command 取证 → 该 stdout 铸的 shell:stdout 对象可被 cite
+// resolve(端到端:run_command 铸对象 → resolveObject → cite 记 cites 关系)。
+describe('#148 run_command output is citable end-to-end', () => {
+  class CiteRunCommandGateway implements IModelGateway {
+    private cited = false
+    async complete(req: ModelRequest): Promise<ModelResponse> {
+      const blob = JSON.stringify(req)
+      const m = blob.match(/(obj:sha256:[0-9a-f]+)/)  // run_command 铸的 objectId(tool_result 内被转义,直接配值)
+      if (!m) return toolCallResponse('tc-run', 'run_command', { command: 'echo EVIDENCE-148' })
+      if (!this.cited) {
+        this.cited = true
+        return toolCallResponse('tc-cite', 'cite', { claim: 'evidence is 148', objectId: m[1] })
+      }
+      return textResponse('done')
+    }
+    async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+  }
+
+  it('run_command stdout objectId resolves through cite → records a cites relation', async () => {
+    const stateStore = new MemoryStore()
+    const eventStore = new MemoryEventStore()
+    const milkie = new Milkie({
+      stateStore,
+      eventStore,
+      traceObjectStore: new MemoryTraceObjectStore(),
+      gateway: new CiteRunCommandGateway(),
+    })
+    milkie.registerAgent(makeConfig({ fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 5 }] } }))
+
+    const result = await milkie.invoke({
+      agentId: 'test-agent', goal: 'verify', input: 'cite the fetched evidence', contextId: 'ctx-cite-148',
+    })
+    const events = await eventStore.readByRunId(result.agentRunId)
+
+    // cite 成功 = 记录了一条 cites 关系(说明 run_command 铸的 objectId 被 resolve)
+    const rels = events.filter(e => e.type === 'relation.created').map(e => e.payload as { type?: string })
+    expect(rels.some(p => p.type === 'cites')).toBe(true)
+    // 且确有 shell:stdout 对象被 promote(object.created)
+    const objs = events.filter(e => e.type === 'object.created').map(e => e.payload as { type?: string })
+    expect(objs.some(p => p.type === 'shell:stdout')).toBe(true)
+  })
+})

--- a/src/__tests__/execTools.test.ts
+++ b/src/__tests__/execTools.test.ts
@@ -71,6 +71,33 @@ describe('built-in run_command tool (#134)', () => {
     expect(out.stdout).toContain('chars dropped')
   })
 
+  // #148: lazy-register stdout as a citable object so any shell-fetched evidence
+  // (file/network/db) can be cited via the framework `cite` tool.
+  it('lazy-registers a shell:stdout object for non-empty stdout and surfaces objectId first', async () => {
+    const registered: Array<{ type: string; meta?: Record<string, unknown> }> = []
+    const created: unknown[] = []
+    const ctx = {
+      registerObject: (spec: { type: string; meta?: Record<string, unknown> }) => { registered.push(spec); return { objectId: `obj:reg:${registered.length}` } },
+      createObject:   (spec: unknown) => { created.push(spec); return { objectId: 'obj:eager' } },
+    } as unknown as ToolContext
+    const out = (await runCmd.handler({ command: 'echo evidence-xyz' }, ctx)) as RunCommandOutput & { objectId?: string }
+    expect(out.objectId).toBe('obj:reg:1')
+    expect(registered).toHaveLength(1)
+    expect(registered[0]!.type).toBe('shell:stdout')
+    expect(created).toHaveLength(0) // lazy: registerObject, not eager createObject
+    expect(out.stdout).toContain('evidence-xyz')
+  })
+
+  it('does not register an object when stdout is empty (e.g. stderr-only)', async () => {
+    const registered: unknown[] = []
+    const ctx = {
+      registerObject: (spec: unknown) => { registered.push(spec); return { objectId: 'obj:x' } },
+    } as unknown as ToolContext
+    const out = (await runCmd.handler({ command: 'echo oops 1>&2' }, ctx)) as RunCommandOutput & { objectId?: string }
+    expect(registered).toHaveLength(0)
+    expect(out.objectId).toBeUndefined()
+  })
+
   it('handler is invokable as a ToolDefinition (ctx not required)', async () => {
     const out = (await runCmd.handler({ command: 'echo viahandler' }, {} as ToolContext)) as RunCommandOutput
     expect(out.stdout).toContain('viahandler')

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -81,9 +81,12 @@ export const execTools: ToolDefinition[] = [
   {
     name:        'run_command',
     description:
-      'Execute a shell command in a subprocess and return { stdout, stderr, exitCode, timedOut, truncated }. ' +
+      'Execute a shell command in a subprocess and return { objectId?, stdout, stderr, exitCode, timedOut, truncated }. ' +
       'Use this to run skill scripts (e.g. `python skills/<name>/scripts/x.py`), CLIs (`inv`, `codex-cli`), ' +
-      'and other tools. Output over 30000 chars per stream is truncated (head+tail kept).',
+      'and other tools. Output over 30000 chars per stream is truncated (head+tail kept). ' +
+      'When stdout is non-empty the result carries an `objectId` for that output — to source a claim from this ' +
+      'fetched data (a file you cat-ed, an API/DB you queried, a page you scraped), pass that objectId to the ' +
+      'cite tool. Never write provenance like "(source:...)" in prose; cite the objectId instead.',
     inputSchema: {
       type:       'object',
       properties: {
@@ -93,6 +96,23 @@ export const execTools: ToolDefinition[] = [
       },
       required:   ['command'],
     },
-    handler: async (input) => runCommand(input as RunCommandInput),
+    handler: async (input, ctx) => {
+      const out = await runCommand(input as RunCommandInput)
+      // #148: lazy-register non-empty stdout as a citable object (like grep) so any
+      // shell-fetched evidence (file / network / db) can be sourced via the `cite`
+      // tool — no per-skill refactoring. registerObject is lazy (no event); the
+      // object is promoted only when the agent actually cites it, so routine
+      // commands (ls/mkdir) never flood the lineage graph. objectId is placed
+      // FIRST so it survives the result-truncation strategy — the agent must see
+      // it to cite. Stdout is a genuine tool-call record (origin invariant holds).
+      if (ctx?.registerObject && out.stdout) {
+        const { objectId } = ctx.registerObject({
+          type: 'shell:stdout',
+          meta: { command: (input as RunCommandInput).command, exitCode: out.exitCode },
+        })
+        return { objectId, ...out }
+      }
+      return out
+    },
   },
 ]


### PR DESCRIPTION
Closes #148

## 背景
alfred 的 skill 全经 `run_command` 取数(文件/网络/DB/抓取),但 run_command 不铸对象,而 `cite` 要求 objectId 来自数据工具 → agent 无法 cite 任何 shell 取来的证据。驱动:xforce-io/alfred#62。

## 改动
- `run_command` handler 接 `ctx`,对**非空 stdout** `ctx.registerObject({type:'shell:stdout', meta:{command, exitCode}})`(lazy,像 grep,不发事件;被 cite 时才 promote)。objectId 置前抗 truncate。
- 工具描述点明:非空 stdout 带 objectId、可传给 `cite`。

## 为什么这样
- **泛化**:任何 shell 取数一次性可 cite,零 per-skill 改造(回应 alfred#62 '难道每个 skill/工具都改造')。
- **合规**:stdout 是真实 tool-call record(符合 'origin is a tool-call record')。
- **不 flood**:lazy register,仅被 cite 者 promote(ls/mkdir 不污染)。
- 粒度:粗(claim→整次输出);细粒度 per-record 由 native 数据工具(read_file/grep)另行增强。

## 测试
- 单元:run_command 非空 stdout lazy-register 并置前 objectId;空 stdout 不铸。
- **确定性 e2e**(真 Milkie runtime):agent run_command 取证 → cite 该 shell:stdout 对象 → resolve 成功、记 cites 关系 + object.created。
- 回归:execTools/replay/lineage/toolResultStrategy/AgentRuntime 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)