### PR TITLE
feat(#155): 抽取 citeable helper 统一数据工具接入 lineage

### DIFF
--- a/docs/connecting-data-tools-to-lineage.md
+++ b/docs/connecting-data-tools-to-lineage.md
@@ -1,0 +1,66 @@
+# 数据工具接入 lineage 指引
+
+面向**工具作者**:你写了一个会从外部召回/读取资料的工具(检索、读文件、查库、抓网页……),如何让它召回的资料能被 agent 用 `cite` 溯源。
+
+配套阅读:[`lineage-taxonomy.md`](./lineage-taxonomy.md)(object/relation 的受控词汇表)。
+
+## 何时该接
+
+判断标准只有一条:**这个工具是否把"外部的、不可凭空重现的资料"带进了 agent 的视野,且这份资料可能成为答案里某个论断的依据?**
+
+| 工具类型 | 例子 | 接 lineage? |
+|----------|------|-------------|
+| 数据召回 / 读取 | recall、read_file、grep、query_db、fetch_url | **要** —— 这是溯源的源头 |
+| 副作用型 | mkdir、write_file、git_commit | 不要 —— 没有"被引用的事实" |
+| 纯计算 / 控制 | calculator、子 agent 调度、create_plan | 不要 |
+
+`run_command` 比较特殊:它既能跑副作用命令又能 cat 文件,所以用 lazy 兜底——只要有 stdout 就 register,不被引用就不落账。
+
+## 怎么接:一行 `citeable`
+
+用 `src/tools/lineage.ts` 导出的 `citeable` helper。它把样板和三个易错点一次封死:**lazy 注册**、**objectId 放结果最前**、**没接 lineage sink 时不污染结果**。
+
+```ts
+import { citeable } from '../tools/lineage.js'
+
+handler: async (input, ctx) => {
+  const results = await myRetriever.search(input.query)   // 你现有的召回逻辑
+  // 批量:每条结果各 mint 一个可 cite 的 object
+  const hits = results.map((r) =>
+    citeable(ctx, r.text, { text: r.text, source: r.docId }, { meta: { source: r.docId, score: r.score } }),
+  )
+  return { hits }
+}
+```
+
+`citeable(ctx, content, result, opts?)`:
+
+- `content` —— 用来算 hash 的**原文**(内容寻址 → 同样内容跨 run 去重)。
+- `result` —— 要返回给 agent 的结果体;`objectId` 会被 spread 到它**最前面**。
+- `opts.type` —— object 类型,默认 `'passage'`(见下)。
+- `opts.meta` —— 定位信息(doc id、行号、url、score 等),会进 `object.created` payload。
+
+接入后**零额外接线**:agent 在 state 的 `tools` allowlist 里只要有 `cite`,就能引用这些 objectId,RecordingIOPort 在 `tool.responded` 之后自动落账。记得把工具名和 `cite` 一起加进用到它的 state 的 `tools`。
+
+## objectType 怎么选
+
+- 一般召回的一段文本 → 直接用核心类型 `'passage'`,跨 run 查询能按核心类型聚合。
+- 想区分来源便于后续分析 → 用 `namespace:kind`(如 `'shell:stdout'`、`'rag:chunk'`),约定见 [`lineage-taxonomy.md`](./lineage-taxonomy.md)。
+
+## 工具 description 的话术模板
+
+description 要告诉 agent"每条结果带 objectId,用 cite 引用,别在散文里手写来源"。照抄这个骨架:
+
+> Returns `{ hits: [{ objectId, text, source }] }`. Each hit carries an `objectId` —
+> to source a claim from a retrieved passage, pass that objectId to the `cite` tool.
+> Never write provenance like "(doc:...)" in prose; cite the objectId instead.
+
+## 为什么 objectId 必须在最前
+
+result-truncation 策略可能截掉结果尾部。objectId 在尾部 → agent 看不见 → 没法 cite。`citeable` 已经替你保证它在首位,但如果你手写返回结构,务必把 objectId 放第一个键。
+
+## 跨语言:外部语言只做数据源
+
+召回服务是 Python/Go/Java 写的没关系。让 milkie 这边的 handler 当**瘦适配层**:通过 subprocess / HTTP / RPC 调外部服务,外部只返回**原始数据**(text + 定位信息),`citeable`、hash、objectId 全在 **TS 侧** mint。这样跨语言**零对齐成本**——内容寻址只在一处发生。`run_command`(`src/tools/exec.ts`)就是这个模式的现成证明:它 spawn 任意语言的子进程,只对 stdout 做物化。
+
+只有当外部系统要**独立持久化溯源、跨服务共享同一个 objectId** 时,才需要在那门语言里复刻 objectId 的内容寻址算法(canonical JSON + sha256,见 `src/trace/hash.ts`)。那是另一个量级的工程,不要提前做。

--- a/src/__tests__/citeable.test.ts
+++ b/src/__tests__/citeable.test.ts
@@ -1,0 +1,45 @@
+import { citeable } from '../tools/lineage'
+import { sha256Hex } from '../trace/hash'
+import type { ToolContext } from '../types/tool'
+
+// A minimal ToolContext that records registerObject calls (lazy lineage sink).
+function mockCtx() {
+  const calls: Array<{ type: string; hash?: string; meta?: Record<string, unknown> }> = []
+  const ctx = {
+    registerObject: (spec: { type: string; hash?: string; meta?: Record<string, unknown> }) => {
+      calls.push(spec)
+      return { objectId: `obj:reg:${calls.length}` }
+    },
+  } as unknown as ToolContext
+  return { ctx, calls }
+}
+
+describe('citeable helper (#155)', () => {
+  it('mints via registerObject and puts objectId first in the result', () => {
+    const { ctx, calls } = mockCtx()
+    const out = citeable(ctx, 'hello world', { text: 'hello world', source: 'doc1' })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.type).toBe('passage')                 // default type
+    expect(calls[0]!.hash).toBe(sha256Hex('hello world'))  // content-bound hash
+    expect((out as Record<string, unknown>).objectId).toBe('obj:reg:1')
+    expect(Object.keys(out)[0]).toBe('objectId')          // objectId first → survives truncation
+    expect((out as Record<string, unknown>).source).toBe('doc1')  // original fields kept
+  })
+
+  it('honors a custom type and meta', () => {
+    const { ctx, calls } = mockCtx()
+    citeable(ctx, 'out', { stdout: 'out' }, { type: 'shell:stdout', meta: { command: 'ls', exitCode: 0 } })
+
+    expect(calls[0]!.type).toBe('shell:stdout')
+    expect(calls[0]!.meta).toEqual({ command: 'ls', exitCode: 0 })
+  })
+
+  it('without a lineage sink returns the result unchanged (no objectId key)', () => {
+    const ctx = {} as unknown as ToolContext   // registerObject absent → lineage off
+    const out = citeable(ctx, 'x', { text: 'x' })
+
+    expect('objectId' in out).toBe(false)
+    expect(out).toEqual({ text: 'x' })
+  })
+})

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
-import { sha256Hex } from '../trace/hash.js'
 import type { ToolDefinition } from '../types/tool.js'
