### PR TITLE
feat(#150): shell:stdout 对象补内容哈希 —— objectId 内容绑定，消除同命令重复执行撞 ID

### DIFF
--- a/src/__tests__/execTools.test.ts
+++ b/src/__tests__/execTools.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execTools, runCommand, type RunCommandOutput } from '../tools/exec'
+import { sha256Hex } from '../trace/hash'
 import type { ToolContext } from '../types/tool'
 
 const runCmd = execTools.find(t => t.name === 'run_command')!
@@ -86,6 +87,50 @@ describe('built-in run_command tool (#134)', () => {
     expect(registered[0]!.type).toBe('shell:stdout')
     expect(created).toHaveLength(0) // lazy: registerObject, not eager createObject
     expect(out.stdout).toContain('evidence-xyz')
+  })
+
+  // #150: the registered spec must carry a content hash of the (capped) stdout so the
+  // objectId is content-bound — same command re-run with different output must not
+  // collide on the same objectId, and the object is byte-bound to the trace record.
+  it('registers shell:stdout with a content hash of the capped stdout', async () => {
+    const registered: Array<{ type: string; hash?: string; meta?: Record<string, unknown> }> = []
+    const ctx = {
+      registerObject: (spec: { type: string; hash?: string; meta?: Record<string, unknown> }) => { registered.push(spec); return { objectId: 'obj:x' } },
+    } as unknown as ToolContext
+    const out = (await runCmd.handler({ command: 'echo hash-me' }, ctx)) as RunCommandOutput
+    expect(registered).toHaveLength(1)
+    expect(registered[0]!.hash).toBe(sha256Hex(out.stdout))
+  })
+
+  it('same command, different stdout → different content hash (no objectId collision)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'milkie-exec-'))
+    try {
+      const registered: Array<{ hash?: string }> = []
+      const ctx = {
+        registerObject: (spec: { hash?: string }) => { registered.push(spec); return { objectId: 'obj:x' } },
+      } as unknown as ToolContext
+      await writeFile(join(dir, 'data.txt'), 'first fetch')
+      await runCmd.handler({ command: 'cat data.txt', cwd: dir }, ctx)
+      await writeFile(join(dir, 'data.txt'), 'second fetch — content changed')
+      await runCmd.handler({ command: 'cat data.txt', cwd: dir }, ctx)
+      expect(registered).toHaveLength(2)
+      expect(registered[0]!.hash).toBeTruthy()
+      expect(registered[0]!.hash).not.toBe(registered[1]!.hash)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('hashes the capped stdout (matches the trace record bytes, not the raw stream)', async () => {
+    const registered: Array<{ hash?: string }> = []
+    const ctx = {
+      registerObject: (spec: { hash?: string }) => { registered.push(spec); return { objectId: 'obj:x' } },
+    } as unknown as ToolContext
+    const out = (await runCmd.handler({
+      command: `${NODE} -e "process.stdout.write('A'.repeat(50)+'B'.repeat(100000)+'Z'.repeat(50))"`,
+    }, ctx)) as RunCommandOutput
+    expect(out.truncated).toBe(true)
+    expect(registered[0]!.hash).toBe(sha256Hex(out.stdout)) // out.stdout is the capped text
   })
 
   it('does not register an object when stdout is empty (e.g. stderr-only)', async () => {

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { sha256Hex } from '../trace/hash.js'
 import type { ToolDefinition } from '../types/tool.js'
 
 // Built-in shell/exec tool (#134). Lets an agent run subprocess commands —
@@ -106,8 +107,12 @@ export const execTools: ToolDefinition[] = [
       // FIRST so it survives the result-truncation strategy — the agent must see
       // it to cite. Stdout is a genuine tool-call record (origin invariant holds).
       if (ctx?.registerObject && out.stdout) {
+        // #150: hash the capped stdout (what the trace's tool.responded record holds)
+        // so the objectId is content-bound — same command re-run with different
+        // output mints a different object instead of colliding.
         const { objectId } = ctx.registerObject({
           type: 'shell:stdout',
+          hash: sha256Hex(out.stdout),
           meta: { command: (input as RunCommandInput).command, exitCode: out.exitCode },
         })
         return { objectId, ...out }


### PR DESCRIPTION
Closes #150。

## 改动

`run_command` lazy-register `shell:stdout` 对象时补 `hash: sha256Hex(out.stdout)`（`src/tools/exec.ts`，+4 行）。`registerObject` spec 的 `hash` 字段与 objectIdFor 的 canonical bytes 早已支持，本 PR 是首个使用方，AgentRuntime 零改动。

## 要点

- **哈希 capStream 截断后的 stdout**：注册发生在 capStream 之后，`out.stdout` 即 trace `tool.responded` 落盘的字节——对象与可回查的证据记录字节级对齐。
- **replay 安全**：回放时 stdout 由 ReplayingIOPort 从 trace 回灌，字节一致 → hash 一致 → objectId 在 record/replay 中相同。
- 同命令同输出仍同 objectId——内容寻址的正确语义，非 bug。

## 测试（TDD，先红后绿）

新增 3 个用例（`execTools.test.ts`）：

1. 注册 spec 携带 `hash === sha256Hex(out.stdout)`；
2. 同命令（`cat data.txt`）两次执行、文件内容不同 → hash 不同（撞 ID 场景的直接复现）；
3. 超 30k 截断场景：hash 绑定截断后文本，非原始流。

全量回归：100 套件 / 807 通过 / 0 失败（含 #148 cite e2e）；`tsc --noEmit` 干净。

## 关联

- issue：#150（上游 #148 / PR #149；来源讨论 xforce-io/alfred#62，活体验证证据见该 issue 关闭评论）

🤖 Generated with [Claude Code](https://claude.com/claude-code)