### PR TITLE
feat(#79): 结构化服务日志（pino/NDJSON-stderr，三层可观测之 logging 层）

### DIFF
--- a/docs/design/79-service-logging.md
+++ b/docs/design/79-service-logging.md
@@ -1,0 +1,85 @@
+# #79 服务日志（service/operational logging）
+
+> Issue: https://github.com/xforce-io/milkie/issues/79
+> 状态：设计定稿（讨论记录见 issue 评论），随 feat/79-service-logging 实现。
+
+## 1. 定位：三层可观测，service log 是第三层
+
+| 层 | 实现 | 视角 | 性质 |
+|---|---|---|---|
+| event log | `src/trace/JsonlEventStore.ts` | 业务事实（llm/tool 配对事件） | 真相源，可 replay |
+| trajectory | `src/trajectory/*`（`ITrajectoryRecorder`，Span 模型） | 业务执行的因果/耗时结构 | 诊断 |
+| **service log（本期）** | `src/logging/*` | 运维：服务在怎么跑 | 遥测，可丢弃 |
+
+对齐业界三支柱：event log ≈ events、trajectory ≈ tracing、service log ≈ logging。
+**三层并存，互不吸收**，用 `runId`/`contextId` 关联互跳。
+
+**边界纪律**：service log 只在服务边界打 wide event，不进入执行内部。
+判别式：*运维值班的人要看的*进 service log；排查业务执行细节才看的留 trajectory；
+不把运维日志塞进 event log，也不用 event log 当运维日志读。
+
+## 2. 选型与形态
+
+- **pino** 作 logger 本体（运行时依赖）。不自研：这块是独立能力，会持续长大。
+- NDJSON 输出到 **stderr**。偏离 issue 原文的"stdout"是有意的：stdout 已被程序输出占用
+  ——CLI 的结果输出（`cli/index.ts`）、serve 的 `MILKIE_SERVE_READY <port>` 端口标记
+  （下游靠解析它发现端口）。日志混入会破坏下游解析。12-factor 语义不变：仍是标准流、
+  不落文件、由外部采集（本地 `2> milkie.log`）。
+- `pino-pretty` 作 devDependency：TTY（`process.stderr.isTTY`）自动启用，
+  `LOG_FORMAT=json|pretty` 强制覆盖；pretty 不可用（生产未装）时静默回退 json。
+- `LOG_LEVEL=debug|info|warn|error|silent` 控级别，默认 `info`。
+
+## 3. 接口（`src/logging/`）
+
+不在 pino 外造抽象层；只导出配置好的工厂与类型别名：
+
+```ts
+export type ServiceLogger = pino.Logger          // re-export，调用方不直接 import pino
+export function createServiceLogger(opts?: {
+  level?: string                                  // 默认 LOG_LEVEL ?? 'info'
+  format?: 'json' | 'pretty'                      // 默认 LOG_FORMAT ?? (stderr TTY ? pretty : json)
+  destination?: pino.DestinationStream            // 默认 stderr；测试注入内存 sink
+}): ServiceLogger
+export function getLogger(): ServiceLogger        // 惰性默认单例（读环境变量）
+```
+
+维度通过 pino child 注入，埋点处不手动带字段：
+
+```ts
+logger.child({ mod: 'server' })          // 模块维度：runtime/gateway/server/cli/store/tools
+logger.child({ runId, contextId })       // 请求维度：correlation id
+```
+
+## 4. 字段 schema
+
+固定：`ts`（ISO8601 UTC）、`level`（字符串标签）、`mod`、`msg`、`runId`/`contextId`（有则带）、
+`err`（pino 标准 serializer，含 `message`/`stack`）。事件附加字段平铺：
+
+- HTTP：`method` `path` `status` `ms`
+- LLM：`model` `durationMs` `inputTokens` `outputTokens`
+- invoke：`agentId` `runId` `contextId` `durationMs` `status`
+
+## 5. 埋点清单（MVP）
+
+| 位置 | 事件 | 级别 |
+|---|---|---|
+| `serveMain` / `runServeServer` | 启动（port/agentId/stateStore 种类）、关闭 | info |
+| `createServeServer` 请求分发层 | 每请求一条：method/path/status/ms（SSE 含完整流时长） | info |
+| `Milkie.invoke()` | 每次 invoke 一条汇总：agentId/runId/contextId/durationMs/status | info / error |
+| `LoggingGateway`（`GatewayFactory.createGateway` 统一包装两 adapter） | 每次 LLM 调用一条：model/durationMs/token 用量；失败带 `err` | info / error |
+| 收编零散 console.*：`tools/system.ts` manifest 三处 warn、`Milkie.resolveModel` tier 回退 | `logger.warn` | warn |
+
+埋点偏差说明：issue 原文的 `turns` 不记——`AgentResult` 未暴露 turn 数，待运行时暴露后补；
+"gateway 重试"埋点无对应物（重试只在工具层，归 trajectory），本期不做。
+
+不动的：CLI 结果输出是程序输出非日志；`trajectory/ConsoleRecorder` 属 trajectory 层。
+
+## 6. 脱敏
+
+service log **不携带 prompt/completion 正文**，只记元数据。正文在 event log，按 runId 跳转。
+`err.message` 保留原样；不主动序列化请求体。
+
+## 7. 测试策略
+
+注入内存 destination 断言 NDJSON。覆盖：级别过滤、format 选择（LOG_FORMAT/TTY/回退）、
+child 字段合并、err 序列化、LLM 成败两路、HTTP 请求行、并发 invoke 时 runId 不串线。

--- a/docs/superpowers/plans/2026-06-11-service-logging.md
+++ b/docs/superpowers/plans/2026-06-11-service-logging.md
@@ -1,0 +1,1062 @@
+# Service Logging (#79) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 milkie 增加结构化服务日志层（pino，NDJSON 到 stderr），覆盖 HTTP 请求、invoke 汇总、LLM 调用、生命周期与既有零散 console.* 的收编。
+
+**Architecture:** 新建 `src/logging/`（pino 工厂 + 类型别名 + LoggingGateway 装饰器），通过 pino child 注入 `mod`/`runId`/`contextId` 维度；埋点只落在服务边界（serve 分发层、`Milkie.invoke`、`GatewayFactory.createGateway` 包装点）。设计定稿见 `docs/design/79-service-logging.md`。
+
+**Tech Stack:** TypeScript（CJS 编译）、pino ^10、pino-pretty ^13（devDep）、jest + ts-jest。
+
+**约定:** 所有命令在 `/Users/xupeng/dev/github/milkie` 下执行，分支 `feat/79-service-logging`。每个任务 TDD：先写测试看它失败，再最小实现，再全绿提交。
+
+---
+
+### Task 1: logger 工厂（`src/logging/logger.ts`）
+
+**Files:**
+- Create: `src/logging/logger.ts`
+- Create: `src/logging/index.ts`
+- Test: `src/__tests__/logging.test.ts`
+- Modify: `package.json`（依赖）
+
+- [ ] **Step 1: 安装依赖**
+
+```bash
+npm install pino@^10.0.0 && npm install -D pino-pretty@^13.0.0
+```
+
+- [ ] **Step 2: 写失败测试**
+
+```ts
+// src/__tests__/logging.test.ts
+import { createServiceLogger, resolveFormat, getLogger, setLogger } from '../logging/logger'
+
+/** 内存 sink：每条 NDJSON 一行，parse 后断言字段。 */
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+describe('createServiceLogger', () => {
+  it('emits NDJSON with ts(ISO8601)/level-label/msg', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.info({ port: 8080 }, 'serve listening')
+    const [line] = sink.lines()
+    expect(line.msg).toBe('serve listening')
+    expect(line.level).toBe('info')                                   // 字符串标签而非数字
+    expect(line.port).toBe(8080)
+    expect(typeof line.ts).toBe('string')
+    expect(() => new Date(line.ts as string).toISOString()).not.toThrow()
+    expect(line.pid).toBeUndefined()                                  // base 字段去掉
+    expect(line.hostname).toBeUndefined()
+  })
+
+  it('filters below configured level', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'warn', format: 'json', destination: sink.stream })
+    log.info('hidden')
+    log.warn('shown')
+    expect(sink.lines().map(l => l.msg)).toEqual(['shown'])
+  })
+
+  it('level=silent emits nothing', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'silent', format: 'json', destination: sink.stream })
+    log.error('nope')
+    expect(sink.lines()).toEqual([])
+  })
+
+  it('child loggers merge mod and correlation ids', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.child({ mod: 'server' }).child({ runId: 'r1', contextId: 'c1' }).info('http request')
+    const [line] = sink.lines()
+    expect(line.mod).toBe('server')
+    expect(line.runId).toBe('r1')
+    expect(line.contextId).toBe('c1')
+  })
+
+  it('serializes err with message and stack', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.error({ err: new Error('boom') }, 'llm call failed')
+    const [line] = sink.lines()
+    const err = line.err as { message: string; stack: string }
+    expect(err.message).toBe('boom')
+    expect(err.stack).toContain('Error: boom')
+  })
+
+  it('defaults level from LOG_LEVEL env', () => {
+    const prev = process.env['LOG_LEVEL']
+    process.env['LOG_LEVEL'] = 'error'
+    try {
+      const sink = memorySink()
+      const log = createServiceLogger({ format: 'json', destination: sink.stream })
+      log.warn('hidden')
+      log.error('shown')
+      expect(sink.lines().map(l => l.msg)).toEqual(['shown'])
+    } finally {
+      if (prev === undefined) delete process.env['LOG_LEVEL']
+      else process.env['LOG_LEVEL'] = prev
+    }
+  })
+})
+
+describe('resolveFormat', () => {
+  it('LOG_FORMAT=json overrides TTY', () => expect(resolveFormat({ LOG_FORMAT: 'json' }, true)).toBe('json'))
+  it('LOG_FORMAT=pretty overrides non-TTY', () => expect(resolveFormat({ LOG_FORMAT: 'pretty' }, false)).toBe('pretty'))
+  it('defaults to pretty on TTY', () => expect(resolveFormat({}, true)).toBe('pretty'))
+  it('defaults to json off TTY', () => expect(resolveFormat({}, false)).toBe('json'))
+  it('ignores unknown LOG_FORMAT values', () => expect(resolveFormat({ LOG_FORMAT: 'xml' }, false)).toBe('json'))
+})
+
+describe('getLogger / setLogger', () => {
+  afterEach(() => setLogger(undefined))
+  it('getLogger returns a stable lazy singleton', () => {
+    expect(getLogger()).toBe(getLogger())
+  })
+  it('setLogger swaps the singleton (test injection); setLogger(undefined) resets', () => {
+    const sink = memorySink()
+    const injected = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    setLogger(injected)
+    expect(getLogger()).toBe(injected)
+    setLogger(undefined)
+    expect(getLogger()).not.toBe(injected)
+  })
+})
+```
+
+- [ ] **Step 3: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/logging.test.ts --runInBand`
+Expected: FAIL —— `Cannot find module '../logging/logger'`
+
+- [ ] **Step 4: 最小实现**
+
+```ts
+// src/logging/logger.ts
+import pino from 'pino'
+
+/**
+ * #79 服务日志（service log）：运维遥测层，与 event log（业务真相）、trajectory
+ * （span 诊断）三层并存，用 runId/contextId 关联。边界纪律、字段 schema 见
+ * docs/design/79-service-logging.md。
+ *
+ * 类型上只 re-export pino.Logger —— 不在 pino 外造抽象层，调用方不直接 import pino。
+ */
+export type ServiceLogger = pino.Logger
+
+export interface ServiceLoggerOptions {
+  level?:       string                    // 默认 LOG_LEVEL ?? 'info'
+  format?:      'json' | 'pretty'         // 默认 LOG_FORMAT ?? (stderr TTY ? pretty : json)
+  destination?: pino.DestinationStream    // 默认 stderr；测试注入内存 sink
+}
+
+/** format 决策独立成纯函数，TTY/env 分支可单测。 */
+export function resolveFormat(env: { LOG_FORMAT?: string }, isTTY: boolean): 'json' | 'pretty' {
+  if (env.LOG_FORMAT === 'pretty') return 'pretty'
+  if (env.LOG_FORMAT === 'json') return 'json'
+  return isTTY ? 'pretty' : 'json'
+}
+
+export function createServiceLogger(opts: ServiceLoggerOptions = {}): ServiceLogger {
+  const level  = opts.level ?? process.env['LOG_LEVEL'] ?? 'info'
+  const format = opts.format ?? resolveFormat(
+    { LOG_FORMAT: process.env['LOG_FORMAT'] },
+    process.stderr.isTTY === true,
+  )
+  // 日志走 stderr：stdout 已被程序输出占用（CLI 结果、MILKIE_SERVE_READY 端口标记）。
+  let destination: pino.DestinationStream | undefined = opts.destination
+  if (!destination && format === 'pretty') {
+    try {
+      // pino-pretty 是 devDependency；生产未安装时静默回退 json（即 undefined → 下方 stderr）
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pretty = require('pino-pretty') as (o: object) => pino.DestinationStream
+      destination = pretty({ destination: 2 })
+    } catch { /* fall back to json on stderr */ }
+  }
+  destination ??= pino.destination(2)
+  return pino({
+    level,
+    base: undefined,                                            // 去掉 pid/hostname
+    timestamp: () => `,"ts":"${new Date().toISOString()}"`,     // 字段名用 ts（设计 §4）
+    formatters: { level: label => ({ level: label }) },         // 字符串标签而非数字
+    serializers: { err: pino.stdSerializers.err },
+  }, destination)
+}
+
+let defaultLogger: ServiceLogger | undefined
+
+/** 惰性默认单例（读环境变量）。模块级埋点（如 tools/system.ts）从这里取。 */
+export function getLogger(): ServiceLogger {
+  defaultLogger ??= createServiceLogger()
+  return defaultLogger
+}
+
+/** 测试注入用：换掉单例；传 undefined 恢复惰性默认。 */
+export function setLogger(logger: ServiceLogger | undefined): void {
+  defaultLogger = logger
+}
+```
+
+```ts
+// src/logging/index.ts
+export { createServiceLogger, getLogger, setLogger, resolveFormat } from './logger.js'
+export type { ServiceLogger, ServiceLoggerOptions } from './logger.js'
+export { LoggingGateway } from './LoggingGateway.js'   // Task 2 落地前先注释本行
+```
+
+注意：pino 自定义 `timestamp` 输出 `ts` 字段后，pino 默认的 `time` 字段不再出现；
+若 `line.ts` 断言失败而出现 `time`，检查 timestamp 函数返回值必须以 `,` 开头。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `npx jest src/__tests__/logging.test.ts --runInBand`
+Expected: PASS（全部用例）
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add package.json package-lock.json src/logging src/__tests__/logging.test.ts
+git commit -m "feat(#79): 服务日志 logger 工厂 —— pino/NDJSON-stderr/ts-ISO 字段/级别与 format 决策"
+```
+
+---
+
+### Task 2: LoggingGateway 装饰器 + GatewayFactory 接线
+
+**Files:**
+- Create: `src/logging/LoggingGateway.ts`
+- Modify: `src/gateway/GatewayFactory.ts`
+- Test: `src/__tests__/LoggingGateway.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// src/__tests__/LoggingGateway.test.ts
+import { LoggingGateway } from '../logging/LoggingGateway'
+import { createServiceLogger } from '../logging/logger'
+import { createGateway } from '../gateway/GatewayFactory'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+const REQ: ModelRequest = { model: 'test-model', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }
+
+function okGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> {
+      return {
+        content: [{ type: 'text', text: 'ok' }], toolCalls: [],
+        usage: { inputTokens: 11, outputTokens: 7 }, finishReason: 'end_turn',
+      }
+    },
+    async *stream(): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'ok' } }
+      yield { type: 'usage', data: { inputTokens: 3, outputTokens: 5 } }
+    },
+  }
+}
+
+function failGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> { throw new Error('rate limited') },
+    // eslint-disable-next-line require-yield
+    async *stream(): AsyncIterable<ModelEvent> { throw new Error('socket reset') },
+  }
+}
+
+describe('LoggingGateway.complete', () => {
+  it('logs one info wide event with model/durationMs/tokens on success', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(okGateway(), log)
+    await gw.complete(REQ)
+    const [line] = sink.lines()
+    expect(line.msg).toBe('llm call')
+    expect(line.level).toBe('info')
+    expect(line.model).toBe('test-model')
+    expect(typeof line.durationMs).toBe('number')
+    expect(line.inputTokens).toBe(11)
+    expect(line.outputTokens).toBe(7)
+  })
+
+  it('logs error with err.stack and rethrows on failure', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(failGateway(), log)
+    await expect(gw.complete(REQ)).rejects.toThrow('rate limited')
+    const [line] = sink.lines()
+    expect(line.level).toBe('error')
+    expect(line.msg).toBe('llm call failed')
+    expect((line.err as { message: string }).message).toBe('rate limited')
+  })
+
+  it('does not log prompt or completion content (脱敏)', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    await new LoggingGateway(okGateway(), log).complete(REQ)
+    const serialized = JSON.stringify(sink.lines())
+    expect(serialized).not.toContain('"hi"')   // prompt 正文
+    expect(serialized).not.toContain('"ok"')   // completion 正文
+  })
+})
+
+describe('LoggingGateway.stream', () => {
+  it('passes events through and logs one summary with accumulated usage', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(okGateway(), log)
+    const events: ModelEvent[] = []
+    for await (const e of gw.stream(REQ)) events.push(e)
+    expect(events).toHaveLength(2)                       // 事件原样透传
+    const [line] = sink.lines()
+    expect(line.msg).toBe('llm stream')
+    expect(line.model).toBe('test-model')
+    expect(line.inputTokens).toBe(3)
+    expect(line.outputTokens).toBe(5)
+  })
+
+  it('logs error and rethrows when the stream throws', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(failGateway(), log)
+    await expect(async () => { for await (const _ of gw.stream(REQ)) { /* drain */ } }).rejects.toThrow('socket reset')
+    const [line] = sink.lines()
+    expect(line.level).toBe('error')
+    expect(line.msg).toBe('llm stream failed')
+  })
+})
+
+describe('createGateway wiring', () => {
+  it('returns a LoggingGateway-wrapped adapter', () => {
+    const gw = createGateway({ provider: 'anthropic', model: 'claude-x', adapter: 'anthropic' })
+    expect(gw).toBeInstanceOf(LoggingGateway)
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/LoggingGateway.test.ts --runInBand`
+Expected: FAIL —— `Cannot find module '../logging/LoggingGateway'`
+
+- [ ] **Step 3: 实现 LoggingGateway 并接线 GatewayFactory**
+
+```ts
+// src/logging/LoggingGateway.ts
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model.js'
+import type { ServiceLogger } from './logger.js'
+
+/**
+ * #79：在 gateway 统一包装点打 LLM wide event（每调用一条：model/durationMs/token），
+ * 两个 adapter 一处覆盖。只记元数据，不携带 prompt/completion 正文（脱敏，设计 §6）。
+ */
+export class LoggingGateway implements IModelGateway {
+  constructor(
+    private readonly inner: IModelGateway,
+    private readonly log:   ServiceLogger,
+  ) {}
+
+  async complete(request: ModelRequest): Promise<ModelResponse> {
+    const startedAt = Date.now()
+    try {
+      const res = await this.inner.complete(request)
+      this.log.info({
+        model: request.model, durationMs: Date.now() - startedAt,
+        inputTokens: res.usage?.inputTokens, outputTokens: res.usage?.outputTokens,
+      }, 'llm call')
+      return res
+    } catch (err) {
+      this.log.error({ model: request.model, durationMs: Date.now() - startedAt, err }, 'llm call failed')
+      throw err
+    }
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const startedAt = Date.now()
+    let inputTokens = 0
+    let outputTokens = 0
+    try {
+      for await (const e of this.inner.stream(request)) {
+        if (e.type === 'usage') {
+          inputTokens  += e.data.inputTokens
+          outputTokens += e.data.outputTokens
+        }
+        yield e
+      }
+      this.log.info({ model: request.model, durationMs: Date.now() - startedAt, inputTokens, outputTokens }, 'llm stream')
+    } catch (err) {
+      this.log.error({ model: request.model, durationMs: Date.now() - startedAt, err }, 'llm stream failed')
+      throw err
+    }
+  }
+}
+```
+
+注意：`ModelEvent` 的 usage 分支形如 `{ type: 'usage', data: { inputTokens, outputTokens } }`
+（见 `src/gateway/AnthropicAdapter.ts:198-202`）；若类型收窄报错，按 `src/types/model.ts`
+的实际判别联合写 type guard。
+
+```ts
+// src/gateway/GatewayFactory.ts —— 全文替换为：
+import type { ModelConfig } from '../types/agent.js'
+import type { IModelGateway } from '../types/model.js'
+import { AnthropicAdapter } from './AnthropicAdapter.js'
+import { OpenAICompatibleAdapter } from './OpenAICompatibleAdapter.js'
+import { LoggingGateway } from '../logging/LoggingGateway.js'
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
+
+export function createGateway(model: ModelConfig, logger?: ServiceLogger): IModelGateway {
+  const adapter = model.adapter.toLowerCase()
+  // #79：统一在工厂出口包 LoggingGateway，两个 adapter 一处覆盖。
+  // 注入的 gateway（MilkieOptions.gateway，测试用）不经过这里，因此不被包装。
+  const log = logger ?? getLogger().child({ mod: 'gateway' })
+
+  if (adapter === 'anthropic') {
+    return new LoggingGateway(new AnthropicAdapter({ baseUrl: model.baseUrl }), log)
+  }
+
+  if (
+    adapter === 'openai-compatible' ||
+    adapter === 'openai' ||
+    adapter === 'volcengine'
+  ) {
+    return new LoggingGateway(new OpenAICompatibleAdapter({
+      baseUrl: model.baseUrl ?? process.env['VOLCENGINE_API_BASE'],
+      apiKey:
+        process.env['VOLCENGINE_TOKEN'] ??
+        process.env['OPENAI_API_KEY'],
+    }), log)
+  }
+
+  throw new Error(`Unknown model adapter: "${model.adapter}"`)
+}
+```
+
+同时把 `src/logging/index.ts` 中 Task 1 注释掉的 `LoggingGateway` export 行放开。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx jest src/__tests__/LoggingGateway.test.ts src/__tests__/logging.test.ts --runInBand`
+Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/logging src/gateway/GatewayFactory.ts src/__tests__/LoggingGateway.test.ts
+git commit -m "feat(#79): LoggingGateway —— gateway 工厂出口统一打 LLM wide event(model/耗时/token/err)"
+```
+
+---
+
+### Task 3: `Milkie.invoke` 汇总日志 + tier 回退收编
+
+**Files:**
+- Modify: `src/runtime/Milkie.ts`
+- Test: `src/__tests__/Milkie.logging.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// src/__tests__/Milkie.logging.test.ts
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { createServiceLogger } from '../logging/logger'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+const AGENT: AgentConfig = {
+  agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+  fsm: { states: [{ name: 'react', type: 'llm' }] },
+  model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+}
+
+function okGateway(): IModelGateway {
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'done' } }
+    },
+  }
+}
+
+function failGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> { throw new Error('provider down') },
+    // eslint-disable-next-line require-yield
+    async *stream(): AsyncIterable<ModelEvent> { throw new Error('provider down') },
+  }
+}
+
+describe('Milkie.invoke service log', () => {
+  it('logs one info summary per invoke: mod/agentId/runId/contextId/durationMs/status', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const result = await milkie.invoke({ agentId: 'echo', goal: 'g', input: 'hi', contextId: 'ctx-1' })
+    const summaries = sink.lines().filter(l => l.msg === 'invoke completed')
+    expect(summaries).toHaveLength(1)
+    const [line] = summaries
+    expect(line.mod).toBe('runtime')
+    expect(line.agentId).toBe('echo')
+    expect(line.runId).toBe(result.agentRunId)
+    expect(line.contextId).toBe('ctx-1')
+    expect(line.status).toBe('completed')
+    expect(typeof line.durationMs).toBe('number')
+  })
+
+  it('concurrent invokes keep their own runId/contextId（不串线）', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const [a, b] = await Promise.all([
+      milkie.invoke({ agentId: 'echo', goal: 'g', input: 'x', contextId: 'ctx-a' }),
+      milkie.invoke({ agentId: 'echo', goal: 'g', input: 'y', contextId: 'ctx-b' }),
+    ])
+    const byCtx = Object.fromEntries(
+      sink.lines().filter(l => l.msg === 'invoke completed').map(l => [l.contextId, l.runId]),
+    )
+    expect(byCtx['ctx-a']).toBe(a.agentRunId)
+    expect(byCtx['ctx-b']).toBe(b.agentRunId)
+  })
+
+  it('LLM 持续失败时仍出一条 invoke 汇总（AgentRuntime 把错误吞成 status:error）', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: failGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const result = await milkie.invoke({ agentId: 'echo', goal: 'g', input: 'hi', contextId: 'ctx-err' })
+    expect(result.status).toBe('error')
+    const summaries = sink.lines().filter(l => typeof l.msg === 'string' && (l.msg as string).startsWith('invoke'))
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0].status).toBe('error')
+  })
+
+  it('tier 回退从 console.debug 收编为 logger.warn', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    await milkie.complete('echo', { messages: [{ role: 'user', content: [{ type: 'text', text: 'q' }] }], tier: 'no-such-tier' })
+    const warns = sink.lines().filter(l => l.level === 'warn')
+    expect(warns.length).toBeGreaterThanOrEqual(1)
+    expect(warns[0].tier).toBe('no-such-tier')
+    expect(warns[0].agentId).toBe('echo')
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/Milkie.logging.test.ts --runInBand`
+Expected: FAIL —— `logger` 不是 MilkieOptions 的属性（TS 编译错）或断言无日志行
+
+- [ ] **Step 3: 实现**
+
+`src/runtime/Milkie.ts` 改动四处：
+
+(a) import 区新增：
+
+```ts
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
+```
+
+(b) `MilkieOptions` 增加可选注入（追加在 `traceObjectStore?` 之后）：
+
+```ts
+  /** #79：服务日志 logger；缺省用进程级 getLogger()。测试注入内存 sink。 */
+  logger?:          ServiceLogger
+```
+
+类字段与构造器对应增加：
+
+```ts
+  private readonly log: ServiceLogger
+  // constructor 内：
+  this.log = opts.logger ?? getLogger()
+```
+
+(c) `resolveModel` 的 console.debug 行（约 :116）替换为：
+
+```ts
+    if (tier) this.log.warn({ mod: 'runtime', agentId: config.agentId, tier }, 'tier not found; falling back to default model')
+```
+
+(d) `invoke()` 末段（`const rec = …` 之前）建 child 并计时，try/catch 两路都打汇总。
+现 `invoke()` 尾部：
+
+```ts
+    const rec = ioPort instanceof RecordingIOPort ? ioPort : null
+    await rec?.attach({ … })
+
+    try {
+      const result = await runtime.run(request.input)
+      await rec?.detach({ status: result.status, lastTextOutput: result.output })
+      return result
+    } catch (err) {
+      await rec?.detach({ status: 'error', error: err instanceof Error ? err.message : String(err) })
+      throw err
+    }
+```
+
+改为：
+
+```ts
+    const rec = ioPort instanceof RecordingIOPort ? ioPort : null
+    await rec?.attach({
+      agentId:   config.agentId,
+      goal:      request.goal,
+      input:     request.input,
+      contextId,
+      ...(previousRunId ? { previousRunId } : {}),
+    })
+
+    // #79：每 invoke 一条服务日志 wide event（边界汇总，设计 §5）。
+    // turns/token 不在 AgentResult 上，token 已由 LoggingGateway 按调用记录。
+    const invokeLog = this.log.child({ mod: 'runtime', runId: agentRunId, contextId })
+    const invokeStartedAt = Date.now()
+    try {
+      const result = await runtime.run(request.input)
+      await rec?.detach({ status: result.status, lastTextOutput: result.output })
+      invokeLog.info({ agentId: config.agentId, durationMs: Date.now() - invokeStartedAt, status: result.status }, 'invoke completed')
+      return result
+    } catch (err) {
+      await rec?.detach({ status: 'error', error: err instanceof Error ? err.message : String(err) })
+      invokeLog.error({ agentId: config.agentId, durationMs: Date.now() - invokeStartedAt, err }, 'invoke failed')
+      throw err
+    }
+```
+
+(e) `resolveGateway` 把 logger 传给工厂，注入的 logger 才能贯通 gateway 层：
+
+```ts
+    return createGateway(model, this.log.child({ mod: 'gateway' }))
+```
+
+(f) 测试静默：不注入 logger 的存量测试会落到默认 `getLogger()` 朝 stderr 打 info 噪音。
+新建 `jest.setup.ts` 并在 `jest.config.ts` 注册：
+
+```ts
+// jest.setup.ts —— 测试进程默认静默服务日志；显式注入 logger 的用例不受影响。
+process.env['LOG_LEVEL'] ??= 'silent'
+```
+
+```ts
+// jest.config.ts 的 config 对象内追加：
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+```
+
+- [ ] **Step 4: 跑测试确认通过（含回归）**
+
+Run: `npx jest src/__tests__/Milkie.logging.test.ts --runInBand && npm run test:unit`
+Expected: 全 PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/runtime/Milkie.ts src/__tests__/Milkie.logging.test.ts
+git commit -m "feat(#79): Milkie.invoke 每次一条服务日志汇总；tier 回退收编为 logger.warn"
+```
+
+---
+
+### Task 4: serve HTTP 请求日志 + 生命周期日志
+
+**Files:**
+- Modify: `src/cli/serve.ts`
+- Test: `src/__tests__/serve.logging.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// src/__tests__/serve.logging.test.ts
+import http from 'http'
+import type { AddressInfo } from 'net'
+import { createServeServer } from '../cli/serve'
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { BroadcastingEventStore } from '../trace/BroadcastingEventStore'
+import { createServiceLogger } from '../logging/logger'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+function buildMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore } {
+  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
+  const gateway: IModelGateway = {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'ok' } }
+    },
+  }
+  const agent: AgentConfig = {
+    agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  }
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
+  milkie.registerAgent(agent)
+  return { milkie, agentId: 'echo', broadcaster }
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port)))
+}
+
+function get(port: number, path: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path }, res => { res.resume(); res.on('end', () => resolve(res.statusCode ?? 0)) }).on('error', reject)
+  })
+}
+
+function post(port: number, path: string, body: unknown): Promise<{ status: number; text: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path, method: 'POST', headers: { 'content-type': 'application/json' } },
+      res => {
+        let text = ''
+        res.on('data', c => { text += c })
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, text }))
+      },
+    )
+    req.on('error', reject)
+    req.end(JSON.stringify(body))
+  })
+}
+
+/** res.on('finish') 的日志写入在响应抵达客户端后才跑，轮询等它出现。 */
+async function waitFor<T>(read: () => T | undefined, ms = 2000): Promise<T> {
+  const deadline = Date.now() + ms
+  for (;;) {
+    const v = read()
+    if (v !== undefined) return v
+    if (Date.now() > deadline) throw new Error('timed out waiting for log line')
+    await new Promise(r => setTimeout(r, 10))
+  }
+}
+
+describe('serve HTTP service log', () => {
+  let server: http.Server
+  afterEach(() => new Promise<void>(r => server.close(() => r())))
+
+  it('logs one wide event per request: mod/method/path/status/ms', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    expect(await get(port, '/health')).toBe(200)
+    const line = await waitFor(() => sink.lines().find(l => l.msg === 'http request'))
+    expect(line.mod).toBe('server')
+    expect(line.method).toBe('GET')
+    expect(line.path).toBe('/health')
+    expect(line.status).toBe(200)
+    expect(typeof line.ms).toBe('number')
+  })
+
+  it('logs 404 and 400 statuses (异常路径同样有 wide event)', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    await get(port, '/no-such-route')
+    await post(port, '/chat', {})                       // 缺 contextId → 400
+    const seen = await waitFor(() => {
+      const ls = sink.lines().filter(l => l.msg === 'http request')
+      return ls.length >= 2 ? ls : undefined
+    })
+    expect(seen.map(l => [l.path, l.status])).toEqual(expect.arrayContaining([
+      ['/no-such-route', 404],
+      ['/chat', 400],
+    ]))
+  })
+
+  it('SSE 请求记录完整流时长（/chat 正常流）', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    const res = await post(port, '/chat', { contextId: 'c1', input: 'hi' })
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('agent.run.completed')
+    const line = await waitFor(() => sink.lines().find(l => l.msg === 'http request' && l.path === '/chat'))
+    expect(line.status).toBe(200)
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/serve.logging.test.ts --runInBand`
+Expected: FAIL —— `logger` 不是 ServeOptions 属性（TS 编译错）
+
+- [ ] **Step 3: 实现**
+
+`src/cli/serve.ts` 改动：
+
+(a) import 新增：
+
+```ts
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
+```
+
+(b) `ServeOptions` 追加：
+
+```ts
+  /** #79：服务日志 logger；缺省用进程级 getLogger()。测试注入内存 sink。 */
+  logger?:     ServiceLogger
+```
+
+(c) `createServeServer` 开头取 child，并在 `http.createServer` 回调打请求 wide event：
+
+```ts
+export function createServeServer(opts: ServeOptions): Server {
+  const { milkie, agentId, broadcaster } = opts
+  const log = (opts.logger ?? getLogger()).child({ mod: 'server' })
+```
+
+```ts
+  return http.createServer((req, res) => {
+    // #79：每请求一条 wide event。挂在 res 'finish' 上，SSE 长连接记录的是完整流时长。
+    const startedAt = Date.now()
+    res.on('finish', () => {
+      log.info({
+        method: req.method,
+        path:   new URL(req.url ?? '/', 'http://localhost').pathname,
+        status: res.statusCode,
+        ms:     Date.now() - startedAt,
+      }, 'http request')
+    })
+    void (async () => {
+      …（原有路由分发体不动）…
+    })()
+  })
+```
+
+(d) `runServeServer` 加可选 logger 参数并打生命周期日志：
+
+```ts
+export function runServeServer(server: Server, opts: { port: number; host?: string; logger?: ServiceLogger }): Promise<void> {
+  const log = (opts.logger ?? getLogger()).child({ mod: 'server' })
+```
+
+`listen` 回调内（readiness 标记行之后）：
+
+```ts
+      log.info({ port: addr.port, host: opts.host ?? '127.0.0.1' }, 'serve listening')
+```
+
+`shutdown` 函数内（`closing = true` 之后）：
+
+```ts
+      log.info('serve shutting down')
+```
+
+(e) `serveMain` 打启动配置摘要并传递 logger：
+
+```ts
+export async function serveMain(opts: { agent: string; port: number; host?: string; stateStore?: 'memory' | 'sqlite'; dataDir?: string }): Promise<void> {
+  const log = getLogger().child({ mod: 'server' })
+  const { stateStore, eventStore } = await buildServeStores(opts)
+  const broadcaster = new BroadcastingEventStore(eventStore)
+  const milkie = new Milkie({ stateStore, eventStore: broadcaster })
+  const config = milkie.loadAgentFile(opts.agent)
+  log.info({ agentId: config.agentId, stateStore: opts.stateStore ?? 'memory', dataDir: opts.dataDir }, 'serve starting')
+  const server = createServeServer({ milkie, agentId: config.agentId, broadcaster })
+  await runServeServer(server, { port: opts.port, host: opts.host })
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过（含 serve 回归）**
+
+Run: `npx jest src/__tests__/serve.logging.test.ts src/__tests__/serve.test.ts src/__tests__/serve-persistence.test.ts src/__tests__/serveCli.test.ts --runInBand`
+Expected: 全 PASS（serveCli 测试若解析 stdout，确认日志在 stderr 未污染它）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/cli/serve.ts src/__tests__/serve.logging.test.ts
+git commit -m "feat(#79): serve 每请求 wide event(method/path/status/ms) + 启动/关闭生命周期日志"
+```
+
+---
+
+### Task 5: `tools/system.ts` 三处 console.warn 收编
+
+**Files:**
+- Modify: `src/tools/system.ts`
+- Modify: `src/__tests__/skillListManifest.test.ts`（现有 console.warn spy 断言迁移）
+
+- [ ] **Step 1: 改造现有测试为 logger 注入（先行，作为失败测试）**
+
+`src/__tests__/skillListManifest.test.ts`：
+
+把顶部的 spy 设施
+
+```ts
+let warnSpy: jest.SpyInstance
+// beforeEach 内
+warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+// afterEach 内
+warnSpy.mockRestore()
+```
+
+替换为 setLogger 注入（import 区加 `import { createServiceLogger, setLogger } from '../logging/logger'`）：
+
+```ts
+let warnLines: Record<string, unknown>[]
+// beforeEach 内：
+warnLines = []
+const raw: string[] = []
+setLogger(createServiceLogger({
+  level: 'warn', format: 'json',
+  destination: { write: (s: string) => {
+    raw.push(s)
+    warnLines.length = 0
+    warnLines.push(...raw.flatMap(x => x.split('\n').filter(Boolean)).map(x => JSON.parse(x) as Record<string, unknown>))
+  } },
+}))
+// afterEach 内：
+setLogger(undefined)
+```
+
+断言对应替换：
+- `expect(warnSpy).toHaveBeenCalled()` → `expect(warnLines.length).toBeGreaterThan(0)`
+- `expect(warnSpy).not.toHaveBeenCalled()` → `expect(warnLines).toHaveLength(0)`
+
+并新增一条字段断言（任选一个已有的"manifest 读取失败"用例内加）：
+
+```ts
+    expect(warnLines[0].mod).toBe('tools')
+    expect(warnLines[0].level).toBe('warn')
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx jest src/__tests__/skillListManifest.test.ts --runInBand`
+Expected: FAIL —— system.ts 仍走 console.warn，warnLines 为空
+
+- [ ] **Step 3: 实现**
+
+`src/tools/system.ts`：import 区加 `import { getLogger } from '../logging/logger.js'`，
+`loadSkillManifest()` 开头取 `const log = getLogger().child({ mod: 'tools' })`，三处替换：
+
+```ts
+log.warn({ manifestPath, err: e as Error }, `skill_list: failed to read ${SKILL_MANIFEST_ENV}`)
+```
+
+```ts
+log.warn({ manifestPath }, `skill_list: ${SKILL_MANIFEST_ENV} parsed but has no valid 'skills' array; treating as unconfigured`)
+```
+
+```ts
+log.warn({ entry: JSON.stringify(s) }, 'skill_list: skipping malformed skill entry (missing name/description)')
+```
+
+（原 `[milkie]` 前缀去掉——`mod: 'tools'` 字段已承担来源标识。）
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx jest src/__tests__/skillListManifest.test.ts src/__tests__/toolOverrideContract.test.ts --runInBand`
+Expected: PASS（toolOverrideContract 如有 console spy 同步处理）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/tools/system.ts src/__tests__/skillListManifest.test.ts
+git commit -m "refactor(#79): tools/system.ts 零散 console.warn 收编进服务日志(mod=tools)"
+```
+
+---
+
+### Task 6: 全量回归 + lint + 文档/issue 收口 + PR
+
+**Files:**
+- Verify only（无新代码）；`docs/design/79-service-logging.md` 已随分支提交
+
+- [ ] **Step 1: 全量验证**
+
+```bash
+npm run lint && npm run build && npm test
+```
+
+Expected: lint 0 error；tsc 通过；单测 + 确定性 e2e 全 PASS。
+若 e2e 中有解析 stdout 的用例失败，检查是否有日志误写 stdout（必须全在 stderr）。
+
+- [ ] **Step 2: 提交设计文档与计划**
+
+```bash
+git add docs/design/79-service-logging.md docs/superpowers/plans/2026-06-11-service-logging.md
+git commit -m "docs(#79): 服务日志设计文档与实现计划"
+```
+
+- [ ] **Step 3: 推送并建 PR**
+
+```bash
+git push -u origin feat/79-service-logging
+gh pr create --repo xforce-io/milkie --title "feat(#79): 结构化服务日志（pino/NDJSON-stderr，三层可观测之 logging 层）" --body "$(cat <<'EOF'
+Closes #79。设计文档：docs/design/79-service-logging.md（讨论记录见 issue 评论）。
+
+- src/logging/：pino 工厂（ts/level/mod/err schema，LOG_LEVEL/LOG_FORMAT/TTY）+ LoggingGateway
+- 埋点：serve 每请求 wide event、Milkie.invoke 汇总、LLM 调用（工厂出口统一包装）、启动/关闭
+- 收编：tools/system.ts 三处 console.warn、Milkie tier 回退 console.debug
+- 脱敏：不携带 prompt/completion 正文；与 event log 以 runId 关联
+- 偏离 issue 原文两点（已在设计文档 §2/§5 说明）：日志走 stderr（stdout 被 CLI 结果与
+  MILKIE_SERVE_READY 占用）；invoke 汇总暂无 turns 字段（AgentResult 未暴露）
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: issue 正文收敛为摘要 + 设计文档链接（repo doc 即真相源）**

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   testEnvironment: 'node',
   rootDir: '.',
   testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/tests/**/*.test.ts', '<rootDir>/examples/**/*.test.ts'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@milkie/(.*)$':   '<rootDir>/src/$1',
     '^(\\.{1,2}/.+)\\.js$': '$1',   // strip .js for ts-jest CJS resolution

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+// 测试进程默认静默服务日志（#79）；显式注入 logger 的用例不受影响。
+process.env['LOG_LEVEL'] ??= 'silent'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "gray-matter": "^4.0.3",
         "ioredis": "^5.3.2",
         "openai": "^6.38.0",
+        "pino": "^10.3.1",
         "uuid": "^10.0.0"
       },
       "bin": {
@@ -25,6 +26,7 @@
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
+        "pino-pretty": "^13.1.3",
         "ts-jest": "^29.1.5",
         "ts-node": "^10.9.2",
         "tsx": "^4.22.3",
@@ -1380,6 +1382,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1675,6 +1683,15 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2135,6 +2152,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2200,6 +2224,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2518,10 +2552,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2743,6 +2791,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3621,6 +3676,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3956,6 +4021,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4133,6 +4207,81 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -4211,6 +4360,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -4250,6 +4415,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/rc": {
@@ -4295,6 +4466,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -4403,6 +4583,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -4415,6 +4604,23 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4518,6 +4724,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4537,6 +4752,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -4725,6 +4949,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "milkie",
   "version": "0.1.0",
-  "files": ["dist", "agents"],
+  "files": [
+    "dist",
+    "agents"
+  ],
   "description": "TypeScript Agent framework — Agent = FSM",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,6 +33,7 @@
     "gray-matter": "^4.0.3",
     "ioredis": "^5.3.2",
     "openai": "^6.38.0",
+    "pino": "^10.3.1",
     "uuid": "^10.0.0"
   },
   "devDependencies": {
@@ -38,6 +42,7 @@
     "@types/node": "^20.0.0",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
+    "pino-pretty": "^13.1.3",
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.22.3",

--- a/src/__tests__/LoggingGateway.test.ts
+++ b/src/__tests__/LoggingGateway.test.ts
@@ -1,0 +1,106 @@
+import { LoggingGateway } from '../logging/LoggingGateway'
+import { createServiceLogger } from '../logging/logger'
+import { createGateway } from '../gateway/GatewayFactory'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+const REQ: ModelRequest = { model: 'test-model', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] }
+
+function okGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> {
+      return {
+        content: [{ type: 'text', text: 'ok' }], toolCalls: [],
+        usage: { inputTokens: 11, outputTokens: 7 }, finishReason: 'end_turn',
+      }
+    },
+    async *stream(): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'ok' } }
+      yield { type: 'usage', data: { inputTokens: 3, outputTokens: 5 } }
+    },
+  }
+}
+
+function failGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> { throw new Error('rate limited') },
+    // eslint-disable-next-line require-yield
+    async *stream(): AsyncIterable<ModelEvent> { throw new Error('socket reset') },
+  }
+}
+
+describe('LoggingGateway.complete', () => {
+  it('logs one info wide event with model/durationMs/tokens on success', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(okGateway(), log)
+    await gw.complete(REQ)
+    const line = sink.lines()[0]!
+    expect(line.msg).toBe('llm call')
+    expect(line.level).toBe('info')
+    expect(line.model).toBe('test-model')
+    expect(typeof line.durationMs).toBe('number')
+    expect(line.inputTokens).toBe(11)
+    expect(line.outputTokens).toBe(7)
+  })
+
+  it('logs error with err.stack and rethrows on failure', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(failGateway(), log)
+    await expect(gw.complete(REQ)).rejects.toThrow('rate limited')
+    const line = sink.lines()[0]!
+    expect(line.level).toBe('error')
+    expect(line.msg).toBe('llm call failed')
+    expect((line.err as { message: string }).message).toBe('rate limited')
+  })
+
+  it('does not log prompt or completion content (脱敏)', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    await new LoggingGateway(okGateway(), log).complete(REQ)
+    const serialized = JSON.stringify(sink.lines())
+    expect(serialized).not.toContain('"hi"')   // prompt 正文
+    expect(serialized).not.toContain('"ok"')   // completion 正文
+  })
+})
+
+describe('LoggingGateway.stream', () => {
+  it('passes events through and logs one summary with accumulated usage', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(okGateway(), log)
+    const events: ModelEvent[] = []
+    for await (const e of gw.stream(REQ)) events.push(e)
+    expect(events).toHaveLength(2)                       // 事件原样透传
+    const line = sink.lines()[0]!
+    expect(line.msg).toBe('llm stream')
+    expect(line.model).toBe('test-model')
+    expect(line.inputTokens).toBe(3)
+    expect(line.outputTokens).toBe(5)
+  })
+
+  it('logs error and rethrows when the stream throws', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const gw = new LoggingGateway(failGateway(), log)
+    await expect(async () => { for await (const _ of gw.stream(REQ)) { /* drain */ } }).rejects.toThrow('socket reset')
+    const line = sink.lines()[0]!
+    expect(line.level).toBe('error')
+    expect(line.msg).toBe('llm stream failed')
+  })
+})
+
+describe('createGateway wiring', () => {
+  it('returns a LoggingGateway-wrapped adapter', () => {
+    const gw = createGateway({ provider: 'anthropic', model: 'claude-x', adapter: 'anthropic' })
+    expect(gw).toBeInstanceOf(LoggingGateway)
+  })
+})