+import { citeable } from './lineage.js'
 
 // Built-in shell/exec tool (#134). Lets an agent run subprocess commands —
 // skill scripts (`python skills/.../scripts/x.py`), CLIs (`inv`, `codex-cli`), etc.
@@ -98,26 +98,16 @@ export const execTools: ToolDefinition[] = [
       required:   ['command'],
     },
     handler: async (input, ctx) => {
-      const out = await runCommand(input as RunCommandInput)
-      // #148: lazy-register non-empty stdout as a citable object (like grep) so any
-      // shell-fetched evidence (file / network / db) can be sourced via the `cite`
-      // tool — no per-skill refactoring. registerObject is lazy (no event); the
-      // object is promoted only when the agent actually cites it, so routine
-      // commands (ls/mkdir) never flood the lineage graph. objectId is placed
-      // FIRST so it survives the result-truncation strategy — the agent must see
-      // it to cite. Stdout is a genuine tool-call record (origin invariant holds).
-      if (ctx?.registerObject && out.stdout) {
-        // #150: hash the capped stdout (what the trace's tool.responded record holds)
-        // so the objectId is content-bound — same command re-run with different
-        // output mints a different object instead of colliding.
-        const { objectId } = ctx.registerObject({
-          type: 'shell:stdout',
-          hash: sha256Hex(out.stdout),
-          meta: { command: (input as RunCommandInput).command, exitCode: out.exitCode },
-        })
-        return { objectId, ...out }
-      }
-      return out
+      const cmd = input as RunCommandInput
+      const out = await runCommand(cmd)
+      // #148/#155: lazily register non-empty stdout as a citable object via the shared
+      // `citeable` helper, so any shell-fetched evidence (file / network / db) can be
+      // sourced via the `cite` tool with no per-skill refactoring. The helper is lazy
+      // (no event until the agent cites it, so ls/mkdir never flood the lineage graph),
+      // hashes the capped stdout (#150: content-bound objectId — different output mints
+      // a different object), and spreads objectId FIRST so it survives result-truncation.
+      if (!out.stdout) return out
+      return citeable(ctx, out.stdout, out, { type: 'shell:stdout', meta: { command: cmd.command, exitCode: out.exitCode } })
     },
   },
 ]

