### PR TITLE
fix(#178): commit_entity 容错字符串化 context，按 level 名落 WM 键

### DIFF
--- a/examples/repair-ticketing/src/__tests__/entity-resolver.e2e.test.ts
+++ b/examples/repair-ticketing/src/__tests__/entity-resolver.e2e.test.ts
@@ -138,6 +138,33 @@ describe('commit_entity handler', () => {
     expect(emitted).toEqual([])              // not all slots yet
   })
 
+  it('tolerates a stringified `context` and keys WM by the level name, not a numeric fallback', async () => {
+    // Regression: some models (e.g. DeepSeek) serialize the nested `context`
+    // object as a JSON *string*. Unparsed, `context.level` reads undefined and the
+    // slot lands under a numeric path-length key (e.g. "1"), so requiredSlots stay
+    // permanently incomplete. The handler must parse the string form.
+    const { ctx, wm } = makeCtx('总部')
+    const out = (await commitTool.handler(
+      { selected: 'S01', context: '{"level":"site"}' },   // context as a JSON string
+      ctx,
+    )) as { resolved?: { id: string }; validationError?: string }
+    expect(out.validationError).toBeUndefined()
+    expect(out.resolved?.id).toBe('S01')
+    expect(wm.get('site')).toBe('S01')      // keyed by level name…
+    expect(wm.get('1')).toBeUndefined()     // …NOT the numeric path-length fallback
+  })
+
+  it('rejects a commit with no resolvable level instead of writing a numeric key', async () => {
+    const { ctx, wm } = makeCtx('总部')
+    const out = (await commitTool.handler(
+      { selected: 'S01' },                  // no context at all → no level
+      ctx,
+    )) as { validationError?: string }
+    expect(out.validationError).toBeDefined()
+    expect(wm.get('site')).toBeUndefined()
+    expect(wm.get('1')).toBeUndefined()
+  })
+
   it('emits SLOTS_COMPLETE once every required level is in WM (AC8)', async () => {
     const { ctx, emitted, wm } = makeCtx('王芳', { site: 'S01', building: 'B01', department: 'D03' })
     const out = (await commitTool.handler(

--- a/examples/repair-ticketing/src/tools/entity-resolver.ts
+++ b/examples/repair-ticketing/src/tools/entity-resolver.ts
@@ -51,6 +51,21 @@ interface CommitToolOutput {
  * @param requiredSlots ordered level names that must all be present in WM before
  *                      `SLOTS_COMPLETE` fires (e.g. ['site','building','department','assignee']).
  */
+/**
+ * Coerce a tool's `context` argument into an object. Some models (e.g. DeepSeek)
+ * serialize nested-object parameters as a JSON *string* instead of a JSON object;
+ * left unparsed, `context.level` would read `undefined` and the slot would be
+ * written under the wrong key. Parse a string form defensively; pass an object
+ * through; anything else → undefined.
+ */
+function coerceContext<T extends object>(raw: unknown): T | undefined {
+  if (raw == null) return undefined
+  if (typeof raw === 'string') {
+    try { return JSON.parse(raw) as T } catch { return undefined }
+  }
+  return typeof raw === 'object' ? raw as T : undefined
+}
+
 export function makeEntityResolverTools(
   resolver: EntityResolver,
   requiredSlots: string[],
@@ -92,7 +107,7 @@ export function makeEntityResolverTools(
       required: ['context'],
     },
     handler: async (input: unknown, ctx: ToolContext): Promise<unknown> => {
-      const { context } = (input ?? {}) as LookupInput
+      const context = coerceContext<NonNullable<LookupInput['context']>>((input as LookupInput)?.context)
       // Utterance comes from the runtime turn, NOT from the LLM tool params.
       const utterance = ctx.currentTurn ?? ''
       return resolver.lookup({
@@ -122,8 +137,16 @@ export function makeEntityResolverTools(
       required: ['selected', 'context'],
     },
     handler: async (input: unknown, ctx: ToolContext): Promise<unknown> => {
-      const { selected, context } = (input ?? {}) as CommitInput
+      const { selected } = (input ?? {}) as CommitInput
+      const context = coerceContext<NonNullable<CommitInput['context']>>((input as CommitInput)?.context)
       const level = context?.level
+      // The WM slot key IS the level name. Without a level we cannot key the slot
+      // correctly — fail loudly rather than silently writing under a numeric
+      // fallback key (which leaves requiredSlots permanently incomplete).
+      if (!level) {
+        const errorOutput: CommitToolOutput = { validationError: 'commit_entity: missing level in context' }
+        return errorOutput
+      }
       const result = resolver.commit({
         selected: selected ?? '',
         level,
@@ -132,8 +155,7 @@ export function makeEntityResolverTools(
 
       if (result.status === 'complete' || result.status === 'corrected') {
         // WM key = level name; value = the resolved entity id.
-        const key = level ?? result.resolved.path.length.toString()
-        ctx.workingMemory.set(key, result.resolved.id)
+        ctx.workingMemory.set(level, result.resolved.id)
         if (slotsComplete(ctx)) ctx.emit('SLOTS_COMPLETE')
 
         // `corrected` is a Record<string,string> (level → corrected id), per


### PR DESCRIPTION
## 问题

真实 LLM（如 DeepSeek）调用 `commit_entity` 时把嵌套对象参数 `context` 序列化成 **JSON 字符串**，handler 直接 `context?.level` 取到 `undefined`，命中 `path.length` 数字键兜底 → 槽位写进 `"3"` 而非 `department` → `SLOTS_COMPLETE` 永不触发、工单凑不齐。属确定性 correctness bug（非模型质量），在 #174 live eval 中把端到端通过率压到接近 0。

## 修复（`examples/repair-ticketing/src/tools/entity-resolver.ts`）

1. `lookup_entity` / `commit_entity` 用 `coerceContext` 容错解析字符串化的 `context`。
2. 去掉危险的 `path.length` 数字键兜底——无可解析 level 时返回 `validationError`，绝不静默写错键。

## 验证

- 新增 2 个回归测试：context 传 JSON 字符串时 WM 必须按 level 名落键；无 level 时拒绝而非写数字键。
- `examples/repair-ticketing` 全部测试通过（含确定性 e2e + scoring）。
- 不改 lookup/commit 契约语义，对传规范对象的既有调用零影响。

## 范围

仅此一处适配器修复。提示词改进、eval 模型 override、以及"LLM 归一化→resolver 校验"的语义鲁棒性设计另行处理（后续 issue）。

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)