### PR TITLE
feat(#162): repair-ticketing 示例的 Web UI 层（S-011 Path D）

### DIFF
--- a/examples/repair-ticketing/README.md
+++ b/examples/repair-ticketing/README.md
@@ -1,0 +1,59 @@
+# repair-ticketing — 层级实体报修工单（S-011 Path D 的 Web 版）
+
+一个最小可跑的报修工单助手：用户逐级说出报修对象（站点 → 楼宇 → 部门 → 负责人），
+再用一句话描述故障，系统**确定性**生成结构化工单。它是 [S-011 Path D](../../docs/stories)
+（多状态 FSM + 层级槽填充）的 Web UI 形态，把 #167 的可移植解析器内核接进 milkie 的
+`ToolDefinition` 与 FSM 里在线运行——无子进程、无 CLI spawn。
+
+## 运行
+
+```bash
+npm install          # 在仓库根目录
+npx tsx examples/repair-ticketing/src/server.ts
+# 打开 http://localhost:7979
+```
+
+服务器使用 agent 自带模型（volcengine doubao，openai-compatible），运行前请在环境中配置
+对应的 provider 凭据。端口可用 `PORT` 覆盖。
+
+依次输入即可看到四个槽位 chip（站点 / 楼宇 / 部门 / 负责人）逐个点亮，最后给出故障描述后，
+右侧生成工单卡片。例如：`总部` → `主楼` → `IT网络部` → `王芳` → `投影仪无法开机`。
+
+## 它演示了什么
+
+- **三状态 FSM**（见 `src/agent.ts`）：
+  - `collecting_entities`（`llm`）：`lookup_entity` + `commit_entity` 在线逐级解析四级实体，
+    四级齐备时 emit `SLOTS_COMPLETE` → `collecting_description`。
+  - `collecting_description`（`llm`）：仅一个**非 HER** 工具 `commit_description`，把用户的自由
+    文本描述写入工作记忆并 emit `DESCRIPTION_READY` → `emit_ticket`。
+  - `emit_ticket`（`action`）：纯函数 handler 从工作记忆**已确认字段**确定性拼装工单
+    （`assembleTicket`，无 LLM），`DONE` → `completed`（终态）。
+- **确定性工单**：最终工单不由 LLM 编写，而是从已验证的 WM 字段组装，因此可被测试精确断言
+  （`src/__tests__/repair-ticketing.e2e.test.ts`）。
+- **可移植内核**：`resolver/EntityResolver.ts`（#167）是纯库——不碰文件系统，JSON 进 / JSON 出。
+  非 TS 调用方可经 CLI 包装器（`bin/entity-resolver`、`scripts/resolver.ts`）复用同一内核。
+
+## HTTP / SSE 接口
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| `GET`  | `/` | 返回 `public/index.html` |
+| `POST` | `/chat` | `{ input, contextId? }` → 跑一轮 → `{ contextId, runId, status, output, workingMemory, ticket }` |
+| `GET`  | `/events/:contextId` | SSE，回放并实时推送 WM 变更事件（`wm.mutated`），驱动 chip 实时更新 |
+
+工单从 `POST /chat` 的 **live 返回值**（`output` / `ticket`）读取，**不读 checkpoint**：
+`emit_ticket → completed` 是终态 turn，按 #172 终态 turn 不落 checkpoint，读 checkpoint 会丢最终态。
+
+## 测试
+
+```bash
+npx jest examples/repair-ticketing
+```
+
+`repair-ticketing.e2e.test.ts` 用确定性 stub gateway 跑通三状态全流程（happy path），断言确定性
+工单，并覆盖解析器的各类返回状态（别名命中 / 缺级 / 歧义 / unknown / invalid_selection / corrected 回退）。
+
+## 不在范围内
+
+- 不改 `resolver/EntityResolver.ts` 与 `src/tools/entity-resolver.ts`（#167 / #166 的产物）。
+- 无热更新、无鉴权、无真实工单系统对接。

--- a/examples/repair-ticketing/public/index.html
+++ b/examples/repair-ticketing/public/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>报修工单 · Repair Ticketing</title>
+<style>
+  :root { --bg:#0f1115; --panel:#181b22; --line:#2a2f3a; --fg:#e6e9ef; --muted:#8b93a3; --accent:#4f9dff; --ok:#3fd07f; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif;
+         background:var(--bg); color:var(--fg); }
+  header { padding:18px 24px; border-bottom:1px solid var(--line); }
+  header h1 { margin:0; font-size:18px; }
+  header p { margin:4px 0 0; color:var(--muted); font-size:13px; }
+  main { display:grid; grid-template-columns: 1fr 360px; gap:20px; padding:20px 24px; max-width:1100px; margin:0 auto; align-items:start; }
+  .panel { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:16px; }
+  .chips { display:flex; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
+  .chip { flex:1 1 0; min-width:72px; text-align:center; padding:8px 6px; border-radius:9px; border:1px solid var(--line);
+          background:#12151c; color:var(--muted); font-size:13px; transition:all .25s; }
+  .chip .lbl { display:block; font-size:11px; opacity:.7; }
+  .chip .val { display:block; margin-top:3px; font-weight:600; min-height:18px; }
+  .chip.filled { border-color:var(--ok); color:var(--fg); background:rgba(63,208,127,.08); }
+  #log { height:340px; overflow-y:auto; display:flex; flex-direction:column; gap:10px; padding-right:4px; }
+  .msg { padding:9px 12px; border-radius:10px; max-width:86%; white-space:pre-wrap; word-break:break-word; }
+  .msg.user { align-self:flex-end; background:var(--accent); color:#fff; }
+  .msg.bot  { align-self:flex-start; background:#22273180; border:1px solid var(--line); }
+  .msg.sys  { align-self:center; color:var(--muted); font-size:12px; background:none; }
+  form { display:flex; gap:8px; margin-top:14px; }
+  textarea { flex:1; resize:none; height:46px; padding:10px 12px; border-radius:10px; border:1px solid var(--line);
+             background:#12151c; color:var(--fg); font:inherit; }
+  button { padding:0 18px; border:none; border-radius:10px; background:var(--accent); color:#fff; font-weight:600; cursor:pointer; }
+  button:disabled { opacity:.5; cursor:default; }
+  h2 { font-size:13px; text-transform:uppercase; letter-spacing:.05em; color:var(--muted); margin:0 0 12px; }
+  .ticket .row { display:flex; justify-content:space-between; gap:10px; padding:7px 0; border-bottom:1px dashed var(--line); font-size:14px; }
+  .ticket .row:last-child { border-bottom:none; }
+  .ticket .k { color:var(--muted); }
+  .ticket .v { font-weight:600; text-align:right; word-break:break-word; }
+  .empty { color:var(--muted); font-size:13px; }
+  .pill { display:inline-block; font-size:11px; padding:2px 8px; border-radius:99px; background:rgba(63,208,127,.15); color:var(--ok); }
+</style>
+</head>
+<body>
+<header>
+  <h1>报修工单助手 <span class="pill">S-011 Path D</span></h1>
+  <p>逐级定位报修对象（站点 → 楼宇 → 部门 → 负责人），描述故障，系统确定性生成工单。</p>
+</header>
+<main>
+  <section class="panel">
+    <div class="chips" id="chips"></div>
+    <div id="log"></div>
+    <form id="form">
+      <textarea id="input" placeholder="例如：总部 / 主楼 / IT网络部 / 王芳 / 投影仪无法开机" autocomplete="off"></textarea>
+      <button id="send" type="submit">发送</button>
+    </form>
+  </section>
+  <aside class="panel">
+    <h2>工单预览</h2>
+    <div id="ticket"><div class="empty">完成全部步骤后，工单将在此生成。</div></div>
+  </aside>
+</main>
+
+<script>
+const SLOTS = [
+  { key: 'site',       label: '站点' },
+  { key: 'building',   label: '楼宇' },
+  { key: 'department', label: '部门' },
+  { key: 'assignee',   label: '负责人' },
+];
+const TICKET_FIELDS = [
+  ['ticketId', '工单号'], ['site', '站点'], ['building', '楼宇'],
+  ['department', '部门'], ['assignee', '负责人'], ['description', '故障描述'], ['createdAt', '创建时间'],
+];
+
+const $ = (id) => document.getElementById(id);
+let contextId = null;
+let evtSource = null;
+
+function renderChips(wm = {}) {
+  $('chips').innerHTML = SLOTS.map(s => {
+    const val = wm[s.key];
+    return `<div class="chip ${val ? 'filled' : ''}">
+      <span class="lbl">${s.label}</span><span class="val">${val ?? '—'}</span></div>`;
+  }).join('');
+}
+
+function addMsg(text, cls) {
+  const el = document.createElement('div');
+  el.className = `msg ${cls}`;
+  el.textContent = text;
+  $('log').appendChild(el);
+  $('log').scrollTop = $('log').scrollHeight;
+}
+
+function renderTicket(ticket) {
+  if (!ticket) return;
+  $('ticket').innerHTML = `<div class="ticket">` + TICKET_FIELDS.map(
+    ([k, label]) => `<div class="row"><span class="k">${label}</span><span class="v">${ticket[k] ?? '—'}</span></div>`
+  ).join('') + `</div>`;
+}
+
+// SSE: live WM-change events fill the slot chips as each commit succeeds.
+function connectStream(id) {
+  if (evtSource) evtSource.close();
+  evtSource = new EventSource(`/events/${encodeURIComponent(id)}`);
+  evtSource.onmessage = (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === 'wm') renderChips(data.snapshot);
+    } catch { /* ignore keep-alives */ }
+  };
+}
+
+async function send(text) {
+  addMsg(text, 'user');
+  $('send').disabled = true;
+  try {
+    const res = await fetch('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ input: text, contextId }),
+    });
+    const data = await res.json();
+    if (data.error) { addMsg('错误：' + data.error, 'sys'); return; }
+
+    if (!contextId) { contextId = data.contextId; connectStream(contextId); }
+    renderChips(data.workingMemory);
+
+    if (data.ticket) {
+      renderTicket(data.ticket);
+      addMsg('✅ 工单已生成：' + data.ticket.ticketId, 'bot');
+    } else {
+      addMsg(data.output || '（已处理）', 'bot');
+    }
+  } catch (err) {
+    addMsg('请求失败：' + err.message, 'sys');
+  } finally {
+    $('send').disabled = false;
+    $('input').focus();
+  }
+}
+
+$('form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = $('input').value.trim();
+  if (!text) return;
+  $('input').value = '';
+  send(text);
+});
+$('input').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); $('form').requestSubmit(); }
+});
+
+renderChips();
+addMsg('请逐条输入：站点、楼宇、部门、负责人，最后描述故障现象。', 'sys');
+</script>
+</body>
+</html>