--- a/src/__tests__/Milkie.logging.test.ts
+++ b/src/__tests__/Milkie.logging.test.ts
@@ -1,0 +1,105 @@
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { createServiceLogger } from '../logging/logger'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+const AGENT: AgentConfig = {
+  agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+  fsm: { states: [{ name: 'react', type: 'llm' }] },
+  model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+}
+
+function okGateway(): IModelGateway {
+  return {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text: 'done' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'done' } }
+    },
+  }
+}
+
+function failGateway(): IModelGateway {
+  return {
+    async complete(): Promise<ModelResponse> { throw new Error('provider down') },
+    // eslint-disable-next-line require-yield
+    async *stream(): AsyncIterable<ModelEvent> { throw new Error('provider down') },
+  }
+}
+
+describe('Milkie.invoke service log', () => {
+  it('logs one info summary per invoke: mod/agentId/runId/contextId/durationMs/status', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const result = await milkie.invoke({ agentId: 'echo', goal: 'g', input: 'hi', contextId: 'ctx-1' })
+    const summaries = sink.lines().filter(l => l.msg === 'invoke completed')
+    expect(summaries).toHaveLength(1)
+    const line = summaries[0]!
+    expect(line.mod).toBe('runtime')
+    expect(line.agentId).toBe('echo')
+    expect(line.runId).toBe(result.agentRunId)
+    expect(line.contextId).toBe('ctx-1')
+    expect(line.status).toBe('completed')
+    expect(typeof line.durationMs).toBe('number')
+  })
+
+  it('concurrent invokes keep their own runId/contextId（不串线）', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const [a, b] = await Promise.all([
+      milkie.invoke({ agentId: 'echo', goal: 'g', input: 'x', contextId: 'ctx-a' }),
+      milkie.invoke({ agentId: 'echo', goal: 'g', input: 'y', contextId: 'ctx-b' }),
+    ])
+    const byCtx = Object.fromEntries(
+      sink.lines().filter(l => l.msg === 'invoke completed').map(l => [l.contextId, l.runId]),
+    )
+    expect(byCtx['ctx-a']).toBe(a.agentRunId)
+    expect(byCtx['ctx-b']).toBe(b.agentRunId)
+  })
+
+  it('LLM 持续失败时仍出一条 invoke 汇总（AgentRuntime 把错误吞成 status:error）', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: failGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    const result = await milkie.invoke({ agentId: 'echo', goal: 'g', input: 'hi', contextId: 'ctx-err' })
+    expect(result.status).toBe('error')
+    const summaries = sink.lines().filter(l => typeof l.msg === 'string' && (l.msg as string).startsWith('invoke'))
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]!.status).toBe('error')
+  })
+
+  it('tier 回退从 console.debug 收编为 logger.warn', async () => {
+    const sink = memorySink()
+    const milkie = new Milkie({
+      stateStore: new MemoryStore(), gateway: okGateway(),
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    milkie.registerAgent(AGENT)
+    await milkie.complete('echo', { messages: [{ role: 'user', content: [{ type: 'text', text: 'q' }] }], tier: 'no-such-tier' })
+    const warns = sink.lines().filter(l => l.level === 'warn')
+    expect(warns.length).toBeGreaterThanOrEqual(1)
+    expect(warns[0]!.tier).toBe('no-such-tier')
+    expect(warns[0]!.agentId).toBe('echo')
+  })
+})

