### PR TITLE
Fix skill_request fallback for manifest-backed skills

### DIFF
--- a/src/__tests__/skillListManifest.test.ts
+++ b/src/__tests__/skillListManifest.test.ts
@@ -9,6 +9,7 @@ import { createServiceLogger, setLogger } from '../logging/logger'
 // → 返回真实完整技能列表；未配置 / 读失败 → degrade（行为软）+ WARNING（日志硬）。
 
 const skillList = systemTools.find(t => t.name === 'skill_list')!
+const skillRequest = systemTools.find(t => t.name === 'skill_request')!
 const ctx = {} as unknown as ToolContext
 
 let tmpDir: string
@@ -141,5 +142,56 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
     expect(out.registryConfigured).toBe(true)
     expect(out.skills.map(s => s.name)).toEqual(['good', 'also-good'])
     expect(warnLines().length).toBeGreaterThan(0)
+  })
+})
+
+describe('skill_request manifest-backed fallback (#153)', () => {
+  it('原生 AgentConfig 未声明但 manifest 有该 skill 时，不返回误导性的 unavailable', async () => {
+    const p = writeManifest('request-fallback.json', JSON.stringify({
+      skills: [
+        { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+      ],
+    }))
+    process.env[ENV_KEY] = p
+    const unavailableCtx = {
+      requestSkill: (name: string) => ({ requested: name, status: 'unavailable' }),
+    } as unknown as ToolContext
+
+    const out = await skillRequest.handler({ name: 'twitter-watch' }, unavailableCtx) as Record<string, unknown>
+
+    expect(out).toMatchObject({
+      requested: 'twitter-watch',
+      status:    'manifest_backed',
+      skill:     { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+    })
+    expect(out.status).not.toBe('unavailable')
+    expect(out).toHaveProperty('instructionPath', '/abs/twitter-watch/SKILL.md')
+    expect(String(out.message)).toContain('SKILL.md')
+  })
+
+  it('原生 skill_request 成功时保持原生返回，不走 manifest fallback', async () => {
+    const p = writeManifest('native-wins.json', JSON.stringify({
+      skills: [
+        { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+      ],
+    }))
+    process.env[ENV_KEY] = p
+    const nativeCtx = {
+      requestSkill: (_name: string) => ({
+        requested: 'twitter-watch',
+        status:    'pending_next_epoch',
+        version:   '9.9.9',
+        scope:     'turn',
+      }),
+    } as unknown as ToolContext
+
+    const out = await skillRequest.handler({ name: 'twitter-watch' }, nativeCtx)
+
+    expect(out).toEqual({
+      requested: 'twitter-watch',
+      status:    'pending_next_epoch',
+      version:   '9.9.9',
+      scope:     'turn',
+    })
   })
 })

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import type { ToolDefinition } from '../types/tool.js'
 import { getLogger } from '../logging/logger.js'
 
@@ -56,6 +57,31 @@ function loadSkillManifest(): { skills: SkillEntry[]; registryConfigured: boolea
   return { skills, registryConfigured: true }
 }
 
+function normalizeSkillName(name: string): string {
+  return name.trim().replace(/\s+skill$/i, '')
+}
+
+function manifestBackedSkillRequest(name: string): Record<string, unknown> | undefined {
+  const manifest = loadSkillManifest()
+  if (!manifest.registryConfigured) return undefined
+
+  const normalized = normalizeSkillName(name)
+  const skill = manifest.skills.find(s => normalizeSkillName(s.name) === normalized)
+  if (!skill) return undefined
+
+  const dir = typeof skill.dir === 'string' ? skill.dir : undefined
+  const instructionPath = dir ? path.join(dir, 'SKILL.md') : undefined
+  return {
+    requested: normalized,
+    status:    'manifest_backed',
+    skill,
+    ...(instructionPath ? { instructionPath } : {}),
+    message: instructionPath
+      ? `Skill "${normalized}" is available via the manifest, but this agent was not configured with inline skillInstructions. Read ${instructionPath} with run_command/cat, then follow that SKILL.md.`
+      : `Skill "${normalized}" is available via the manifest, but this agent was not configured with inline skillInstructions and the manifest entry has no dir. Use skill_list details or host instructions to locate its SKILL.md.`,
+  }
+}
+
 export const systemTools: ToolDefinition[] = [
   {
     name:        'skill_list',
@@ -83,7 +109,9 @@ export const systemTools: ToolDefinition[] = [
     },
     handler: async (input: unknown, ctx) => {
       const { name, scope } = input as { name: string; scope?: 'turn' | 'session' }
-      return ctx.requestSkill?.(name, scope) ?? { requested: name, status: 'unavailable' }
+      const result = ctx.requestSkill?.(name, scope) ?? { requested: name, status: 'unavailable' }
+      if ((result as { status?: unknown }).status !== 'unavailable') return result
+      return manifestBackedSkillRequest(name) ?? result
     },
   },
 ]


### PR DESCRIPTION
## Summary

Closes #153.

This fixes the manifest-backed skill path where `skill_list` can expose skills from `MILKIE_SKILL_MANIFEST`, but `skill_request` still returned a bare `unavailable` because the agent config did not include inline `skills` + `skillInstructions`.

Changes:

- keep native `skill_request` behavior unchanged when it returns `pending_next_epoch`
- when native skill loading returns `unavailable`, look up the requested skill in `MILKIE_SKILL_MANIFEST`
- if found, return `status: "manifest_backed"` with the manifest skill entry, `instructionPath` when `dir` is present, and an explicit `SKILL.md` reading instruction
- add tests for both the manifest fallback and native-success precedence

## Tests

- `npx jest src/__tests__/skillListManifest.test.ts --runInBand`
- `npx jest tests/e2e/deterministic.test.ts tests/e2e/s-010-skill-versioned-load-and-ab-experiment.e2e.test.ts --runInBand --testNamePattern="skill_request|Skill|skill"`
- `npm run build`