--- a/examples/repair-ticketing/src/__tests__/repair-ticketing.e2e.test.ts
+++ b/examples/repair-ticketing/src/__tests__/repair-ticketing.e2e.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Issue #162 — repair-ticketing example: the full three-state flow as an e2e.
+ *
+ * This is the coverage the #166 adapter test does NOT provide: the end-to-end
+ * journey through all three FSM states —
+ *   collecting_entities → collecting_description → emit_ticket (action) → completed
+ * — driven by a deterministic stub gateway, asserting the ticket assembled by the
+ * pure-function action handler.
+ *
+ * Two #162 acceptance points are pinned here:
+ *   1. emit_ticket is an `action` state whose handler assembles the ticket
+ *      deterministically from confirmed WM — never LLM-authored.
+ *   2. The ticket is read from the LIVE `milkie.invoke` return value (result.output),
+ *      NOT from a checkpoint: emit_ticket → completed is a terminal turn, and #172
+ *      does not persist a checkpoint for terminal turns, so a checkpoint read would
+ *      drop the final state.
+ *
+ * The error-path block at the bottom exercises every CommitOutput status the
+ * resolver can return (alias / missing / ambiguous / unknown / invalid_selection /
+ * corrected). These overlap with the #166 adapter test by design — #162's
+ * acceptance asks for them in this example's e2e, so they live here too to keep
+ * #162 self-contained.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import type { AgentResult, Message } from '../../../../src/types/common.js'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../../../../src/types/model.js'
+import type { ToolContext, ToolDefinition } from '../../../../src/types/tool.js'
+import { Milkie } from '../../../../src/runtime/Milkie.js'
+import { MemoryStore } from '../../../../src/store/MemoryStore.js'
+import { MemoryEventStore } from '../../../../src/trace/MemoryEventStore.js'
+import { WorkingMemory } from '../../../../src/store/WorkingMemory.js'
+
+import { EntityResolver, type Schema } from '../../resolver/EntityResolver.js'
+import { assembleTicket, buildRepairTicketingTools, repairTicketingAgentConfig } from '../agent.js'
+
+// ─────────────────────────────── Fixtures ────────────────────────────────────
+
+const schema = JSON.parse(
+  readFileSync(join(__dirname, '../../resolver/schema.json'), 'utf8'),
+) as Schema
+const csv = readFileSync(join(__dirname, '../../resolver/data.csv'), 'utf8')
+
+const resolver = EntityResolver.load(schema, csv)
+const tools = buildRepairTicketingTools(resolver)
+const lookupTool = tools.find(t => t.name === 'lookup_entity')!
+const commitTool = tools.find(t => t.name === 'commit_entity')!
+
+// ─────────────────────────── Pure-function assembly ──────────────────────────
+
+describe('assembleTicket (pure, LLM-free)', () => {
+  it('assembles a fully deterministic ticket from confirmed fields (#162)', () => {
+    const ticket = assembleTicket(
+      { site: 'S01', building: 'B01', department: 'D03', assignee: 'E008', description: '投影仪无法开机' },
+      () => '2026-06-16T00:00:00.000Z',  // injected clock → exact, assertable createdAt
+    )
+    expect(ticket).toEqual({
+      ticketId:    'TKT-S01-B01-D03-E008',
+      site:        'S01',
+      building:    'B01',
+      department:  'D03',
+      assignee:    'E008',
+      description: '投影仪无法开机',
+      createdAt:   '2026-06-16T00:00:00.000Z',
+    })
+  })
+})
+
+// ─────────────────────────── Deterministic gateway ───────────────────────────
+
+/**
+ * Drives the whole flow with no live model. Per the active FSM state (tracked by
+ * counting committed entity levels) it issues `lookup_entity` then `commit_entity`
+ * for each of the four levels, then `commit_description` once entities are done.
+ * Selections come from the resolver's own suggestion — the model never invents an
+ * id, and never supplies the utterance/description (the tools read those from the
+ * runtime turn).
+ */
+class RepairTicketGateway implements IModelGateway {
+  private readonly levelOrder = ['site', 'building', 'department', 'assignee']
+  private committed = 0
+
+  async complete(request: ModelRequest): Promise<ModelResponse> {
+    const messages = request.messages
+    const last = messages[messages.length - 1]
+    const producedBy = last && last.role === 'tool' ? this.precedingToolUse(messages) : undefined
+    const result = last && last.role === 'tool' ? this.parseToolResult(last) : null
+
+    if (producedBy === 'lookup_entity') {
+      const level = this.levelOrder[this.committed]!
+      const opts = (result?.['options'] as string[] | undefined) ?? []
+      const selected = (result?.['suggested'] as string | null) ?? opts[0]
+      return this.tool(`commit-${level}`, 'commit_entity', { selected, context: { level } })
+    }
+    if (producedBy === 'commit_entity') {
+      this.committed++
+      return this.text(
+        this.committed >= this.levelOrder.length
+          ? '已登记到负责人，请用一句话描述故障现象。'
+          : '已记录，请继续。',
+      )
+    }
+    if (producedBy === 'commit_description') {
+      return this.text('已记录故障描述。')
+    }
+
+    // Fresh user turn (no preceding tool result).
+    if (this.committed < this.levelOrder.length) {
+      const level = this.levelOrder[this.committed]!
+      return this.tool(`lookup-${level}`, 'lookup_entity', { context: { level } })
+    }
+    // All four levels confirmed → this turn carries the free-text description.
+    return this.tool('commit-desc', 'commit_description', {})
+  }
+
+  async *stream(_request: ModelRequest): AsyncIterable<never> {
+    yield* []
+  }
+
+  private precedingToolUse(messages: Message[]): string | undefined {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]!
+      if (m.role === 'assistant') {
+        const tu = m.content.find(c => c.type === 'tool_use')
+        if (tu && tu.type === 'tool_use') return tu.name
+      }
+    }
+    return undefined
+  }
+
+  private parseToolResult(m: Message): Record<string, unknown> | null {
+    const part = m.content.find(c => c.type === 'tool_result')
+    if (!part || part.type !== 'tool_result') return null
+    try {
+      return JSON.parse(part.content) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+
+  private text(text: string): ModelResponse {
+    return { content: [{ type: 'text', text }], toolCalls: [], finishReason: 'end_turn' }
+  }
+
+  private tool(id: string, name: string, input: unknown): ModelResponse {
+    return {
+      content:      [{ type: 'tool_use', id, name, input }],
+      toolCalls:    [{ id, name, input }],
+      finishReason: 'tool_use',
+    }
+  }
+}
+
+// ─────────────────────────── Happy path (full FSM) ───────────────────────────
+
+describe('repair-ticketing — happy path through emit_ticket (FSM e2e)', () => {
+  const DESCRIPTION = '三楼会议室的投影仪无法开机'
+  const contextId = `ctx-repair-ticket-${Date.now()}`
+  let milkie: Milkie
+  let lastResult: AgentResult
+
+  async function sendTurn(input: string): Promise<AgentResult> {
+    return milkie.invoke({ agentId: 'repair-ticketing', goal: '登记一张报修工单', input, contextId })
+  }
+
+  beforeAll(async () => {
+    milkie = new Milkie({
+      stateStore: new MemoryStore(),
+      eventStore: new MemoryEventStore(),
+      gateway:    new RepairTicketGateway(),
+    })
+    for (const tool of tools) milkie.registerTool(tool)
+    milkie.registerAgent(repairTicketingAgentConfig)
+
+    await sendTurn('总部')          // → site S01
+    await sendTurn('主楼')          // → building B01
+    await sendTurn('IT网络部')      // → department D03
+    await sendTurn('王芳')          // → assignee E008 → SLOTS_COMPLETE → collecting_description
+    lastResult = await sendTurn(DESCRIPTION)  // → commit_description → emit_ticket → completed
+  }, 60_000)
+
+  it('reaches a completed terminal turn', () => {
+    expect(lastResult.status).toBe('completed')
+  })
+
+  it('emits the ticket on the live invoke output, deterministically assembled from WM (#162)', () => {
+    // Read the ticket from the LIVE return value — not a checkpoint (#172: the
+    // terminal turn persists none).
+    const ticket = JSON.parse(lastResult.output)
+    expect(ticket).toMatchObject({
+      ticketId:    'TKT-S01-B01-D03-E008',
+      site:        'S01',
+      building:    'B01',
+      department:  'D03',
+      assignee:    'E008',
+      description: DESCRIPTION,
+    })
+    // createdAt is a system timestamp — assert its shape, not an exact value.
+    expect(ticket.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+})
+
+// ─────────────────────────── Error paths (resolver statuses) ──────────────────
+
+function makeCtx(currentTurn: string, preset: Record<string, string> = {}): {
+  ctx: ToolContext; emitted: string[]; wm: WorkingMemory
+} {
+  const emitted: string[] = []
+  const wm = new WorkingMemory()
+  for (const [k, v] of Object.entries(preset)) wm.set(k, v)
+  const ctx = {
+    workingMemory: wm,
+    emit: (event: string) => { emitted.push(event) },
+    currentTurn,
+  } as unknown as ToolContext
+  return { ctx, emitted, wm }
+}
+
+const lookup = (tool: ToolDefinition, level: string, ctx: ToolContext) =>
+  tool.handler({ context: { level } }, ctx) as Promise<{ options: string[]; suggested: string | null }>
+
+const commit = (tool: ToolDefinition, selected: string, level: string, ctx: ToolContext) =>
+  tool.handler({ selected, context: { level } }, ctx) as Promise<{
+    resolved?: { id: string }; corrected?: Record<string, string>; validationError?: string
+  }>
+
+describe('repair-ticketing — every resolver status reachable through the tools (#162)', () => {
+  it('alias match: a department alias resolves and is suggested', async () => {
+    const { ctx } = makeCtx('硬件部', { site: 'S01', building: 'B01' })
+    const out = await lookup(lookupTool, 'department', ctx)
+    expect(out.options).toContain('D02')   // 硬件部 = alias of IT硬件组 (D02)
+    expect(out.suggested).toBe('D02')
+  })
+
+  it('missing-level: an under-selection at the wrong level is rejected', async () => {
+    const { ctx, wm } = makeCtx('总部')
+    const out = await commit(commitTool, 'B01', 'site', ctx)  // B01 is a building, not a site
+    expect(out.validationError).toBeDefined()
+    expect(wm.get('site')).toBeUndefined()
+  })
+
+  it('ambiguous: multiple equally-scored candidates yield no suggestion', async () => {
+    const { ctx } = makeCtx('张', { site: 'S01', building: 'B01', department: 'D03' })
+    const out = await lookup(lookupTool, 'assignee', ctx)
+    expect(out.options.length).toBeGreaterThanOrEqual(2)  // 张伟(E007) + 张亮(E009)
+    expect(out.suggested).toBeNull()
+  })
+
+  it('unknown: an id that exists at no level is rejected', async () => {
+    const { ctx, wm } = makeCtx('总部')
+    const out = await commit(commitTool, 'ZZZ', 'site', ctx)
+    expect(out.validationError).toBeDefined()
+    expect(wm.get('site')).toBeUndefined()
+  })
+
+  it('invalid_selection: a selection conflicting with the pinned branch and uncorrectable is rejected', async () => {
+    // pinned 总部/东楼 (S01/B02); E020 lives under 分部 (S02) with no same-label
+    // sibling under the pinned branch → no correction possible.
+    const { ctx, wm } = makeCtx('赵明', { site: 'S01', building: 'B02' })
+    const out = await commit(commitTool, 'E020', 'assignee', ctx)
+    expect(out.validationError).toBeDefined()
+    expect(wm.get('assignee')).toBeUndefined()
+  })
+
+  it('corrected: a selection conflicting with the pinned branch auto-corrects to the same-label sibling', async () => {
+    // pinned 总部/主楼 (S01/B01); E012 (张伟, under B02/D07) auto-corrects to the
+    // same-label E007 (张伟, under B01/D03).
+    const { ctx, wm } = makeCtx('张伟', { site: 'S01', building: 'B01' })
+    const out = await commit(commitTool, 'E012', 'assignee', ctx)
+    expect(out.resolved?.id).toBe('E007')
+    expect(out.corrected).toMatchObject({ department: 'D03' })
+    expect(wm.get('assignee')).toBe('E007')
+  })
+})

--- a/examples/repair-ticketing/src/agent.ts
+++ b/examples/repair-ticketing/src/agent.ts
@@ -1,0 +1,185 @@
+// Repair-ticketing agent — the web UI layer over the portable hierarchical
+// entity resolver (#162 / S-011 Path D).
+//
+// Three-state FSM:
+//   collecting_entities  (llm)    lookup_entity + commit_entity resolve the four
+//                                 hierarchy levels in-process; SLOTS_COMPLETE →
+//                                 collecting_description.
+//   collecting_description (llm)  one NON-HER tool, commit_description, records
+//                                 the user's free-text fault description into WM
+//                                 and fires DESCRIPTION_READY → emit_ticket.
+//   emit_ticket          (action) a pure, LLM-free handler that assembles the
+//                                 final ticket from the already-confirmed WM
+//                                 fields; DONE → completed (terminal).
+//
+// Why collecting_description carries a tool at all: an `llm` state can only fire
+// a named business event (DESCRIPTION_READY) from a tool's `ctx.emit`, and the
+// emit_ticket handler reads `description` from WM — so *something* must both
+// write the description and emit. commit_description is that something. It is not
+// a hierarchical-entity (HER) tool, honoring "no HER tools" while keeping the
+// state self-consistent. Like the HER tools, it takes the description from the
+// runtime turn (`ctx.currentTurn`), never from an LLM-supplied parameter, so the
+// stored description is the user's verbatim words — not a model paraphrase.
+
+import type { AgentConfig } from '../../../src/types/agent.js'
+import type { ToolContext, ToolDefinition } from '../../../src/types/tool.js'
+import type { EntityResolver } from '../resolver/EntityResolver.js'
+import { makeEntityResolverTools } from './tools/entity-resolver.js'
+
+/** Ordered hierarchy levels that must all be confirmed before SLOTS_COMPLETE. */
+export const REQUIRED_SLOTS = ['site', 'building', 'department', 'assignee'] as const
+
+/**
+ * The structured repair ticket. Every field is derived deterministically from
+ * confirmed working-memory state — the LLM never authors this object (#162: the
+ * final ticket is assembled from verified WM, not invented by the model, so it
+ * can be asserted in tests).
+ */
+export interface Ticket {
+  ticketId:    string
+  site:        string
+  building:    string
+  department:  string
+  assignee:    string
+  description: string
+  createdAt:   string
+}
+
+/**
+ * Pure-function ticket assembly. No LLM, no I/O, no hidden state — given the same
+ * confirmed fields and the same clock it returns the same ticket, so callers can
+ * assert the whole object exactly (inject `now` in tests for a fixed timestamp).
+ *
+ * `ticketId` is a deterministic function of the four resolved entity ids, so two
+ * tickets for the same target collide by design — fine for a demo, and it keeps
+ * the id assertable without a counter or RNG.
+ */
+export function assembleTicket(
+  fields: { site: string; building: string; department: string; assignee: string; description: string },
+  now: () => string = () => new Date().toISOString(),
+): Ticket {
+  return {
+    ticketId:    `TKT-${fields.site}-${fields.building}-${fields.department}-${fields.assignee}`,
+    site:        fields.site,
+    building:    fields.building,
+    department:  fields.department,
+    assignee:    fields.assignee,
+    description: fields.description,
+    createdAt:   now(),
+  }
+}
+
+/**
+ * `commit_description` — the lone tool of `collecting_description`. Records the
+ * free-text fault description into WM and fires DESCRIPTION_READY. The text is
+ * read from `ctx.currentTurn` (the trusted runtime turn), NOT a tool parameter,
+ * mirroring the HER adapter's trust boundary.
+ */
+export function makeCommitDescriptionTool(): ToolDefinition {
+  return {
+    name: 'commit_description',
+    description:
+      '记录用户对故障现象的自由文本描述。系统会自动采用用户本轮的原始输入作为描述内容——' +
+      '你无需传入任何参数，只需在用户给出描述后调用本工具。确认后进入工单生成阶段。',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async (_input: unknown, ctx: ToolContext): Promise<unknown> => {
+      const description = (ctx.currentTurn ?? '').trim()
+      ctx.workingMemory.set('description', description)
+      ctx.emit('DESCRIPTION_READY')
+      return { description }
+    },
+  }
+}
+
+/**
+ * `assemble_ticket` — the handler for the `emit_ticket` action state. Reads the
+ * confirmed fields from WM and assembles the ticket deterministically (no LLM).
+ *
+ * The handler's return value becomes the run's `lastTextOutput` →
+ * `AgentResult.output`. That is deliberate: `emit_ticket → completed` is a
+ * terminal turn, which per #172 does NOT persist a checkpoint, so the ticket is
+ * only reliably available from the live `milkie.invoke` return value. Callers
+ * (server, e2e) read it there — never from a checkpoint.
+ */
+export function makeAssembleTicketTool(): ToolDefinition {
+  return {
+    name: 'assemble_ticket',
+    description: 'Action 处理器：从工作记忆已确认字段确定性拼装报修工单（纯函数，无 LLM）。',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async (_input: unknown, ctx: ToolContext): Promise<unknown> => {
+      const get = (key: string): string => {
+        const value = ctx.workingMemory.get(key)
+        if (value == null || value === '') {
+          throw new Error(`assemble_ticket: working memory missing confirmed field "${key}"`)
+        }
+        return String(value)
+      }
+      const ticket = assembleTicket({
+        site:        get('site'),
+        building:    get('building'),
+        department:  get('department'),
+        assignee:    get('assignee'),
+        description: get('description'),
+      })
+      ctx.workingMemory.set('ticket', ticket)
+      return JSON.stringify(ticket)
+    },
+  }
+}
+
+/**
+ * Wire the full tool set for the example over a loaded resolver: the HER pair
+ * (`lookup_entity` + `commit_entity`), `commit_description`, and the
+ * `assemble_ticket` action handler. Shared by the server and the e2e so both
+ * drive the identical agent.
+ */
+export function buildRepairTicketingTools(resolver: EntityResolver): ToolDefinition[] {
+  return [
+    ...makeEntityResolverTools(resolver, [...REQUIRED_SLOTS]),
+    makeCommitDescriptionTool(),
+    makeAssembleTicketTool(),
+  ]
+}
+
+export const repairTicketingAgentConfig: AgentConfig = {
+  agentId:      'repair-ticketing',
+  version:      '1.0.0',
+  systemPrompt:
+    `你是报修工单助手，按以下流程协助用户：
+1. 逐级定位报修对象（站点 → 楼宇 → 部门 → 负责人）。对每一级：先调用 lookup_entity 检索候选，再调用 commit_entity 确认其中一个候选。系统会自动以用户本轮原话作为查询，你只需指定 level。
+2. 四级全部确认后，请用户用一句话描述故障现象（位置 + 问题）。用户描述后调用 commit_description（描述内容由系统自动采集，无需传参）。
+3. 系统随后自动生成结构化工单。`,
+  fsm: {
+    states: [
+      {
+        name:  'collecting_entities',
+        type:  'llm',
+        tools: ['lookup_entity', 'commit_entity'],
+        on:    { SLOTS_COMPLETE: 'collecting_description' },
+      },
+      {
+        name:         'collecting_description',
+        type:         'llm',
+        tools:        ['commit_description'],
+        instructions: '请用户用一句话描述故障现象（所在位置 + 具体问题）。用户给出描述后调用 commit_description。',
+        on:           { DESCRIPTION_READY: 'emit_ticket' },
+      },
+      {
+        // Action state: the handler assembles the ticket deterministically and
+        // auto-DONEs (no ctx.emit) → completed.
+        name:    'emit_ticket',
+        type:    'action',
+        handler: 'assemble_ticket',
+        on:      { DONE: 'completed' },
+      },
+      {
+        // Terminal: executeFSM breaks on entry (non-llm + terminal), so no extra
+        // LLM call happens after the ticket is assembled.
+        name:     'completed',
+        type:     'action',
+        terminal: true,
+      },
+    ],
+  },
+  model: { provider: 'volcengine', model: 'doubao-seed-2.0-lite', adapter: 'openai-compatible' },
+}

--- a/examples/repair-ticketing/src/server.ts
+++ b/examples/repair-ticketing/src/server.ts
@@ -1,0 +1,214 @@
+// Repair-ticketing playground server (#162 / S-011 Path D as a UI).
+//
+// Plain node `http` — no framework — matching the agent-docs-qa example. Three
+// routes:
+//   GET  /                     → serve public/index.html
+//   POST /chat                 → run one milkie turn; return status/output, the
+//                                reconstructed workingMemory, and the assembled
+//                                ticket (parsed from the live invoke output).
+//   GET  /events/:contextId    → SSE stream of WM-change events (wm.mutated) so
+//                                the UI fills slot chips in real time.
+//
+// The model is the agent's own (volcengine doubao via openai-compatible); set the
+// provider credentials in the environment before running. Tests inject a
+// deterministic gateway instead — see src/__tests__/repair-ticketing.e2e.test.ts.
+
+import http, { type IncomingMessage, type ServerResponse, type Server } from 'http'
+import { promises as fs, readFileSync } from 'fs'
+import path from 'path'
+import { v4 as uuidv4 } from 'uuid'
+
+import { Milkie } from '../../../src/runtime/Milkie.js'
+import { MemoryStore } from '../../../src/store/MemoryStore.js'
+import { MemoryEventStore } from '../../../src/trace/MemoryEventStore.js'
+import { BroadcastingEventStore } from '../../../src/trace/BroadcastingEventStore.js'
+import type { IModelGateway } from '../../../src/types/model.js'
+import type { Event } from '../../../src/trace/types.js'
+
+import { EntityResolver, type Schema } from '../resolver/EntityResolver.js'
+import { buildRepairTicketingTools, repairTicketingAgentConfig, type Ticket } from './agent.js'
+
+export interface ServerConfig {
+  port:        number
+  exampleDir:  string
+  /** Test injection. When omitted Milkie falls back to the agent's own model. */
+  gateway?:    IModelGateway
+}
+
+interface ServerState {
+  milkie:     Milkie
+  eventStore: BroadcastingEventStore
+  publicDir:  string
+  /** All runIds seen per contextId, oldest-first — for SSE catch-up across turns. */
+  runsByContext: Map<string, string[]>
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', c => chunks.push(c as Buffer))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+/** A `wm.mutated` payload carries the full WorkingMemory as `{ data, log }`;
+ *  the UI only wants the flat field map under `data`. */
+function flatData(snapshot: unknown): Record<string, unknown> {
+  return (snapshot as { data?: Record<string, unknown> } | null)?.data ?? {}
+}
+
+/** The cumulative WM field map for a run = its last `wm.mutated` snapshot (each
+ *  snapshot is the full WorkingMemory, not a delta). Empty object if the run made
+ *  no tool-driven WM writes. */
+function latestWorkingMemory(events: Event[]): Record<string, unknown> {
+  let data: Record<string, unknown> = {}
+  for (const e of events) {
+    if (e.type === 'wm.mutated') {
+      data = flatData((e.payload as { snapshot: unknown }).snapshot)
+    }
+  }
+  return data
+}
+
+/** Parse the live invoke output as a ticket, or null when this turn produced
+ *  plain text (every turn before emit_ticket). */
+function parseTicket(output: string): Ticket | null {
+  try {
+    const parsed = JSON.parse(output) as Partial<Ticket>
+    return parsed && typeof parsed === 'object' && typeof parsed.ticketId === 'string'
+      ? (parsed as Ticket)
+      : null
+  } catch {
+    return null
+  }
+}
+
+async function handleChat(req: IncomingMessage, res: ServerResponse, s: ServerState): Promise<void> {
+  const { input, contextId } = JSON.parse(await readBody(req)) as { input: string; contextId?: string }
+  if (!input) { sendJson(res, 400, { error: 'input required' }); return }
+
+  const ctxId  = contextId ?? uuidv4()
+  const result = await s.milkie.invoke({
+    agentId:   repairTicketingAgentConfig.agentId,
+    goal:      '登记一张报修工单',
+    input,
+    contextId: ctxId,
+  })
+
+  const runs = s.runsByContext.get(ctxId) ?? []
+  runs.push(result.agentRunId)
+  s.runsByContext.set(ctxId, runs)
+
+  const events = await s.eventStore.readByRunId(result.agentRunId)
+  sendJson(res, 200, {
+    contextId:     ctxId,
+    runId:         result.agentRunId,
+    status:        result.status,
+    output:        result.output,
+    workingMemory: latestWorkingMemory(events),
+    // Read from the live invoke output, NOT a checkpoint: emit_ticket → completed
+    // is a terminal turn and #172 does not persist a checkpoint for it.
+    ticket:        parseTicket(result.output),
+  })
+}
+
+async function handleSse(req: IncomingMessage, res: ServerResponse, s: ServerState, contextId: string): Promise<void> {
+  res.writeHead(200, {
+    'content-type':      'text/event-stream',
+    'cache-control':     'no-cache',
+    'connection':        'keep-alive',
+    'x-accel-buffering': 'no',
+  })
+
+  const write = (event: Event): void => {
+    if (event.type === 'wm.mutated' && !res.writableEnded) {
+      const snapshot = flatData((event.payload as { snapshot: unknown }).snapshot)
+      res.write(`data: ${JSON.stringify({ type: 'wm', snapshot })}\n\n`)
+    }
+  }
+
+  // Catch-up: replay past WM-change events across every turn of this context.
+  for (const runId of s.runsByContext.get(contextId) ?? []) {
+    for (const e of await s.eventStore.readByRunId(runId)) write(e)
+  }
+
+  const unsubscribe = s.eventStore.subscribe(contextId, write)
+  req.on('close', () => {
+    unsubscribe()
+    if (!res.writableEnded) res.end()
+  })
+}
+
+async function serveIndex(res: ServerResponse, publicDir: string): Promise<void> {
+  try {
+    const html = await fs.readFile(path.join(publicDir, 'index.html'), 'utf-8')
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end(html)
+  } catch {
+    res.writeHead(404).end()
+  }
+}
+
+export async function startServer(config: ServerConfig): Promise<Server> {
+  const resolverDir = path.join(config.exampleDir, 'resolver')
+  const schema = JSON.parse(readFileSync(path.join(resolverDir, 'schema.json'), 'utf-8')) as Schema
+  const csv    = readFileSync(path.join(resolverDir, 'data.csv'), 'utf-8')
+  const resolver = EntityResolver.load(schema, csv)
+
+  const eventStore = new BroadcastingEventStore(new MemoryEventStore())
+  const milkie = new Milkie({
+    stateStore: new MemoryStore(),
+    eventStore,
+    gateway:    config.gateway,   // omitted → Milkie builds the agent's own model gateway
+  })
+  for (const tool of buildRepairTicketingTools(resolver)) milkie.registerTool(tool)
+  milkie.registerAgent(repairTicketingAgentConfig)
+
+  const state: ServerState = {
+    milkie,
+    eventStore,
+    publicDir:     path.join(config.exampleDir, 'public'),
+    runsByContext: new Map(),
+  }
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const route = new URL(req.url ?? '/', 'http://localhost').pathname
+
+      if (req.method === 'POST' && route === '/chat') return handleChat(req, res, state)
+
+      const sse = route.match(/^\/events\/([^/]+)$/)
+      if (req.method === 'GET' && sse) return handleSse(req, res, state, decodeURIComponent(sse[1]!))
+
+      if (req.method === 'GET' && (route === '/' || route === '/index.html')) {
+        return serveIndex(res, state.publicDir)
+      }
+      res.writeHead(404).end()
+    } catch (err) {
+      sendJson(res, 500, { error: (err as Error).message })
+    }
+  })
+
+  await new Promise<void>(resolve => server.listen(config.port, () => resolve()))
+  return server
+}
+
+export async function stopServer(server: Server): Promise<void> {
+  await new Promise<void>(resolve => server.close(() => resolve()))
+}
+
+// CLI entry — only when run directly (`npx tsx src/server.ts`). Tests import
+// startServer/stopServer and inject their own gateway. __dirname keeps this
+// compatible with both ts-jest (CommonJS) and tsx.
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)
+if (isMain) {
+  const PORT = Number(process.env.PORT ?? 7979)
+  startServer({ port: PORT, exampleDir: path.dirname(__dirname) })
+    .then(() => console.log(`repair-ticketing playground at http://localhost:${PORT}`))
+}


### PR DESCRIPTION
Closes #162

实现 issue #162 已批准的 implement 计划（comment 4718199299，👍）：为层级实体报修工单补齐 example 的 Web UI 层 + e2e。范围仅 `examples/repair-ticketing/`，不改 `resolver/` 与 `src/tools/`。

## 交付
- **`src/agent.ts`** — 三状态 FSM
  - `collecting_entities`（`llm`：`lookup_entity` + `commit_entity`，`SLOTS_COMPLETE` → 下一态）
  - `collecting_description`（`llm`：仅一个**非 HER** 工具 `commit_description`，从 `ctx.currentTurn` 读自由描述写入 WM 并 emit `DESCRIPTION_READY`）
  - `emit_ticket`（**`action`**：纯函数 `assembleTicket` 从已确认 WM 字段确定性拼装工单，**无 LLM**），`DONE` → `completed`（终态）
- **`src/server.ts`** — 原生 node http：`GET /` · `POST /chat` · `GET /events/:contextId`（SSE 推 `wm.mutated`）
- **`public/index.html`** — 自包含 HTML+JS：4 个 slot chip 实时填充 + 工单卡片
- **`README.md`**
- **`src/__tests__/repair-ticketing.e2e.test.ts`** — 全流程 happy path（确定性 stub gateway）+ 确定性工单断言 + 六类解析器状态（别名/缺级/歧义/unknown/invalid_selection/corrected）

## 落实的两条 #162 硬验收
1. `emit_ticket` 为 `type: 'action'` 纯函数确定性组装，不让 LLM 编最终工单 JSON。
2. e2e 工单从 **live `milkie.invoke` 返回值**（`result.output`）断言，**不读 checkpoint**——`emit_ticket → completed` 是终态 turn，按 #172 终态 turn 不落 checkpoint。

## 一处自洽性说明
批准计划写 `collecting_description`"no tools"，但同时要求 `on DESCRIPTION_READY` 且 `emit_ticket` 从 WM 读 `description`——这在 LLM 状态里内部矛盾（无工具则无人 emit 业务事件、无人写 WM）。按 issue body 原话"no **HER** tools"实现：该状态带非 HER 工具 `commit_description`，描述从运行时 turn 读、不让 LLM 编造。已在代码注释标注。

## 验证
- `npx jest examples/repair-ticketing` → **80 passed**；examples 全量 **157 passed**
- `server.ts` `tsc --noEmit` 通过
- HTTP 冒烟：`GET /` 出 HTML、`POST /chat` 槽位逐轮填充、终轮出工单 `TKT-S01-B01-D03-E008`、SSE 推扁平 WM 帧

🤖 Generated with [Claude Code](https://claude.com/claude-code)