--- a/src/__tests__/logging.test.ts
+++ b/src/__tests__/logging.test.ts
@@ -1,0 +1,99 @@
+import { createServiceLogger, resolveFormat, getLogger, setLogger } from '../logging/logger'
+
+/** 内存 sink：每条 NDJSON 一行，parse 后断言字段。 */
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+describe('createServiceLogger', () => {
+  it('emits NDJSON with ts(ISO8601)/level-label/msg', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.info({ port: 8080 }, 'serve listening')
+    const line = sink.lines()[0]!
+    expect(line.msg).toBe('serve listening')
+    expect(line.level).toBe('info')                                   // 字符串标签而非数字
+    expect(line.port).toBe(8080)
+    expect(typeof line.ts).toBe('string')
+    expect(() => new Date(line.ts as string).toISOString()).not.toThrow()
+    expect(line.pid).toBeUndefined()                                  // base 字段去掉
+    expect(line.hostname).toBeUndefined()
+  })
+
+  it('filters below configured level', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'warn', format: 'json', destination: sink.stream })
+    log.info('hidden')
+    log.warn('shown')
+    expect(sink.lines().map(l => l.msg)).toEqual(['shown'])
+  })
+
+  it('level=silent emits nothing', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'silent', format: 'json', destination: sink.stream })
+    log.error('nope')
+    expect(sink.lines()).toEqual([])
+  })
+
+  it('child loggers merge mod and correlation ids', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.child({ mod: 'server' }).child({ runId: 'r1', contextId: 'c1' }).info('http request')
+    const line = sink.lines()[0]!
+    expect(line.mod).toBe('server')
+    expect(line.runId).toBe('r1')
+    expect(line.contextId).toBe('c1')
+  })
+
+  it('serializes err with message and stack', () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    log.error({ err: new Error('boom') }, 'llm call failed')
+    const line = sink.lines()[0]!
+    const err = line.err as { message: string; stack: string }
+    expect(err.message).toBe('boom')
+    expect(err.stack).toContain('Error: boom')
+  })
+
+  it('defaults level from LOG_LEVEL env', () => {
+    const prev = process.env['LOG_LEVEL']
+    process.env['LOG_LEVEL'] = 'error'
+    try {
+      const sink = memorySink()
+      const log = createServiceLogger({ format: 'json', destination: sink.stream })
+      log.warn('hidden')
+      log.error('shown')
+      expect(sink.lines().map(l => l.msg)).toEqual(['shown'])
+    } finally {
+      if (prev === undefined) delete process.env['LOG_LEVEL']
+      else process.env['LOG_LEVEL'] = prev
+    }
+  })
+})
+
+describe('resolveFormat', () => {
+  it('LOG_FORMAT=json overrides TTY', () => expect(resolveFormat({ LOG_FORMAT: 'json' }, true)).toBe('json'))
+  it('LOG_FORMAT=pretty overrides non-TTY', () => expect(resolveFormat({ LOG_FORMAT: 'pretty' }, false)).toBe('pretty'))
+  it('defaults to pretty on TTY', () => expect(resolveFormat({}, true)).toBe('pretty'))
+  it('defaults to json off TTY', () => expect(resolveFormat({}, false)).toBe('json'))
+  it('ignores unknown LOG_FORMAT values', () => expect(resolveFormat({ LOG_FORMAT: 'xml' }, false)).toBe('json'))
+})
+
+describe('getLogger / setLogger', () => {
+  afterEach(() => setLogger(undefined))
+  it('getLogger returns a stable lazy singleton', () => {
+    expect(getLogger()).toBe(getLogger())
+  })
+  it('setLogger swaps the singleton (test injection); setLogger(undefined) resets', () => {
+    const sink = memorySink()
+    const injected = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    setLogger(injected)
+    expect(getLogger()).toBe(injected)
+    setLogger(undefined)
+    expect(getLogger()).not.toBe(injected)
+  })
+})

