### PR TITLE
fix(#185): eval scorer 不再用 status 误判 clarify/reject

### DIFF
--- a/examples/repair-ticketing/eval/scoring.ts
+++ b/examples/repair-ticketing/eval/scoring.ts
@@ -103,7 +103,13 @@ export function scoreCase(c: EvalCase, obs: Observed, ids: IdsByLevel): CaseResu
 
   // ── Clarify / reject cases ──────────────────────────────────────────────────
   if (c.expect.outcome) {
-    const emittedTicket = obs.ticket != null || obs.status === 'completed'
+    // "Emitted a ticket" === a ticket object actually exists. NOT `status ===
+    // 'completed'`: under #175's single autonomous llm state EVERY normal turn
+    // completes (the run finishes each turn), so a correct clarify/reject turn is
+    // also 'completed' — using status here false-flagged every clarify/reject case
+    // as premature_emit. The ticket is read authoritatively from WM (run-eval), so
+    // its presence is the right signal.
+    const emittedTicket = obs.ticket != null
     if (emittedTicket) failures.add('premature_emit')
 
     const knownPrefix = c.expect.slots ?? {}


### PR DESCRIPTION
## 问题（系统性低报）

#174 eval 的 clarify/reject 用例以 `obs.ticket != null || obs.status === 'completed'` 判断"是否开单"。但 **#175 单态 llm loop 下每一轮正常结束 status 都是 `'completed'`**——哪怕模型只是正确澄清、并未开单。于是**所有 clarify/reject 用例无论对错都被判 `premature_emit`**，`clarification` 恒为 0%，eval 系统性低报。

## 修复

工单现已可靠从 WM 读（#180/#184 的 `readTicket`），故判据只看 `obs.ticket != null`：
```diff
- const emittedTicket = obs.ticket != null || obs.status === 'completed'
+ const emittedTicket = obs.ticket != null
```

## 影响（DeepSeek，同 agent/同模型）

| | scorer 修复前 | 修复后 |
|---|---|---|
| clarification | "0%"（假象） | **~71–100%（真实）** |
| 当前 main 通过率 | 报 69% | **真实 ~72%** |

逐轮追踪佐证：模型本就正确澄清（ambiguous→列候选问用户、unknown→请补充），是 scorer 看不见。premature_emit 在修复后归零。

## 验证

- `scoring.test.ts` 14/14、example 全套 114/114 绿；tsc 0 错。
- premature_emit 单测仍通过（它构造的是真有 ticket 的 Observed，不依赖 status）。

## 说明（不在本 PR）

- 这次还发现 eval **run-to-run 方差很大**（长多轮 case：canonical 跨几次跑 4/4→1/4→2/4；逐轮追踪证明同一 case 这次全对、那次全空 = DeepSeek 随机性 + 连跑时的瞬时超时，非逻辑 bug）。**降方差（温度 0 + 瞬时错误重试 + 多跑取均值）**留作 #185 后续。
- 真实能力缺口仅剩 **correction（多轮纠正）**。

Refs #185, #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)