--- a/src/tools/lineage.ts
+++ b/src/tools/lineage.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition, ToolContext } from '../types/tool.js'
-import type { RelationType } from '../trace/types.js'
+import type { ObjectType, RelationType } from '../trace/types.js'
+import { sha256Hex } from '../trace/hash.js'
 
 /**
  * #113 P3: framework built-in lineage-declaration tools.
@@ -14,6 +15,33 @@ import type { RelationType } from '../trace/types.js'
  *   - promoteObject  → emit a lazily-registered object on first citation
  *   - createObject / createRelation → record claim + typed edge
  */
+
+/**
+ * #155: the one-liner for a *data tool* (recall / read / fetch) to make a piece of
+ * fetched content citable. Wraps the lazy-lineage boilerplate every such tool would
+ * otherwise hand-write, closing its three foot-guns at once:
+ *   - lazy `registerObject` (no event until a cite promotes it → wide recall never
+ *     floods the event log);
+ *   - the resulting `objectId` is spread to the FRONT of the result, so it survives
+ *     result-truncation and the agent can actually see+cite it;
+ *   - no-op when no lineage sink is wired (`registerObject` absent) — returns the
+ *     result untouched, never injecting a stray `objectId` key.
+ * `content` is what gets hashed (content-addressed id → cross-run dedupe); `type`
+ * defaults to 'passage' (override with a `namespace:kind`, e.g. 'shell:stdout').
+ */
+export function citeable<T extends object>(
+  ctx: ToolContext,
+  content: string,
+  result: T,
+  opts?: { type?: ObjectType; meta?: Record<string, unknown> },
+): T | ({ objectId: string } & T) {
+  const objectId = ctx?.registerObject?.({
+    type: opts?.type ?? 'passage',
+    hash: sha256Hex(content),
+    meta: opts?.meta,
+  })?.objectId
+  return objectId ? { objectId, ...result } : result
+}
 
 function unresolved(ctx: ToolContext, objectId: string): boolean {
   return !!ctx.resolveObject && !ctx.resolveObject(objectId)


### PR DESCRIPTION
## 概要

抽取 `citeable` 薄 helper,把"数据工具接入 lineage"的样板与三个易错点一次封死,让接入从手写样板降到一行调用,并用它收编现有 `run_command`。

## 改动

- **`src/tools/lineage.ts`**:新增 `citeable(ctx, content, result, opts)`,封装数据工具接入 lineage 的样板与三个易错点——lazy `registerObject`、`objectId` 置于结果首位(躲 result-truncation)、无 lineage sink 时不污染结果。
- **`src/tools/exec.ts`**:`run_command` 改用 `citeable`,行为等价(`type=shell:stdout`、hash=capped stdout、`objectId` 仍在首位均不变)。
- **`docs/connecting-data-tools-to-lineage.md`**:数据工具接入 lineage 的约定指引(何时接 / citeable 范式 / objectType 选择 / cite 话术 / 跨语言边界层)。
- 新增 `citeable` 单测;execTools / lineageTools 回归全绿。

## 测试

- 新增 `src/__tests__/citeable.test.ts`
- execTools / lineageTools 回归全绿

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)