--- a/src/__tests__/serve.logging.test.ts
+++ b/src/__tests__/serve.logging.test.ts
@@ -1,0 +1,131 @@
+import http from 'http'
+import type { AddressInfo } from 'net'
+import { createServeServer } from '../cli/serve'
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { BroadcastingEventStore } from '../trace/BroadcastingEventStore'
+import { createServiceLogger } from '../logging/logger'
+import type { AgentConfig } from '../types/agent'
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+
+function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
+  const raw: string[] = []
+  return {
+    lines: () => raw.flatMap(s => s.split('\n').filter(Boolean)).map(s => JSON.parse(s) as Record<string, unknown>),
+    stream: { write: (s: string) => { raw.push(s) } },
+  }
+}
+
+function buildMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore } {
+  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
+  const gateway: IModelGateway = {
+    async complete(_req: ModelRequest): Promise<ModelResponse> {
+      return { content: [{ type: 'text', text: 'ok' }], toolCalls: [], finishReason: 'end_turn' }
+    },
+    async *stream(_req: ModelRequest): AsyncIterable<ModelEvent> {
+      yield { type: 'message_delta', data: { text: 'ok' } }
+    },
+  }
+  const agent: AgentConfig = {
+    agentId: 'echo', version: '1.0.0', systemPrompt: 'echo',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model: { provider: 'stub', model: 'stub', adapter: 'stub' },
+  }
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
+  milkie.registerAgent(agent)
+  return { milkie, agentId: 'echo', broadcaster }
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port)))
+}
+
+function get(port: number, path: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path }, res => { res.resume(); res.on('end', () => resolve(res.statusCode ?? 0)) }).on('error', reject)
+  })
+}
+
+function post(port: number, path: string, body: unknown): Promise<{ status: number; text: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path, method: 'POST', headers: { 'content-type': 'application/json' } },
+      res => {
+        let text = ''
+        res.on('data', c => { text += c })
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, text }))
+      },
+    )
+    req.on('error', reject)
+    req.end(JSON.stringify(body))
+  })
+}
+
+/** res.on('finish') 的日志写入在响应抵达客户端后才跑，轮询等它出现。 */
+async function waitFor<T>(read: () => T | undefined, ms = 2000): Promise<T> {
+  const deadline = Date.now() + ms
+  for (;;) {
+    const v = read()
+    if (v !== undefined) return v
+    if (Date.now() > deadline) throw new Error('timed out waiting for log line')
+    await new Promise(r => setTimeout(r, 10))
+  }
+}
+
+describe('serve HTTP service log', () => {
+  let server: http.Server
+  afterEach(() => new Promise<void>(r => server.close(() => r())))
+
+  it('logs one wide event per request: mod/method/path/status/ms', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    expect(await get(port, '/health')).toBe(200)
+    const line = await waitFor(() => sink.lines().find(l => l.msg === 'http request'))
+    expect(line.mod).toBe('server')
+    expect(line.method).toBe('GET')
+    expect(line.path).toBe('/health')
+    expect(line.status).toBe(200)
+    expect(typeof line.ms).toBe('number')
+  })
+
+  it('logs 404 and 400 statuses (异常路径同样有 wide event)', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    await get(port, '/no-such-route')
+    await post(port, '/chat', {})                       // 缺 contextId → 400
+    const seen = await waitFor(() => {
+      const ls = sink.lines().filter(l => l.msg === 'http request')
+      return ls.length >= 2 ? ls : undefined
+    })
+    expect(seen.map(l => [l.path, l.status])).toEqual(expect.arrayContaining([
+      ['/no-such-route', 404],
+      ['/chat', 400],
+    ]))
+  })
+
+  it('SSE 请求记录完整流时长（/chat 正常流）', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    const res = await post(port, '/chat', { contextId: 'c1', input: 'hi' })
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('agent.run.completed')
+    const line = await waitFor(() => sink.lines().find(l => l.msg === 'http request' && l.path === '/chat'))
+    expect(line.status).toBe(200)
+  })
+})

