### PR TITLE
【runtime】de-core 收尾：清除 pendingEvents 残骸与已死的 FSMEngine.snapshot/restore

### DIFF
--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -236,6 +236,8 @@ describe('AgentRuntime', () => {
       expect(checkpoint.lifecycle?.status).toBe('interrupted')
       expect(checkpoint.lifecycle?.resumeKind).toBe('loop')
       expect(checkpoint.fsm).toBeUndefined()
+      // #181: the #60 pendingEvents residue is gone — never written to checkpoints.
+      expect(checkpoint.pendingEvents).toBeUndefined()
       expect(checkpoint.meta.contextId).toBe('ctx-interrupt')
       expect(checkpoint.meta.agentRunId).toBe(result.agentRunId)
     })

--- a/src/__tests__/FSMEngine.test.ts
+++ b/src/__tests__/FSMEngine.test.ts
@@ -107,48 +107,4 @@ describe('FSMEngine', () => {
       expect(() => fsm.transitionTo('handle_a')).toThrow(/unknown state/)
     })
   })
-
-  describe('snapshot / restore', () => {
-    it('snapshots the current user state', () => {
-      const fsm = new FSMEngine(reactFSM)
-      const snap = fsm.snapshot()
-      expect(snap.currentState).toBe('react')
-    })
-
-    it('carries the optional resumeState through the snapshot', () => {
-      const fsm = new FSMEngine(reactFSM)
-      fsm.transitionTo('paused')
-      const snap = fsm.snapshot('react')
-      expect(snap.currentState).toBe('paused')
-      expect(snap.resumeState).toBe('react')
-    })
-
-    it('restores a user state from a snapshot', () => {
-      const fsm = new FSMEngine(terminalFSM)
-      fsm.transitionTo('end')
-      const snap = fsm.snapshot()
-      expect(snap.currentState).toBe('end')
-
-      const fsm2 = new FSMEngine(terminalFSM)
-      fsm2.restore(snap)
-      expect(fsm2.currentStateName).toBe('end')
-      expect(fsm2.isTerminal()).toBe(true)
-    })
-
-    it('restores a reserved lifecycle state from a snapshot', () => {
-      const fsm = new FSMEngine(reactFSM)
-      fsm.transitionTo('paused')
-      const snap = fsm.snapshot('react')
-
-      const fsm2 = new FSMEngine(reactFSM)
-      fsm2.restore(snap)
-      expect(fsm2.currentStateName).toBe('paused')
-      expect(fsm2.isTerminal()).toBe(true)
-    })
-
-    it('throws when restoring an unknown state', () => {
-      const fsm = new FSMEngine(reactFSM)
-      expect(() => fsm.restore({ currentState: 'ghost' })).toThrow(/unknown state/)
-    })
-  })
 })

--- a/src/fsm/FSMEngine.ts
+++ b/src/fsm/FSMEngine.ts
@@ -79,25 +79,4 @@ export class FSMEngine {
   getState(name: string): FSMState | undefined {
     return this.states.get(name)
   }
-
-  snapshot(resumeState?: string): { currentState: string; resumeState?: string; stateData: unknown } {
-    return { currentState: this.current.name, resumeState, stateData: null }
-  }
-
-  restore(snapshot: { currentState: string }): void {
-    if (RESERVED_STATES.includes(snapshot.currentState as typeof RESERVED_STATES[number])) {
-      this.current = {
-        name:     snapshot.currentState,
-        type:     'action',
-        terminal: snapshot.currentState === 'paused' || snapshot.currentState === 'failed',
-      }
-      return
-    }
-
-    const state = this.states.get(snapshot.currentState)
-    if (!state) {
-      throw new Error(`FSM restore: unknown state "${snapshot.currentState}"`)
-    }
-    this.current = state
-  }
 }

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -144,7 +144,6 @@ export class AgentRuntime {
   private readonly factory:     AgentFactory
 
   private eventQueue:    Array<{ type: string; payload: unknown }> = []
-  private pendingEvents: Array<{ type: string; payload: unknown }> = []
   private pendingSkillLoads: Array<SkillLoadRequest> = []
   private loadedSkills: Map<string, SkillLifecyclePayload> = new Map()
   private pendingTraceWrites: Promise<unknown>[] = []
@@ -831,7 +830,8 @@ export class AgentRuntime {
       err.name = 'InterruptSignal'
       throw err
     }
-    this.pendingEvents.push(event)
+    // #181: eventQueue only ever carries 'interrupt' (which threw above), so the
+    // old `pendingEvents.push(event)` was unreachable — removed with the field.
   }
 
   // #73: build the resume-state checkpoint object. checkpointId is a content-free
@@ -852,7 +852,6 @@ export class AgentRuntime {
         workingMemory: this.memory.toJSON(),
         regions:       this.regions.snapshot(),
       },
-      pendingEvents: this.pendingEvents.map(e => ({ type: e.type, payload: e.payload })),
       children:      Array.from(this.childRecords.values()),
       meta: {
         agentId:       this.config.agentId,

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -43,7 +43,9 @@ export interface AgentCheckpoint {
     instructions?:        Record<string, string>
     contextEpoch?:        number
   }
-  pendingEvents: AgentEvent[]
+  // #181: de-core removed the #60 pendingEvents queue; the runtime no longer
+  // writes this. Optional so historical (v1) checkpoints that carry it still parse.
+  pendingEvents?: AgentEvent[]
   children: ChildAgentRecord[]
   meta: {
     agentId:        string


### PR DESCRIPTION
## 摘要

#175 de-core 后两处 **inert 死代码**收尾（PR #177 当时因 D7 敏感刻意未清）。

### 1. 移除 `#60` `pendingEvents` 残骸
de-core 后 `eventQueue` 只进 `{type:'interrupt'}`，interrupt 分支先 `throw`，故 `checkEvents` 末尾 `this.pendingEvents.push` **不可达**、字段恒空，却仍被 `buildCheckpoint` 序列化进 checkpoint。
- 删字段 + 不可达 push + buildCheckpoint 序列化
- `AgentCheckpoint.pendingEvents` 改**可选**（历史 checkpoint 多带一个被忽略字段，JSON 容忍，D7-safe）
- 守门测试：interrupt checkpoint 断言无 `pendingEvents`

### 2. 移除已死的 `FSMEngine.snapshot/restore`
checkpoint v2（§8）后 runtime 不再 `fsm.snapshot`/`fsm.restore`（写走 `lifecycle`、读走 `readCheckpointLifecycle`），二者**无生产引用**。删方法 + 对应 `FSMEngine.test` 用例（§8「删除前先加迁移单测」前置已在 #175 满足）。

## 验证

- 生产 `tsc --noEmit` 清零
- 离线 `jest src/__tests__`（排除 live smoke）**90 suites / 721 tests 绿**（−5 删除的 snapshot/restore 死测试）
- canonical `npm test` 绿（unit 51 + 确定性 e2e 7）
- 残骸清零：`src` 中 `pendingEvents` 仅剩可选类型字段 + 注释；`FSMEngine` 无 `snapshot/restore`

## 非目标

slice 5（core 两个 hook + userland `PhaseDriver` 受监管子流程示例）是更大的独立特性，另开 issue。

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
