### PR TITLE
feat(#180): HER 语言鲁棒性——多算法融合召回 + LLM 接地终判

### DIFF
--- a/examples/repair-ticketing/eval/run-eval.ts
+++ b/examples/repair-ticketing/eval/run-eval.ts
@@ -23,10 +23,38 @@ import { Milkie } from '../../../src/runtime/Milkie.js'
 import { MemoryStore } from '../../../src/store/MemoryStore.js'
 import { MemoryEventStore } from '../../../src/trace/MemoryEventStore.js'
 import { createGateway } from '../../../src/gateway/GatewayFactory.js'
+import { OpenAICompatibleAdapter } from '../../../src/gateway/OpenAICompatibleAdapter.js'
+import type { IModelGateway } from '../../../src/types/model.js'
 import type { Event } from '../../../src/trace/types.js'
 
 import { EntityResolver, type Schema } from '../resolver/EntityResolver.js'
 import { buildRepairTicketingTools, repairTicketingAgentConfig } from '../src/agent.js'
+
+// Eval model override (#174/#180): the example ships with doubao-seed-2.0-lite,
+// too weak to exercise the flow. When DEEPSEEK_API_KEY is set, run the SAME
+// agent/flow against DeepSeek; the committed example config is untouched.
+const useDeepseek = !!process.env['DEEPSEEK_API_KEY']
+const evalAgentConfig = useDeepseek
+  ? {
+      ...repairTicketingAgentConfig,
+      model: {
+        provider: 'deepseek',
+        model:    process.env['EVAL_MODEL'] ?? 'deepseek-chat',
+        adapter:  'openai-compatible' as const,
+        baseUrl:  process.env['DEEPSEEK_API_BASE'] ?? 'https://api.deepseek.com',
+      },
+    }
+  : repairTicketingAgentConfig
+
+function buildEvalGateway(): IModelGateway {
+  if (useDeepseek) {
+    return new OpenAICompatibleAdapter({
+      baseUrl: process.env['DEEPSEEK_API_BASE'] ?? 'https://api.deepseek.com',
+      apiKey:  process.env['DEEPSEEK_API_KEY'],
+    })
+  }
+  return createGateway(repairTicketingAgentConfig.model)
+}
 
 import {
   scoreCase, aggregate, LEVELS,
@@ -87,10 +115,22 @@ function latestWorkingMemory(events: Event[], prev: Record<string, unknown>): Re
   return data
 }
 
-function parseTicket(output: string): Record<string, unknown> | null {
+function isTicket(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && typeof (v as Record<string, unknown>)['ticketId'] === 'string'
+}
+
+/**
+ * Read the assembled ticket. #175 made assemble_ticket a TOOL whose result the
+ * model RELAYS as formatted prose (a markdown table), so the run's text output is
+ * no longer raw ticket JSON — but assemble_ticket also stores the ticket object in
+ * WM (`ctx.workingMemory.set('ticket', …)`). Read it from WM first (authoritative,
+ * model-paraphrase-proof); fall back to JSON in the text output for older shapes.
+ */
+function readTicket(workingMemory: Record<string, unknown>, output: string): Record<string, unknown> | null {
+  if (isTicket(workingMemory['ticket'])) return workingMemory['ticket'] as Record<string, unknown>
   try {
     const parsed = JSON.parse(output) as Record<string, unknown>
-    return parsed && typeof parsed === 'object' && typeof parsed['ticketId'] === 'string' ? parsed : null
+    return isTicket(parsed) ? parsed : null
   } catch {
     return null
   }
@@ -98,11 +138,11 @@ function parseTicket(output: string): Record<string, unknown> | null {
 
 /** Feed every turn of one case through a fresh Milkie and capture the observed end
  *  state (final WM, terminal-turn ticket, turn count). */
-async function runCase(c: EvalCase, gateway: ReturnType<typeof createGateway>): Promise<Observed> {
+async function runCase(c: EvalCase, gateway: IModelGateway): Promise<Observed> {
   const eventStore = new MemoryEventStore()
   const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore, gateway })
   for (const tool of buildRepairTicketingTools(resolver)) milkie.registerTool(tool)
-  milkie.registerAgent(repairTicketingAgentConfig)
+  milkie.registerAgent(evalAgentConfig)
 
   const contextId = `eval-${c.id}`
   let workingMemory: Record<string, unknown> = {}
@@ -123,13 +163,13 @@ async function runCase(c: EvalCase, gateway: ReturnType<typeof createGateway>): 
     }
   } catch (err) {
     return {
-      status: 'error', workingMemory, ticket: parseTicket(lastOutput),
+      status: 'error', workingMemory, ticket: readTicket(workingMemory, lastOutput),
       turnCount: c.turns.length, error: (err as Error).message,
     }
   }
 
   return {
-    status, workingMemory, ticket: parseTicket(lastOutput),
+    status, workingMemory, ticket: readTicket(workingMemory, lastOutput),
     turnCount: c.turns.length,
   }
 }
@@ -195,18 +235,19 @@ function renderReport(m: Metrics, results: CaseResult[], model: string, startedA
 // ─────────────────────────────────── Main ────────────────────────────────────
 
 async function main(): Promise<void> {
-  if (!process.env['VOLCENGINE_TOKEN'] || !process.env['VOLCENGINE_API_BASE']) {
+  const hasVolc = process.env['VOLCENGINE_TOKEN'] && process.env['VOLCENGINE_API_BASE']
+  if (!useDeepseek && !hasVolc) {
     console.log(
       'SKIPPED: live model credentials not set. ' +
-      'Set VOLCENGINE_TOKEN and VOLCENGINE_API_BASE to run the repair-ticketing eval.',
+      'Set VOLCENGINE_TOKEN + VOLCENGINE_API_BASE (or DEEPSEEK_API_KEY) to run the repair-ticketing eval.',
     )
     return
   }
 
   const cases = loadCases()
   const ids   = buildIdsByLevel()
-  const gateway = createGateway(repairTicketingAgentConfig.model)
-  const model = repairTicketingAgentConfig.model.model
+  const gateway = buildEvalGateway()
+  const model = evalAgentConfig.model.model
   const startedAt = new Date().toISOString()
 
   console.log(`Running ${cases.length} cases against ${model} …`)

--- a/examples/repair-ticketing/resolver/EntityResolver.ts
+++ b/examples/repair-ticketing/resolver/EntityResolver.ts
@@ -17,6 +17,8 @@
 //   lookupEntities({ utterance, pinned, dict })            -> LookupOutput
 //   commitEntities({ utterance, selected, pinned, dict })  -> CommitOutput
 
+import { recall as runRecall, type RecallConfig, type RecallResult } from './recall.js'
+
 // ─── schema types ─────────────────────────────────────────────────────────────
 
 export interface LevelSchema {
@@ -251,6 +253,23 @@ export class EntityResolver {
 
   commit(input: CommitRequest): CommitOutput {
     return commitEntities({ ...input, dict: this.dict })
+  }
+
+  // #180: deterministic multi-algorithm fusion recall (step 1). Delegates to
+  // resolver/recall.ts over this dict — LLM-free, returns neutral RecallResult.
+  recall(
+    utterance: string,
+    pinned: Record<string, string> = {},
+    config?: RecallConfig,
+    level?: string,
+  ): RecallResult {
+    return runRecall(this.dict, utterance, pinned, config, level)
+  }
+
+  /** Human-readable label for a level name (e.g. 'site' → '站点'); name itself if
+   *  unknown. Lets the scenario layer render话术 without reaching into the dict. */
+  levelLabel(name: string): string {
+    return this.dict.schema.levels.find(l => l.name === name)?.label ?? name
   }
 }
 

--- a/examples/repair-ticketing/resolver/EntityResolver.ts
+++ b/examples/repair-ticketing/resolver/EntityResolver.ts
@@ -92,7 +92,9 @@ export type CommitOutput =
 
 // ─── internal ────────────────────────────────────────────────────────────────
 
-interface EntityRecord {
+// Exported for the in-package fusion-recall module (#180, resolver/recall.ts).
+// Still an internal core type — not part of the public lookup/commit contract.
+export interface EntityRecord {
   id: string
   label: string
   path: string[]
@@ -273,7 +275,7 @@ export function nextLevel(dict: HierarchicalDict, pinned: Record<string, string>
 // recalled or suggested from the CLI (#167 item 1). With a longer `pinned` prefix
 // this naturally narrows to the remaining levels, collapsing to the single leaf
 // once every ancestor is pinned.
-function targetLevels(
+export function targetLevels(
   dict: HierarchicalDict,
   pinned: Record<string, string>,
   level?: string,
@@ -542,7 +544,7 @@ function parseCSVLine(line: string): string[] {
 // Strip the target level's own pin, leaving only strictly-higher (ancestor)
 // constraints. An entity's own level is never present in `ancestors`, so a pin
 // at the target level must not be used for topological filtering (#167).
-function ancestorOnly(pinned: Record<string, string>, level: string): Record<string, string> {
+export function ancestorOnly(pinned: Record<string, string>, level: string): Record<string, string> {
   const ancestors: Record<string, string> = {}
   for (const [k, v] of Object.entries(pinned)) {
     if (k !== level) ancestors[k] = v
@@ -550,7 +552,7 @@ function ancestorOnly(pinned: Record<string, string>, level: string): Record<str
   return ancestors
 }
 
-function matchesPinned(entity: EntityRecord, pinned: Record<string, string>): boolean {
+export function matchesPinned(entity: EntityRecord, pinned: Record<string, string>): boolean {
   for (const [k, v] of Object.entries(pinned)) {
     if (entity.ancestors[k] !== v) return false
   }

--- a/examples/repair-ticketing/resolver/__tests__/recall.test.ts
+++ b/examples/repair-ticketing/resolver/__tests__/recall.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+import path from 'path'
+
+import { loadHierarchicalDict, type Schema, type HierarchicalDict } from '../EntityResolver'
+import { recall, type RecallResult } from '../recall'
+
+const schema = JSON.parse(fs.readFileSync(path.join(__dirname, '../schema.json'), 'utf-8')) as Schema
+const csv = fs.readFileSync(path.join(__dirname, '../data.csv'), 'utf-8')
+const dict: HierarchicalDict = loadHierarchicalDict(schema, csv)
+
+const at = (r: RecallResult, level: string) => r.byLevel.find(l => l.level === level)
+const ids = (r: RecallResult, level: string) => (at(r, level)?.candidates ?? []).map(c => c.id)
+
+describe('fusion recall (#180) — step 1, deterministic, LLM-free', () => {
+  it('exact name → decisive sole site', () => {
+    const r = recall(dict, '总部')
+    expect(at(r, 'site')!.decisive).toBe('S01')
+    expect(at(r, 'site')!.candidates[0]!.via).toContain('exact')
+  })
+
+  it('alias → recalls the aliased department (硬件部 = IT硬件组 D02)', () => {
+    const r = recall(dict, '硬件部', { site: 'S01', building: 'B01' })
+    expect(ids(r, 'department')).toContain('D02')
+    expect(at(r, 'department')!.candidates.find(c => c.id === 'D02')!.matchedSurface).toBe('硬件部')
+  })
+
+  it('typo → edit-distance recalls 总部 from 总布', () => {
+    const r = recall(dict, '总布')
+    const site = at(r, 'site')!
+    expect(site.candidates.map(c => c.id)).toContain('S01')
+    expect(site.candidates.find(c => c.id === 'S01')!.via).toContain('edit')
+  })
+
+  it('ambiguous → multiple candidates, NOT decisive (张 → 张伟 + 张亮)', () => {
+    const r = recall(dict, '张', { site: 'S01', building: 'B01', department: 'D03' })
+    const a = at(r, 'assignee')!
+    expect(a.candidates.map(c => c.id)).toEqual(expect.arrayContaining(['E007', 'E009']))
+    expect(a.candidates.length).toBeGreaterThanOrEqual(2)
+    expect(a.decisive).toBeNull()   // → must go to step-2 LLM, not auto-commit
+  })
+
+  it('unknown → empty candidates (→ clarify/unknown, never hard-commit)', () => {
+    const r = recall(dict, '火星基地', { site: 'S01', building: 'B01', department: 'D03' })
+    expect(at(r, 'assignee')!.candidates).toHaveLength(0)
+    expect(at(r, 'assignee')!.decisive).toBeNull()
+  })
+
+  it('pinned filter → branch-confined; clear name is decisive', () => {
+    const r = recall(dict, '王芳', { site: 'S01', building: 'B01', department: 'D03' })
+    expect(at(r, 'assignee')!.decisive).toBe('E008')
+  })
+
+  it('level-less → an embedded name lands on its own level only', () => {
+    // "网络部" appears in dept_name "IT网络部"; no pinned context.
+    const r = recall(dict, '网络部')
+    expect(ids(r, 'department')).toContain('D03')
+    expect(at(r, 'site')!.candidates).toHaveLength(0)       // does not bleed into other levels
+    expect(at(r, 'building')!.candidates).toHaveLength(0)
+  })
+})

--- a/examples/repair-ticketing/resolver/recall.ts
+++ b/examples/repair-ticketing/resolver/recall.ts
@@ -1,0 +1,259 @@
+// Deterministic multi-algorithm fusion recall (#180) — the portable, LLM-free
+// "step 1" of repair-ticketing's slot filling.
+//
+// Given an utterance + already-pinned ancestors, recall scores every entity at
+// each remaining level with several independent matchers (exact / substring /
+// char-n-gram / edit distance), each producing its own ranking, then fuses the
+// rankings with Reciprocal Rank Fusion (RRF). The output is NEUTRAL data —
+// candidate ids, scores, paths, which matcher hit, and a `decisive` fast-path
+// hint — with NO user-facing wording and NO LLM. Scenario话术 and the LLM
+// final-select (step 2) live in the adapter layer (#166), not here.
+//
+// Zero new dependencies by design (#167 portability). Pinyin and full BM25-idf
+// weighting are deliberately out of this first cut (pinyin needs a hanzi→pinyin
+// table = a dependency); the four matchers below already cover exact / alias /
+// substring / partial / typo.
+
+import type { HierarchicalDict, EntityRecord } from './EntityResolver.js'
+import { targetLevels, ancestorOnly, matchesPinned } from './EntityResolver.js'
+
+export type MatchAlgo = 'exact' | 'substring' | 'ngram' | 'edit'
+
+/** A neutral recall candidate — real entity id the LLM may later pick from. */
+export interface RecallCandidate {
+  id: string
+  label: string
+  level: string
+  path: string[]          // full ancestor path → tree topology for step-2 judging
+  score: number           // fused RRF score (higher = better)
+  via: MatchAlgo[]        // which matchers contributed (descending contribution)
+  matchedSurface: string  // the label/alias surface form that matched best
+}
+
+export interface LevelRecall {
+  level: string
+  candidates: RecallCandidate[]   // pinned-filtered, score-descending, capped to topK
+  decisive: string | null         // fast-path: a clearly-unique winner's id, else null
+}
+
+export interface RecallResult {
+  byLevel: LevelRecall[]          // remaining (unfilled) levels only
+}
+
+export interface RecallConfig {
+  algos?: MatchAlgo[]             // default: all four
+  rrfK?: number                   // RRF constant, default 60
+  topK?: number                   // candidates kept per level, default 5
+  ngram?: number                  // char n-gram size for ngram/edit windows, default 2
+  minScore?: number               // drop candidates scoring below this (post-fusion), default 0
+  decisiveRatio?: number          // top must beat 2nd by this RRF ratio to be decisive, default 1.5
+}
+
+const DEFAULTS: Required<RecallConfig> = {
+  algos: ['exact', 'substring', 'ngram', 'edit'],
+  rrfK: 60,
+  topK: 5,
+  ngram: 2,
+  minScore: 0,
+  decisiveRatio: 1.5,
+}
+
+// ─── per-matcher scoring (surface form vs utterance) ──────────────────────────
+// Each returns 0..1. The utterance is matched against an entity's surface forms
+// (label + alias columns); the entity's per-matcher score is its best surface.
+
+function scoreExact(surface: string, q: string): number {
+  if (!surface) return 0
+  if (surface === q) return 1
+  // The whole entity name appears verbatim inside a longer utterance ("…网络部…").
+  if (q.includes(surface)) return 0.95
+  return 0
+}
+
+function scoreSubstring(surface: string, q: string): number {
+  if (!surface) return 0
+  if (q.includes(surface)) return Math.min(1, surface.length / Math.max(1, q.length)) * 0.6 + 0.4
+  if (surface.includes(q)) return Math.min(1, q.length / Math.max(1, surface.length)) * 0.6 + 0.3
+  return 0
+}
+
+/** Char n-gram overlap (Dice coefficient) — BM25-style lexical recall for short
+ *  strings, dependency-free. Catches reordering / partial overlap. */
+function scoreNgram(surface: string, q: string, n: number): number {
+  const a = charNgrams(surface, n)
+  const b = charNgrams(q, n)
+  if (a.size === 0 || b.size === 0) return 0
+  let inter = 0
+  for (const g of a) if (b.has(g)) inter++
+  return (2 * inter) / (a.size + b.size)
+}
+
+/** Best normalized edit-distance similarity of `surface` against any same-length
+ *  window of the utterance — typo tolerance ("总布"→"总部") without matching a
+ *  short name against the whole long sentence.
+ *
+ *  First-char anchor: only windows that share the surface's first character count.
+ *  Short Chinese names make raw edit distance noisy — a window like "络部" is one
+ *  edit from "总部" purely by a coincidental tail char, the same 0.5 similarity a
+ *  real typo "总布" scores. Anchoring on the first char keeps real typos (which
+ *  rarely corrupt the leading char) and drops tail-coincidence noise. The rare
+ *  leading-char typo is given up here — substring/ngram/step-2 can still catch it. */
+function scoreEdit(surface: string, q: string): number {
+  if (!surface) return 0
+  const w = surface.length
+  const head = surface[0]
+  if (q.length <= w) return q[0] === head ? editSim(surface, q) : 0
+  let best = 0
+  for (let i = 0; i + w <= q.length; i++) {
+    if (q[i] !== head) continue
+    best = Math.max(best, editSim(surface, q.slice(i, i + w)))
+    if (best === 1) break
+  }
+  return best
+}
+
+// ─── primitives ───────────────────────────────────────────────────────────────
+
+function charNgrams(s: string, n: number): Set<string> {
+  const out = new Set<string>()
+  if (s.length < n) { if (s) out.add(s); return out }
+  for (let i = 0; i + n <= s.length; i++) out.add(s.slice(i, i + n))
+  return out
+}
+
+function editSim(a: string, b: string): number {
+  const d = levenshtein(a, b)
+  const m = Math.max(a.length, b.length)
+  return m === 0 ? 0 : 1 - d / m
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+  let prev = Array.from({ length: n + 1 }, (_, j) => j)
+  let cur = new Array<number>(n + 1)
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      cur[j] = Math.min(prev[j]! + 1, cur[j - 1]! + 1, prev[j - 1]! + cost)
+    }
+    [prev, cur] = [cur, prev]
+  }
+  return prev[n]!
+}
+
+const SCORERS: Record<MatchAlgo, (surface: string, q: string, n: number) => number> = {
+  exact:     (s, q) => scoreExact(s, q),
+  substring: (s, q) => scoreSubstring(s, q),
+  ngram:     (s, q, n) => scoreNgram(s, q, n),
+  edit:      (s, q) => scoreEdit(s, q),
+}
+
+// ─── per-level recall ──────────────────────────────────────────────────────────
+
+interface Scored {
+  entity: EntityRecord
+  perAlgo: Map<MatchAlgo, number>   // best surface score per matcher
+  bestSurface: Map<MatchAlgo, string>
+}
+
+function scoreLevel(
+  entities: EntityRecord[],
+  q: string,
+  cfg: Required<RecallConfig>,
+): Scored[] {
+  const out: Scored[] = []
+  for (const entity of entities) {
+    const surfaces = [entity.label, ...Object.values(entity.searchValues)]
+      .map(s => (s ?? '').toLowerCase())
+      .filter(Boolean)
+    const perAlgo = new Map<MatchAlgo, number>()
+    const bestSurface = new Map<MatchAlgo, string>()
+    for (const algo of cfg.algos) {
+      let best = 0, bestS = ''
+      for (const surface of surfaces) {
+        const s = SCORERS[algo](surface, q, cfg.ngram)
+        if (s > best) { best = s; bestS = surface }
+      }
+      if (best > 0) { perAlgo.set(algo, best); bestSurface.set(algo, bestS) }
+    }
+    if (perAlgo.size > 0) out.push({ entity, perAlgo, bestSurface })
+  }
+  return out
+}
+
+/** Fuse per-matcher rankings into one score via Reciprocal Rank Fusion. */
+function fuse(scored: Scored[], cfg: Required<RecallConfig>): Map<string, number> {
+  const fused = new Map<string, number>()
+  for (const algo of cfg.algos) {
+    const ranked = scored
+      .filter(s => s.perAlgo.has(algo))
+      .sort((a, b) => b.perAlgo.get(algo)! - a.perAlgo.get(algo)!)
+    ranked.forEach((s, i) => {
+      fused.set(s.entity.id, (fused.get(s.entity.id) ?? 0) + 1 / (cfg.rrfK + i + 1))
+    })
+  }
+  return fused
+}
+
+function decisiveOf(cands: RecallCandidate[], cfg: Required<RecallConfig>): string | null {
+  if (cands.length === 0) return null
+  if (cands.length === 1) return cands[0]!.id
+  const [a, b] = cands
+  const strong = (c: RecallCandidate) => c.via.includes('exact') || c.via.includes('substring')
+  // A single strong direct hit with no equally-strong rival → accept.
+  if (strong(a!) && !strong(b!)) return a!.id
+  // Otherwise require a clear RRF lead.
+  if (a!.score >= b!.score * cfg.decisiveRatio) return a!.id
+  return null
+}
+
+/**
+ * Recall candidates for every remaining level, fused and ranked. Pure, deterministic,
+ * LLM-free. `pinned` filters to the matching branch and (level-less) derives which
+ * levels to search; `level` overrides to a single level.
+ */
+export function recall(
+  dict: HierarchicalDict,
+  utterance: string,
+  pinned: Record<string, string> = {},
+  config: RecallConfig = {},
+  level?: string,
+): RecallResult {
+  const cfg = { ...DEFAULTS, ...config }
+  const q = utterance.toLowerCase().trim()
+  const byLevel: LevelRecall[] = []
+
+  for (const lvl of targetLevels(dict, pinned, level)) {
+    const levelMap = dict.index.get(lvl)
+    if (!levelMap) continue
+    const ancestorPins = ancestorOnly(pinned, lvl)
+    const entities = [...levelMap.values()].filter(e => matchesPinned(e, ancestorPins))
+
+    const scored = q ? scoreLevel(entities, q, cfg) : []
+    const fused = fuse(scored, cfg)
+
+    let candidates: RecallCandidate[] = scored.map(s => {
+      const via = [...s.perAlgo.entries()].sort((a, b) => b[1] - a[1]).map(([algo]) => algo)
+      return {
+        id: s.entity.id,
+        label: s.entity.label,
+        level: lvl,
+        path: s.entity.path,
+        score: fused.get(s.entity.id) ?? 0,
+        via,
+        matchedSurface: s.bestSurface.get(via[0]!) ?? s.entity.label,
+      }
+    })
+    candidates = candidates
+      .filter(c => c.score > cfg.minScore)
+      .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+      .slice(0, cfg.topK)
+
+    byLevel.push({ level: lvl, candidates, decisive: decisiveOf(candidates, cfg) })
+  }
+
+  return { byLevel }
+}

--- a/examples/repair-ticketing/src/__tests__/entity-resolver.e2e.test.ts
+++ b/examples/repair-ticketing/src/__tests__/entity-resolver.e2e.test.ts
@@ -32,7 +32,7 @@ import { MemoryEventStore } from '../../../../src/trace/MemoryEventStore.js'
 import { TrajectoryStore } from '../../../../src/trajectory/TrajectoryStore.js'
 
 import { EntityResolver, type Schema } from '../../resolver/EntityResolver.js'
-import { makeEntityResolverTools } from '../tools/entity-resolver.js'
+import { makeEntityResolverTools, makeResolveEntitiesTool } from '../tools/entity-resolver.js'
 
 // ─────────────────────────────── Fixtures ────────────────────────────────────
 
@@ -407,5 +407,60 @@ describe('Path D: hierarchical slot filling inside a single autonomous state (e2
     expect(lastResult.status).toBe('completed')
     const transitionSpans = trajectory.spans.filter(s => s.name === 'fsm.transition')
     expect(transitionSpans).toEqual([])  // no business transitions remain
+  })
+})
+
+// ─── resolve_entities (#180: recall + fast-path orchestration, deterministic) ───
+
+const resolveTool = makeResolveEntitiesTool(resolver, REQUIRED)
+interface ResolveOut {
+  committed: Array<{ level: string; id: string }>
+  needsSelection: Array<{ level: string; candidates: Array<{ id: string }> }>
+  notFound: string[]
+  message: string | null
+}
+const resolve = (ctx: ToolContext) => resolveTool.handler({}, ctx) as Promise<ResolveOut>
+
+describe('resolve_entities — deterministic recall + fast-path (#180)', () => {
+  it('one-shot multi-level utterance auto-commits every decisive level', async () => {
+    const { ctx, wm } = makeCtx('总部主楼IT网络部的王芳')
+    const out = await resolve(ctx)
+    expect(out.committed.map(c => c.level)).toEqual(['site', 'building', 'department', 'assignee'])
+    expect(wm.get('site')).toBe('S01')
+    expect(wm.get('building')).toBe('B01')
+    expect(wm.get('department')).toBe('D03')
+    expect(wm.get('assignee')).toBe('E008')
+    expect(out.needsSelection).toEqual([])
+  })
+
+  it('drip-feed: commits the current level, then asks for the next', async () => {
+    const { ctx, wm } = makeCtx('主楼', { site: 'S01' })
+    const out = await resolve(ctx)
+    expect(wm.get('building')).toBe('B01')                 // committed this turn
+    expect(out.committed.map(c => c.level)).toContain('building')
+    expect(out.notFound).toContain('department')           // next level prompted
+    expect(out.message).toMatch(/部门/)
+  })
+
+  it('typo auto-commits via fuzzy recall (总布 → 总部)', async () => {
+    const { ctx, wm } = makeCtx('总布')
+    await resolve(ctx)
+    expect(wm.get('site')).toBe('S01')
+  })
+
+  it('ambiguous level → needsSelection with real candidates, no commit', async () => {
+    const { ctx, wm } = makeCtx('张', { site: 'S01', building: 'B01', department: 'D03' })
+    const out = await resolve(ctx)
+    expect(wm.get('assignee')).toBeUndefined()             // never hard-commits an ambiguous slot
+    const sel = out.needsSelection.find(s => s.level === 'assignee')!
+    expect(sel.candidates.map(c => c.id)).toEqual(expect.arrayContaining(['E007', 'E009']))
+    expect(out.message).toMatch(/确认|哪一个/)
+  })
+
+  it('unknown → notFound, never invents a slot', async () => {
+    const { ctx, wm } = makeCtx('火星基地', { site: 'S01', building: 'B01', department: 'D03' })
+    const out = await resolve(ctx)
+    expect(wm.get('assignee')).toBeUndefined()
+    expect(out.notFound).toContain('assignee')
   })
 })

--- a/examples/repair-ticketing/src/agent.ts
+++ b/examples/repair-ticketing/src/agent.ts
@@ -23,7 +23,7 @@
 import type { AgentConfig } from '../../../src/types/agent.js'
 import type { ToolContext, ToolDefinition } from '../../../src/types/tool.js'
 import type { EntityResolver } from '../resolver/EntityResolver.js'
-import { makeEntityResolverTools } from './tools/entity-resolver.js'
+import { makeEntityResolverTools, makeResolveEntitiesTool } from './tools/entity-resolver.js'
 
 /** Ordered hierarchy levels that must all be confirmed before a ticket can open. */
 export const REQUIRED_SLOTS = ['site', 'building', 'department', 'assignee'] as const
@@ -179,6 +179,11 @@ export function makeAssembleTicketTool(): ToolDefinition {
  */
 export function buildRepairTicketingTools(resolver: EntityResolver): ToolDefinition[] {
   return [
+    // #180: resolve_entities (recall + fast-path) is the primary entity tool; the
+    // lower-level lookup_entity/commit_entity pair stays registered — commit_entity
+    // is the model's step-2 "pick from candidates", and both remain the resolver
+    // adapter's tested contract (#166).
+    makeResolveEntitiesTool(resolver, [...REQUIRED_SLOTS]),
     ...makeEntityResolverTools(resolver, [...REQUIRED_SLOTS]),
     makeCommitDescriptionTool(),
     makeAssembleTicketTool(),
@@ -190,19 +195,24 @@ export const repairTicketingAgentConfig: AgentConfig = {
   version:      '2.0.0',
   systemPrompt:
     `你是报修工单助手，在一个自主对话中按以下顺序协助用户（软引导，非强制状态机）：
-1. 逐级定位报修对象（站点 → 楼宇 → 部门 → 负责人）。对每一级：先调用 lookup_entity 检索候选，再调用 commit_entity 确认其中一个候选。系统会自动以用户本轮原话作为查询，你只需指定 level。
+1. 逐级定位报修对象（站点 → 楼宇 → 部门 → 负责人）。每轮先调用 resolve_entities——系统会用用户本轮原话自动检索，并把能【唯一确定】的层级直接确认（无需你指定 level，也无需传参）。然后按其返回处理：
+   - committed：已自动确认的层级，无需再操作。
+   - needsSelection：某一级有多个候选。若能从上下文或对话历史判断是哪一个，就用 commit_entity 选定那个候选的 id（id 必须来自候选，不得臆造）；若无法判断，就把 message 转述给用户，请其在候选中选择。
+   - notFound：该层级本轮还无法确定。请按 message 请用户补充这一层级。
 2. 四级全部确认后，请用户用一句话描述故障现象（位置 + 问题）。用户描述后调用 commit_description（描述内容由系统自动采集，无需传参）。
 3. 四级实体与描述都确认后，调用 assemble_ticket 生成结构化工单，并把工单原样回复用户。
 注意：assemble_ticket 有前置条件——必须先集齐四级实体与描述；若它返回 preconditionFailed，请先补齐 missing 列出的字段，不要重复空调用。`,
   // #175: a single autonomous llm state. No `on:` edges, no business events.
-  // The four tools drive lookup → commit → describe → assemble within one
-  // tool-loop; assemble_ticket's precondition is the only hard gate.
+  // #180: resolve_entities does deterministic recall + fast-path commit; commit_entity
+  // is the model's step-2 pick from candidates; commit_description + assemble_ticket
+  // close the journey. lookup_entity is intentionally NOT exposed here (resolve_entities
+  // supersedes it) though it stays registered for the adapter contract/tests.
   fsm: {
     states: [
       {
         name:  'repair',
         type:  'llm',
-        tools: ['lookup_entity', 'commit_entity', 'commit_description', 'assemble_ticket'],
+        tools: ['resolve_entities', 'commit_entity', 'commit_description', 'assemble_ticket'],
       },
     ],
   },

--- a/examples/repair-ticketing/src/messages.ts
+++ b/examples/repair-ticketing/src/messages.ts
@@ -1,0 +1,37 @@
+// Scenario-layer user-facing wording (#180) for repair-ticketing.
+//
+// The portable core (resolver) returns only neutral status + structured data —
+// never话术. This module renders the Chinese the END USER sees, keyed off those
+// statuses/outcomes. Model-facing话术 (system prompt, tool descriptions) lives in
+// agent.ts; keep these two separate so wording changes never touch logic/core.
+
+/** A candidate as surfaced to the user during clarification. */
+export interface ChoiceLabel {
+  id: string
+  label: string
+  path: string[]
+}
+
+const fmtChoices = (cands: ChoiceLabel[]): string =>
+  cands.map(c => `${c.id}（${c.label}）`).join('、')
+
+export const repairMessages = {
+  /** Multiple candidates at a level and context can't disambiguate → ask the user. */
+  clarifyAmbiguous: (levelLabel: string, cands: ChoiceLabel[]): string =>
+    `「${levelLabel}」匹配到多个，请确认是哪一个：${fmtChoices(cands)}。`,
+
+  /** The next level isn't yet resolvable from this turn — prompt for it. Covers both
+   *  "the user hasn't named it yet" and "what they said didn't match anything". */
+  promptForLevel: (levelLabel: string): string =>
+    `请提供报修对象的${levelLabel}（名称、别名或简称均可）。`,
+
+  /** A selection conflicted with the confirmed branch and could not be corrected. */
+  rejectInvalid: (levelLabel: string): string =>
+    `该${levelLabel}与已确认的上级不一致，无法采用，请重新提供。`,
+
+  /** A selection was auto-corrected to stay consistent with the confirmed branch. */
+  noticeCorrected: (levelLabel: string, toLabel: string): string =>
+    `已按已确认的分支将${levelLabel}校正为「${toLabel}」。`,
+}
+
+export type RepairMessages = typeof repairMessages

--- a/examples/repair-ticketing/src/tools/entity-resolver.ts
+++ b/examples/repair-ticketing/src/tools/entity-resolver.ts
@@ -20,6 +20,8 @@
 
 import type { ToolContext, ToolDefinition } from '../../../../src/types/tool.js'
 import type { EntityResolver, ResolvedEntity } from '../../resolver/EntityResolver.js'
+import type { RecallConfig } from '../../resolver/recall.js'
+import { repairMessages } from '../messages.js'
 
 interface LookupInput {
   context?: { level?: string; sessionHint?: string }
@@ -178,4 +180,100 @@ export function makeEntityResolverTools(
   }
 
   return [lookupEntity, commitEntity]
+}
+
+/**
+ * `resolve_entities` — the #180 "step 1 + fast-path" orchestration tool. One call
+ * per user turn does the deterministic work the model used to fumble:
+ *
+ *   for each still-unfilled level, in order (站点→楼宇→部门→负责人):
+ *     • run the fusion recall (resolver.recall) over this turn's utterance, branch-
+ *       filtered by the already-committed ancestors;
+ *     • if it has a DECISIVE unique winner → commit it straight to WM (no LLM) and
+ *       move to the next level;
+ *     • else stop: report the level as `needsSelection` (multiple candidates — the
+ *       model may pick with commit_entity if context disambiguates, else clarify)
+ *       or `notFound` (none — prompt the user for this level).
+ *
+ * The LLM never picks a level and never invents an id: decisive levels are
+ * committed deterministically; ambiguous ones hand the model REAL candidates to
+ * choose from. No business event (#175) — completeness is read back from WM by the
+ * assemble_ticket precondition. User-facing wording comes from messages.ts.
+ */
+export function makeResolveEntitiesTool(
+  resolver: EntityResolver,
+  requiredSlots: string[],
+  recallConfig?: RecallConfig,
+): ToolDefinition {
+  const pinnedFromWM = (ctx: ToolContext): Record<string, string> => {
+    const pinned: Record<string, string> = {}
+    for (const level of requiredSlots) {
+      const value = ctx.workingMemory.get(level)
+      if (value != null && value !== '') pinned[level] = String(value)
+    }
+    return pinned
+  }
+  const firstUnfilled = (ctx: ToolContext): string | undefined =>
+    requiredSlots.find(l => {
+      const v = ctx.workingMemory.get(l)
+      return v == null || v === ''
+    })
+
+  return {
+    name: 'resolve_entities',
+    description:
+      '用用户本轮原话自动逐级检索并提交能【唯一确定】的层级（站点→楼宇→部门→负责人，系统自动取原话为查询，你无需传参）。' +
+      '返回 committed（已自动确认）、needsSelection（同级多个候选，需判断）、notFound（该层级尚未给出）、message（可向用户转述的提示）。' +
+      '处理建议：needsSelection 时若能从上下文/历史判断是哪一个，用 commit_entity 选定；否则把 message 转述给用户澄清。notFound 时请用户补充该层级。每轮先调用本工具。',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async (_input: unknown, ctx: ToolContext): Promise<unknown> => {
+      const utterance = (ctx.currentTurn ?? '').trim()
+      const committed: Array<{ level: string; id: string; label: string }> = []
+      const corrected: Array<{ level: string; toId: string }> = []
+      const needsSelection: Array<{ level: string; candidates: Array<{ id: string; label: string; path: string[] }> }> = []
+      const notFound: string[] = []
+      const messages: string[] = []
+
+      // Process the next-unfilled level repeatedly; each decisive commit re-pins and
+      // unlocks the following level within the SAME turn (handles "总部主楼网络部的王芳").
+      for (;;) {
+        const level = firstUnfilled(ctx)
+        if (!level) break
+        const pinned = pinnedFromWM(ctx)
+        const lr = resolver.recall(utterance, pinned, recallConfig, level).byLevel[0]
+
+        if (lr?.decisive) {
+          const out = resolver.commit({ selected: lr.decisive, level, pinned })
+          if (out.status === 'complete' || out.status === 'corrected') {
+            ctx.workingMemory.set(level, out.resolved.id)
+            committed.push({ level, id: out.resolved.id, label: out.resolved.label })
+            if (out.status === 'corrected') {
+              corrected.push({ level, toId: out.resolved.id })
+              messages.push(repairMessages.noticeCorrected(resolver.levelLabel(level), out.resolved.label))
+            }
+            continue   // re-pinned → try the next level this same turn
+          }
+          // Decisive recall but commit rejected (conflicts with pinned branch) → stop.
+          notFound.push(level)
+          messages.push(repairMessages.promptForLevel(resolver.levelLabel(level)))
+          break
+        }
+
+        if (lr && lr.candidates.length > 0) {
+          needsSelection.push({
+            level,
+            candidates: lr.candidates.map(c => ({ id: c.id, label: c.label, path: c.path })),
+          })
+          messages.push(repairMessages.clarifyAmbiguous(resolver.levelLabel(level), lr.candidates))
+          break   // first ambiguous level halts the deterministic run
+        }
+
+        notFound.push(level)
+        messages.push(repairMessages.promptForLevel(resolver.levelLabel(level)))
+        break
+      }
+
+      return { committed, corrected, needsSelection, notFound, message: messages.join(' ') || null }
+    },
+  }
 }


### PR DESCRIPTION
## 背景

#174 的 live eval 暴露：repair-ticketing 在真实 LLM 下端到端质量极低（#175 当前 main 仅 **2.6%**）。根因——匹配是纯确定性子串打分、且要 LLM 自己选 level：错别字/同义/口语接不住，跨轮还跟丢层级。

## 方案（设计见 #180）

**两步分工**：第一步纯符号确定性召回（零 LLM），第二步 LLM 仅在歧义时从真实候选里接地终判。

- **`resolver/recall.ts`（核心，通用）**：多算法 `exact/substring/ngram/edit` + alias，**RRF 融合**，level-less + pinned 过滤；返回中性 `RecallResult`（id/path/score/via + `decisive` 快路开关）。零新依赖、无话术。
- **`src/tools/entity-resolver.ts` `resolve_entities`（适配器编排）**：逐级 recall + 快路自动 commit；歧义→needsSelection（模型用 commit_entity 接地选）、空→notFound。
- **`src/messages.ts`（场景层话术）**：按 status 渲染用户文案，core 无话术。
- 分层：core 只放通用机制+中性数据；配置/话术/LLM 全在场景层。

## 结果（DeepSeek，同口径对照）

| 同 harness + 同模型 | 通过率 | 槽全对 | 工单正确 |
|------|------|------|------|
| #175 无 recall（当前 main） | **1/39 (2.6%)** | 3.1% | 3.1% |
| **#175 + recall（本 PR）** | **27/39 (69%)** | **84%** | **84%** |

**recall 净贡献 +66pp**（同架构同模型同 harness，唯一变量=recall）。

按 tag：canonical / colloquial / multi-level / alias / cross-branch **全 4/4**；typo / synonym 3/4。**语言鲁棒类 26/28**。

## 附带修复

- **eval harness 从 WM 读工单**：#175 把 emit_ticket 改为工具后，工单经模型转述成表格、不再是 JSON 输出，harness 误报 missing_ticket。改为从 WM 读（assemble_ticket 已存）。
- 新增可选 DeepSeek 模型 override（example 提交配置不变）。

## 测试

- 新增 `recall.test.ts`（7）+ `resolve_entities` 确定性测试（5）；example 全套 **114/114** 绿，tsc 0 错。
- 不改 lookup/commit 契约，#166 适配器测试不动。

## 已知遗留（不在本 PR，另开跟进 issue）

- **ambiguous/unknown 不澄清**（premature_emit）：歧义/查无时模型仍猜着填。
- **多轮纠正**（correction）：用户"不对，是分部"的回退。
- 召回 **拼音 + 完整 BM25-idf**（需依赖）为后续档。

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)