--- a/src/__tests__/skillListManifest.test.ts
+++ b/src/__tests__/skillListManifest.test.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import path from 'path'
 import { systemTools } from '../tools/system'
 import type { ToolContext } from '../types/tool'
+import { createServiceLogger, setLogger } from '../logging/logger'
 
 // #139 提议1: skill_list 默认 handler 读 MILKIE_SKILL_MANIFEST 指向的本地 manifest
 // → 返回真实完整技能列表；未配置 / 读失败 → degrade（行为软）+ WARNING（日志硬）。
@@ -13,7 +14,12 @@ const ctx = {} as unknown as ToolContext
 let tmpDir: string
 const ENV_KEY = 'MILKIE_SKILL_MANIFEST'
 let savedEnv: string | undefined
-let warnSpy: jest.SpyInstance
+let logRaw: string[]
+/** #79：WARNING 断言走注入的服务日志（mod=tools），不再 spy console。 */
+const warnLines = (): Record<string, unknown>[] =>
+  logRaw.flatMap(s => s.split('\n').filter(Boolean))
+    .map(s => JSON.parse(s) as Record<string, unknown>)
+    .filter(l => l.level === 'warn')
 
 beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-skill-manifest-'))
@@ -24,12 +30,16 @@ afterAll(() => {
 beforeEach(() => {
   savedEnv = process.env[ENV_KEY]
   delete process.env[ENV_KEY]
-  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  logRaw = []
+  setLogger(createServiceLogger({
+    level: 'warn', format: 'json',
+    destination: { write: (s: string) => { logRaw.push(s) } },
+  }))
 })
 afterEach(() => {
   if (savedEnv === undefined) delete process.env[ENV_KEY]
   else process.env[ENV_KEY] = savedEnv
-  warnSpy.mockRestore()
+  setLogger(undefined)
 })
 
 function writeManifest(name: string, content: string): string {
@@ -43,7 +53,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).not.toHaveBeenCalled()
+    expect(warnLines()).toHaveLength(0)
   })
 
   it('env 已设、manifest 有效 → 返回完整列表，原样透传宿主附加字段（dir/version 不投影）', async () => {
@@ -66,7 +76,9 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
+    expect(warnLines()[0]!.mod).toBe('tools')
+    expect(warnLines()[0]!.level).toBe('warn')
   })
 
   it('env 已设、JSON 损坏 → degrade + WARNING', async () => {
@@ -75,7 +87,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
   })
 
   it('合法 JSON 但顶层为 null → 不抛、degrade false + WARNING（契约点2：绝不抛给 LLM）', async () => {
@@ -85,7 +97,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
   })
 
   it('合法 JSON 但缺 skills 键（{}）→ degrade false + WARNING（不静默 true 空表，避免重新引入误导性空）', async () => {
@@ -94,7 +106,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
   })
 
   it('skills 非数组（{"skills":"x"}）→ degrade false + WARNING', async () => {
@@ -103,7 +115,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(false)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
   })
 
   it('合法空数组（{"skills":[]}）→ registryConfigured:true，宿主显式声明零技能，不 WARNING', async () => {
@@ -112,7 +124,7 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: unknown[]; registryConfigured: boolean }
     expect(out.skills).toEqual([])
     expect(out.registryConfigured).toBe(true)
-    expect(warnSpy).not.toHaveBeenCalled()
+    expect(warnLines()).toHaveLength(0)
   })
 
   it('单条目 malformed（缺 name/description）→ 跳过该条 + WARNING，其余正常返回', async () => {
@@ -128,6 +140,6 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     const out = await skillList.handler({}, ctx) as { skills: Array<Record<string, unknown>>; registryConfigured: boolean }
     expect(out.registryConfigured).toBe(true)
     expect(out.skills.map(s => s.name)).toEqual(['good', 'also-good'])
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnLines().length).toBeGreaterThan(0)
   })
 })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -11,6 +11,7 @@ import type { IEventStore } from '../trace/EventStore.js'
 import type { AgentResult, AttachProjectionRequest, JSONValue, Message } from '../types/common.js'
 import type { ModelEvent, ModelResponse } from '../types/model.js'
 import type { PortableSession } from '../runtime/PortableSession.js'
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
 
 /**
  * #86: `milkie serve` HTTP + SSE sidecar. Built (not started) by this factory so
@@ -35,6 +36,8 @@ export interface ServeOptions {
   agentId:     string
   /** The Milkie's eventStore, wrapped so persistent events fan out by contextId. */
   broadcaster: BroadcastingEventStore
