### PR TITLE
fix(#194): 移除误提交的 node_modules 自引用 symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/xupeng/dev/github/milkie/node_modules


### PR DESCRIPTION
## 问题

`node_modules` 被作为 mode 120000 符号链接追踪，且指向自身绝对路径（`7b69a83` 引入）。每次 checkout/reset/pull 都会用这个自引用 symlink 覆盖 npm 装好的真实目录，导致 Node 无法解析任何依赖 → `better-sqlite3` 加载失败 → 依赖 milkie 的 everbot daemon preflight 失败、拒绝启动。

## 修复

`git rm --cached node_modules` —— 从版本库移除该条目，`.gitignore`（已含 `node_modules/`）随即生效，不再被重建。本地真实目录不受影响。

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)