+  /** #79：服务日志 logger；缺省用进程级 getLogger()。测试注入内存 sink。 */
+  logger?:     ServiceLogger
 }
 
 /**
@@ -77,6 +80,7 @@ function outputText(result: ModelResponse): string {
 
 export function createServeServer(opts: ServeOptions): Server {
   const { milkie, agentId, broadcaster } = opts
+  const log = (opts.logger ?? getLogger()).child({ mod: 'server' })
 
   /**
    * Drive one turn (invoke or resume) and stream it as SSE. The stream forwards
@@ -266,6 +270,16 @@ export function createServeServer(opts: ServeOptions): Server {
   }
 
   return http.createServer((req, res) => {
+    // #79：每请求一条 wide event。挂在 res 'finish' 上，SSE 长连接记录的是完整流时长。
+    const startedAt = Date.now()
+    res.on('finish', () => {
+      log.info({
+        method: req.method,
+        path:   new URL(req.url ?? '/', 'http://localhost').pathname,
+        status: res.statusCode,
+        ms:     Date.now() - startedAt,
+      }, 'http request')
+    })
     void (async () => {
       try {
         const url = new URL(req.url ?? '/', 'http://localhost')
@@ -300,18 +314,21 @@ export function createServeServer(opts: ServeOptions): Server {
  * discover the port immediately even though this command never "returns" until
  * shutdown.
  */
-export function runServeServer(server: Server, opts: { port: number; host?: string }): Promise<void> {
+export function runServeServer(server: Server, opts: { port: number; host?: string; logger?: ServiceLogger }): Promise<void> {
+  const log = (opts.logger ?? getLogger()).child({ mod: 'server' })
   return new Promise<void>((resolve, reject) => {
     const onError = (err: Error): void => reject(err)
     server.on('error', onError)
     server.listen(opts.port, opts.host ?? '127.0.0.1', () => {
       const addr = server.address() as { port: number }
       process.stdout.write(`MILKIE_SERVE_READY ${addr.port}\n`)
+      log.info({ port: addr.port, host: opts.host ?? '127.0.0.1' }, 'serve listening')
     })
     let closing = false
     const shutdown = (): void => {
       if (closing) return
       closing = true
+      log.info('serve shutting down')
       // Detach every listener we registered so repeated serve sessions in one
       // process don't accumulate handlers, and release the event loop —
       // stdin.resume() (below) keeps the process alive to watch for stdin close,
@@ -367,10 +384,12 @@ export async function buildServeStores(opts: { stateStore?: 'memory' | 'sqlite';
  * serve until shut down. The gateway is resolved from the agent's own model config.
  */
 export async function serveMain(opts: { agent: string; port: number; host?: string; stateStore?: 'memory' | 'sqlite'; dataDir?: string }): Promise<void> {
+  const log = getLogger().child({ mod: 'server' })
   const { stateStore, eventStore } = await buildServeStores(opts)
   const broadcaster = new BroadcastingEventStore(eventStore)
   const milkie = new Milkie({ stateStore, eventStore: broadcaster })
   const config = milkie.loadAgentFile(opts.agent)
+  log.info({ agentId: config.agentId, stateStore: opts.stateStore ?? 'memory', dataDir: opts.dataDir }, 'serve starting')
   const server = createServeServer({ milkie, agentId: config.agentId, broadcaster })
   await runServeServer(server, { port: opts.port, host: opts.host })
 }

--- a/src/gateway/GatewayFactory.ts
+++ b/src/gateway/GatewayFactory.ts
@@ -2,12 +2,17 @@ import type { ModelConfig } from '../types/agent.js'
 import type { IModelGateway } from '../types/model.js'
 import { AnthropicAdapter } from './AnthropicAdapter.js'
 import { OpenAICompatibleAdapter } from './OpenAICompatibleAdapter.js'
+import { LoggingGateway } from '../logging/LoggingGateway.js'
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
 
-export function createGateway(model: ModelConfig): IModelGateway {
+export function createGateway(model: ModelConfig, logger?: ServiceLogger): IModelGateway {
   const adapter = model.adapter.toLowerCase()
+  // #79：统一在工厂出口包 LoggingGateway，两个 adapter 一处覆盖。
+  // 注入的 gateway（MilkieOptions.gateway，测试用）不经过这里，因此不被包装。
+  const log = logger ?? getLogger().child({ mod: 'gateway' })
 
   if (adapter === 'anthropic') {
-    return new AnthropicAdapter({ baseUrl: model.baseUrl })
+    return new LoggingGateway(new AnthropicAdapter({ baseUrl: model.baseUrl }), log)
   }
 
   if (
@@ -15,12 +20,12 @@ export function createGateway(model: ModelConfig): IModelGateway {
     adapter === 'openai' ||
     adapter === 'volcengine'
   ) {
-    return new OpenAICompatibleAdapter({
+    return new LoggingGateway(new OpenAICompatibleAdapter({
       baseUrl: model.baseUrl ?? process.env['VOLCENGINE_API_BASE'],
       apiKey:
         process.env['VOLCENGINE_TOKEN'] ??
         process.env['OPENAI_API_KEY'],
-    })
+    }), log)
   }
 
   throw new Error(`Unknown model adapter: "${model.adapter}"`)

--- a/src/logging/LoggingGateway.ts
+++ b/src/logging/LoggingGateway.ts
@@ -1,0 +1,47 @@
+import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model.js'
+import type { ServiceLogger } from './logger.js'
+
+/**
+ * #79：在 gateway 统一包装点打 LLM wide event（每调用一条：model/durationMs/token），
+ * 两个 adapter 一处覆盖。只记元数据，不携带 prompt/completion 正文（脱敏，设计 §6）。
+ */
+export class LoggingGateway implements IModelGateway {
+  constructor(
+    private readonly inner: IModelGateway,
+    private readonly log:   ServiceLogger,
+  ) {}
+
+  async complete(request: ModelRequest): Promise<ModelResponse> {
+    const startedAt = Date.now()
+    try {
+      const res = await this.inner.complete(request)
+      this.log.info({
+        model: request.model, durationMs: Date.now() - startedAt,
+        inputTokens: res.usage?.inputTokens, outputTokens: res.usage?.outputTokens,
+      }, 'llm call')
+      return res
+    } catch (err) {
+      this.log.error({ model: request.model, durationMs: Date.now() - startedAt, err }, 'llm call failed')
+      throw err
+    }
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const startedAt = Date.now()
+    let inputTokens = 0
+    let outputTokens = 0
+    try {
+      for await (const e of this.inner.stream(request)) {
+        if (e.type === 'usage') {
+          inputTokens  += e.data.inputTokens
+          outputTokens += e.data.outputTokens
+        }
+        yield e
+      }
+      this.log.info({ model: request.model, durationMs: Date.now() - startedAt, inputTokens, outputTokens }, 'llm stream')
+    } catch (err) {
+      this.log.error({ model: request.model, durationMs: Date.now() - startedAt, err }, 'llm stream failed')
+      throw err
+    }
+  }
+}

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,0 +1,3 @@
+export { createServiceLogger, getLogger, setLogger, resolveFormat } from './logger.js'
+export type { ServiceLogger, ServiceLoggerOptions } from './logger.js'
+// export { LoggingGateway } from './LoggingGateway.js'   // Task 2 落地后放开

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,3 +1,3 @@
 export { createServiceLogger, getLogger, setLogger, resolveFormat } from './logger.js'
 export type { ServiceLogger, ServiceLoggerOptions } from './logger.js'
-// export { LoggingGateway } from './LoggingGateway.js'   // Task 2 落地后放开
+export { LoggingGateway } from './LoggingGateway.js'

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,0 +1,62 @@
+import pino from 'pino'
+
+/**
+ * #79 服务日志（service log）：运维遥测层，与 event log（业务真相）、trajectory
+ * （span 诊断）三层并存，用 runId/contextId 关联。边界纪律、字段 schema 见
+ * docs/design/79-service-logging.md。
+ *
+ * 类型上只 re-export pino.Logger —— 不在 pino 外造抽象层，调用方不直接 import pino。
+ */
+export type ServiceLogger = pino.Logger
+
+export interface ServiceLoggerOptions {
+  level?:       string                    // 默认 LOG_LEVEL ?? 'info'
+  format?:      'json' | 'pretty'         // 默认 LOG_FORMAT ?? (stderr TTY ? pretty : json)
+  destination?: pino.DestinationStream    // 默认 stderr；测试注入内存 sink
+}
+
+/** format 决策独立成纯函数，TTY/env 分支可单测。 */
+export function resolveFormat(env: { LOG_FORMAT?: string }, isTTY: boolean): 'json' | 'pretty' {
+  if (env.LOG_FORMAT === 'pretty') return 'pretty'
+  if (env.LOG_FORMAT === 'json') return 'json'
+  return isTTY ? 'pretty' : 'json'
+}
+
+export function createServiceLogger(opts: ServiceLoggerOptions = {}): ServiceLogger {
+  const level  = opts.level ?? process.env['LOG_LEVEL'] ?? 'info'
+  const format = opts.format ?? resolveFormat(
+    { LOG_FORMAT: process.env['LOG_FORMAT'] },
+    process.stderr.isTTY === true,
+  )
+  // 日志走 stderr：stdout 已被程序输出占用（CLI 结果、MILKIE_SERVE_READY 端口标记）。
+  let destination: pino.DestinationStream | undefined = opts.destination
+  if (!destination && format === 'pretty') {
+    try {
+      // pino-pretty 是 devDependency；生产未安装时静默回退 json（即 undefined → 下方 stderr）
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pretty = require('pino-pretty') as (o: object) => pino.DestinationStream
+      destination = pretty({ destination: 2 })
+    } catch { /* fall back to json on stderr */ }
+  }
+  destination ??= pino.destination(2)
+  return pino({
+    level,
+    base: undefined,                                            // 去掉 pid/hostname
+    timestamp: () => `,"ts":"${new Date().toISOString()}"`,     // 字段名用 ts（设计 §4）
+    formatters: { level: label => ({ level: label }) },         // 字符串标签而非数字
+    serializers: { err: pino.stdSerializers.err },
+  }, destination)
+}
+
+let defaultLogger: ServiceLogger | undefined
+
+/** 惰性默认单例（读环境变量）。模块级埋点（如 tools/system.ts）从这里取。 */
+export function getLogger(): ServiceLogger {
+  defaultLogger ??= createServiceLogger()
+  return defaultLogger
+}
+
+/** 测试注入用：换掉单例；传 undefined 恢复惰性默认。 */
+export function setLogger(logger: ServiceLogger | undefined): void {
+  defaultLogger = logger
+}

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -40,6 +40,7 @@ import {
   PORTABLE_SESSION_SCHEMA_VERSION,
   collectRunTree,
 } from './PortableSession.js'
+import { getLogger, type ServiceLogger } from '../logging/logger.js'
 
 /**
  * #137: read-only run-state of a context, projected from its latest checkpoint.
@@ -80,6 +81,8 @@ export interface MilkieOptions {
    */
   eventStore?:      IEventStore
   traceObjectStore?: ITraceObjectStore
+  /** #79：服务日志 logger；缺省用进程级 getLogger()。测试注入内存 sink。 */
+  logger?:          ServiceLogger
 }
 
 export class Milkie {
@@ -90,6 +93,7 @@ export class Milkie {
   private readonly trajectoryStore: TrajectoryStore | null
   private readonly eventStore:      IEventStore | null
   private readonly traceObjectStore: ITraceObjectStore | null
+  private readonly log:             ServiceLogger
 
   private readonly agents:   Map<string, AgentConfig> = new Map()
 
@@ -107,13 +111,14 @@ export class Milkie {
     this.trajectoryStore = opts.trajectoryStore  ?? null
     this.eventStore      = opts.eventStore       ?? null
     this.traceObjectStore = opts.traceObjectStore ?? null
+    this.log             = opts.logger           ?? getLogger()
   }
 
   private resolveModel(config: AgentConfig, tier?: string): ModelConfig | undefined {
     // #126: a given+matched tier wins; otherwise fall back to the default model
     // (no throw — serve configured with only a default stays usable for any tier).
     if (tier && config.models?.[tier]) return config.models[tier]
-    if (tier) console.debug(`[milkie] tier "${tier}" not found for agent "${config.agentId}"; falling back to default model`)
+    if (tier) this.log.warn({ mod: 'runtime', agentId: config.agentId, tier }, 'tier not found; falling back to default model')
     return config.model ?? this.defaultModel ?? undefined
   }
 
@@ -125,7 +130,7 @@ export class Milkie {
         `Agent "${config.agentId}" has no model and Milkie has no gateway or defaultModel; ` +
         `built-in agents need a gateway or defaultModel at construction.`)
     }
-    return createGateway(model)
+    return createGateway(model, this.log.child({ mod: 'gateway' }))
   }
 
   private wrapIOPort(gateway: IModelGateway, runId: string, cursor?: CausalCursor): IIOPort {
@@ -380,12 +385,18 @@ export class Milkie {
       ...(previousRunId ? { previousRunId } : {}),
     })
 
+    // #79：每 invoke 一条服务日志 wide event（边界汇总，设计 §5）。
+    // turns/token 不在 AgentResult 上，token 已由 LoggingGateway 按调用记录。
+    const invokeLog = this.log.child({ mod: 'runtime', runId: agentRunId, contextId })
+    const invokeStartedAt = Date.now()
     try {
       const result = await runtime.run(request.input)
       await rec?.detach({ status: result.status, lastTextOutput: result.output })
+      invokeLog.info({ agentId: config.agentId, durationMs: Date.now() - invokeStartedAt, status: result.status }, 'invoke completed')
       return result
     } catch (err) {
       await rec?.detach({ status: 'error', error: err instanceof Error ? err.message : String(err) })
+      invokeLog.error({ agentId: config.agentId, durationMs: Date.now() - invokeStartedAt, err }, 'invoke failed')
       throw err
     }
   }

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import type { ToolDefinition } from '../types/tool.js'
+import { getLogger } from '../logging/logger.js'
 
 // skill_list and skill_request are system-injected tools.
 //
@@ -23,6 +24,7 @@ function isValidSkill(s: unknown): s is SkillEntry {
 }
 
 function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolean } {
+  const log = getLogger().child({ mod: 'tools' })
   const manifestPath = process.env[SKILL_MANIFEST_ENV]
   if (!manifestPath) return { skills: [], registryConfigured: false }
 
@@ -31,7 +33,7 @@ function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolea
     parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
   } catch (e) {
     // env 已设却读不到/解析失败 — 大概率 misconfig：行为 degrade，日志响亮。
-    console.warn(`[milkie] skill_list: failed to read ${SKILL_MANIFEST_ENV}=${manifestPath}: ${(e as Error).message}`)
+    log.warn({ manifestPath, err: e as Error }, `skill_list: failed to read ${SKILL_MANIFEST_ENV}`)
     return { skills: [], registryConfigured: false }
   }
 
@@ -42,14 +44,14 @@ function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolea
     ? (parsed as { skills?: unknown }).skills
     : undefined
   if (!Array.isArray(skillsRaw)) {
-    console.warn(`[milkie] skill_list: ${SKILL_MANIFEST_ENV}=${manifestPath} parsed but has no valid 'skills' array; treating as unconfigured`)
+    log.warn({ manifestPath }, `skill_list: ${SKILL_MANIFEST_ENV} parsed but has no valid 'skills' array; treating as unconfigured`)
     return { skills: [], registryConfigured: false }
   }
 
   const skills: SkillEntry[] = []
   for (const s of skillsRaw) {
     if (isValidSkill(s)) skills.push(s)               // 原样透传，含 dir/version 等附加字段
-    else console.warn(`[milkie] skill_list: skipping malformed skill entry (missing name/description): ${JSON.stringify(s)}`)
+    else log.warn({ entry: JSON.stringify(s) }, 'skill_list: skipping malformed skill entry (missing name/description)')
   }
   return { skills, registryConfigured: true }
 }


### PR DESCRIPTION
Closes #79。设计文档：[docs/design/79-service-logging.md](docs/design/79-service-logging.md)（讨论记录见 issue 评论）。

- `src/logging/`：pino 工厂（`ts`/`level`/`mod`/`err` schema，`LOG_LEVEL`/`LOG_FORMAT`/TTY 决策）+ LoggingGateway
- 埋点：serve 每请求 wide event、`Milkie.invoke` 汇总、LLM 调用（gateway 工厂出口统一包装）、启动/关闭生命周期
- 收编：`tools/system.ts` 三处 console.warn、`Milkie` tier 回退 console.debug
- 脱敏：不携带 prompt/completion 正文；与 event log 以 `runId` 关联
- 偏离 issue 原文两点（设计文档 §2/§5 有说明）：日志走 **stderr**（stdout 被 CLI 结果与 `MILKIE_SERVE_READY` 占用）；invoke 汇总暂无 `turns` 字段（`AgentResult` 未暴露）

测试：新增 39 个用例（logger 工厂 13、LoggingGateway 6、Milkie 4、serve 3、skillListManifest 改造 9+ 等），覆盖级别过滤/format 分支/child 合并/err 序列化/并发 runId 不串线/LLM 与 HTTP 失败路径；`npx jest src` 672/672 通过，`npm test`（单测+确定性 e2e）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)