### PR TITLE
fix(#196): serve agent 注册读端 trace 工具 + lookback 10→30

### DIFF
--- a/src/__tests__/traceTools.selfOnly.test.ts
+++ b/src/__tests__/traceTools.selfOnly.test.ts
@@ -1,0 +1,74 @@
+// src/__tests__/traceTools.selfOnly.test.ts
+// #196 follow-up (P1 security): the GENERIC registration (serve/constructor) must
+// expose only a self-view. Reading an arbitrary runId is the diagnoser's privilege,
+// granted via loadStandardAgents(), not something every eventStore-enabled agent
+// should get — otherwise a shared serve instance leaks other sessions' I/O.
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { makeTraceTools } from '../tools/trace'
+import type { Event } from '../trace/types'
+
+function startedEvent(runId: string, previousRunId?: string): Event {
+  return {
+    id: `${runId}-s`, runId, type: 'agent.run.started', actor: 'test', timestamp: 0,
+    payload: { agentId: 'a', goal: 'g', input: 'VICTIM QUESTION', contextId: 'other',
+               ...(previousRunId ? { previousRunId } : {}) },
+  } as Event
+}
+function llmReq(runId: string): Event {
+  return {
+    id: `${runId}-llm`, runId, type: 'llm.requested', actor: 'test', timestamp: 1,
+    payload: { requestHash: 'h1', request: { system: 'SECRET PROMPT', messages: [], tools: [] } },
+  } as Event
+}
+function completed(runId: string): Event {
+  return {
+    id: `${runId}-c`, runId, type: 'agent.run.completed', actor: 'test', timestamp: 4,
+    payload: { lastTextOutput: 'VICTIM ANSWER' },
+  } as Event
+}
+
+describe('makeTraceTools selfOnly mode (generic/serve registration)', () => {
+  it('omits get_run_io entirely (it has no self meaning)', () => {
+    const names = makeTraceTools(new MemoryEventStore(), undefined, { selfOnly: true }).map(t => t.name)
+    expect(names).not.toContain('get_run_io')
+    expect(names).toEqual(expect.arrayContaining(['get_execution', 'get_lineage']))
+  })
+
+  it('get_execution drops runId from its inputSchema', () => {
+    const tool = makeTraceTools(new MemoryEventStore(), undefined, { selfOnly: true })
+      .find(t => t.name === 'get_execution')!
+    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeUndefined()
+  })
+
+  it('get_execution ignores a foreign runId — returns self window, never the target run', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), llmReq('victim'), completed('victim')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_execution')!
+    // Attacker passes the victim's runId AND has no previousRunId of their own.
+    const res = await tool.handler({ runId: 'victim' }, {} as never) as { turns?: unknown[]; steps?: unknown }
+    expect(res.turns).toEqual([])      // self window only; first turn → empty
+    expect(res.steps).toBeUndefined()  // NOT the full projection
+    expect(JSON.stringify(res)).not.toContain('SECRET PROMPT')
+  })
+
+  it('get_lineage ignores a foreign runId — searches only the self window', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), completed('victim')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_lineage')!
+    const res = await tool.handler({ runId: 'victim', query: 'VICTIM' }, {} as never) as { matches: unknown[] }
+    expect(res.matches).toEqual([])
+  })
+})
+
+describe('makeTraceTools full mode (diagnoser, default) is unchanged', () => {
+  it('still exposes get_run_io and honours an explicit runId', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('target'), completed('target')]) await store.append(e)
+    const names = makeTraceTools(store).map(t => t.name)
+    expect(names).toEqual(expect.arrayContaining(['get_run_io', 'get_execution', 'get_lineage']))
+    const tool = makeTraceTools(store).find(t => t.name === 'get_run_io')!
+    const res = await tool.handler({ runId: 'target' }, {} as never) as { question: string; finalAnswer: string }
+    expect(res.question).toBe('VICTIM QUESTION')
+    expect(res.finalAnswer).toBe('VICTIM ANSWER')
+  })
+})

--- a/src/__tests__/traceToolsServeRegistration.test.ts
+++ b/src/__tests__/traceToolsServeRegistration.test.ts
@@ -1,24 +1,56 @@
 // src/__tests__/traceToolsServeRegistration.test.ts
-// #196: read-trace tools (get_execution/get_lineage/get_run_io) must be registered
-// wherever an eventStore is present — not only via the dead-code loadStandardAgents
-// path. This covers the serve --agent path, which #189's tests never exercised.
+// #196: self-explain read-trace tools must be registered wherever an eventStore is
+// present — not only via the opt-in loadStandardAgents path. This covers the serve
+// --agent path, which #189's tests never exercised.
+//
+// #196 follow-up (P1): the generic registration must be SELF-ONLY — get_execution /
+// get_lineage without a runId axis, and NO get_run_io. Reading an arbitrary runId is
+// the diagnoser's privilege (loadStandardAgents). On a shared serve instance the full
+// version would let any session read another's I/O.
 import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
 import { MemoryEventStore } from '../trace/MemoryEventStore'
+import type { ToolDefinition } from '../types/tool'
 
 const toolNames = (m: Milkie): string[] =>
   (m as unknown as { extraTools: Array<{ name: string }> }).extraTools.map(t => t.name)
 
 describe('#196 read-trace tools registered whenever an eventStore is present', () => {
-  it('a Milkie built with an eventStore exposes read-trace tools without loadStandardAgents', () => {
+  it('a Milkie built with an eventStore exposes self-view tools without loadStandardAgents', () => {
     const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
     // No loadStandardAgents() call — mirrors the serve --agent path.
-    expect(toolNames(milkie)).toEqual(
-      expect.arrayContaining(['get_execution', 'get_lineage', 'get_run_io']))
+    expect(toolNames(milkie)).toEqual(expect.arrayContaining(['get_execution', 'get_lineage']))
+  })
+
+  it('the generic registration does NOT expose get_run_io (diagnoser-only privilege)', () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
+    expect(toolNames(milkie)).not.toContain('get_run_io')
+  })
+
+  it('the generic get_execution has no runId axis (cannot read a foreign run)', () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
+    const tool = (milkie as unknown as { extraTools: ToolDefinition[] }).extraTools
+      .find(t => t.name === 'get_execution')!
+    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeUndefined()
   })
 
   it('a Milkie built without an eventStore registers no read-trace tools', () => {
     const milkie = new Milkie({ stateStore: new MemoryStore() })
     expect(toolNames(milkie)).not.toContain('get_execution')
+  })
+})
+
+describe('constructor does not mutate the caller-supplied tools array (P1)', () => {
+  it('leaves the passed array untouched', () => {
+    const tools: ToolDefinition[] = []
+    new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), tools })
+    expect(tools).toHaveLength(0)
+  })
+
+  it('reusing one array across instances does not leak trace tools into a store-less instance', () => {
+    const tools: ToolDefinition[] = []
+    new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore(), tools })
+    const b = new Milkie({ stateStore: new MemoryStore(), tools }) // no eventStore
+    expect(toolNames(b)).not.toContain('get_execution')
   })
 })

--- a/src/__tests__/traceToolsServeRegistration.test.ts
+++ b/src/__tests__/traceToolsServeRegistration.test.ts
@@ -1,0 +1,24 @@
+// src/__tests__/traceToolsServeRegistration.test.ts
+// #196: read-trace tools (get_execution/get_lineage/get_run_io) must be registered
+// wherever an eventStore is present — not only via the dead-code loadStandardAgents
+// path. This covers the serve --agent path, which #189's tests never exercised.
+import { Milkie } from '../runtime/Milkie'
+import { MemoryStore } from '../store/MemoryStore'
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+
+const toolNames = (m: Milkie): string[] =>
+  (m as unknown as { extraTools: Array<{ name: string }> }).extraTools.map(t => t.name)
+
+describe('#196 read-trace tools registered whenever an eventStore is present', () => {
+  it('a Milkie built with an eventStore exposes read-trace tools without loadStandardAgents', () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
+    // No loadStandardAgents() call — mirrors the serve --agent path.
+    expect(toolNames(milkie)).toEqual(
+      expect.arrayContaining(['get_execution', 'get_lineage', 'get_run_io']))
+  })
+
+  it('a Milkie built without an eventStore registers no read-trace tools', () => {
+    const milkie = new Milkie({ stateStore: new MemoryStore() })
+    expect(toolNames(milkie)).not.toContain('get_execution')
+  })
+})

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -113,6 +113,16 @@ export class Milkie {
     this.eventStore      = opts.eventStore       ?? null
     this.traceObjectStore = opts.traceObjectStore ?? null
     this.log             = opts.logger           ?? getLogger()
+
+    // #196: read-trace tools (get_execution/get_lineage/get_run_io) are generic
+    // self-explain capabilities — register them wherever an eventStore exists,
+    // symmetric with the write-side lineageTools that AgentRuntime registers
+    // unconditionally. Previously these were only wired via loadStandardAgents(),
+    // which the serve --agent path never calls, leaving serve agents unable to
+    // self-explain. Dedup is handled downstream (registry registers by name).
+    if (this.eventStore) {
+      this.extraTools.push(...makeTraceTools(this.eventStore, this.traceObjectStore ?? undefined))
+    }
   }
 
   private resolveModel(config: AgentConfig, tier?: string): ModelConfig | undefined {

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -108,20 +108,25 @@ export class Milkie {
     this.stateStore      = opts.stateStore
     this.gatewayOverride = opts.gateway          ?? null
     this.defaultModel    = opts.defaultModel     ?? null
-    this.extraTools      = opts.tools            ?? []
+    this.extraTools      = [...(opts.tools ?? [])]   // copy: never mutate the caller's array
     this.trajectoryStore = opts.trajectoryStore  ?? null
     this.eventStore      = opts.eventStore       ?? null
     this.traceObjectStore = opts.traceObjectStore ?? null
     this.log             = opts.logger           ?? getLogger()
 
-    // #196: read-trace tools (get_execution/get_lineage/get_run_io) are generic
-    // self-explain capabilities — register them wherever an eventStore exists,
-    // symmetric with the write-side lineageTools that AgentRuntime registers
-    // unconditionally. Previously these were only wired via loadStandardAgents(),
-    // which the serve --agent path never calls, leaving serve agents unable to
-    // self-explain. Dedup is handled downstream (registry registers by name).
+    // #196: self-explain read-trace tools (get_execution/get_lineage) are generic
+    // capabilities — register them wherever an eventStore exists, symmetric with the
+    // write-side lineageTools that AgentRuntime registers unconditionally. Previously
+    // these were only wired via loadStandardAgents(), which the serve --agent path
+    // never calls, leaving serve agents unable to self-explain.
+    //
+    // selfOnly: this generic registration is SELF-溯源 only (no runId axis, no
+    // get_run_io). Reading an arbitrary runId is the diagnoser's privilege, granted by
+    // the full version via loadStandardAgents(); the full version, registered later by
+    // name, upgrades these in that opt-in path. Without selfOnly, a shared serve
+    // instance would let one session read another's recorded I/O (#196 P1).
     if (this.eventStore) {
-      this.extraTools.push(...makeTraceTools(this.eventStore, this.traceObjectStore ?? undefined))
+      this.extraTools.push(...makeTraceTools(this.eventStore, this.traceObjectStore ?? undefined, { selfOnly: true }))
     }
   }
 

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -34,7 +34,7 @@ export function makeTraceTools(
     },
   }
   const LOOKBACK_DEFAULT = 3
-  const LOOKBACK_MAX = 10
+  const LOOKBACK_MAX = 30
 
   /** Self view: drop llm step prompt/response bodies, keep tool steps. */
   function selfShape(steps: ExecutionStep[]): { toolSteps: ToolStep[]; llmStepCount: number } {
@@ -60,7 +60,7 @@ export function makeTraceTools(
       '诊断:传 { runId } 取该 run 全量投影(steps)。自溯源:不传 runId,取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。',
     inputSchema: { type: 'object', properties: {
       runId:    { type: 'string' },
-      lookback: { type: 'number', description: '自溯源回看的轮数,默认 3,上限 10' },
+      lookback: { type: 'number', description: '自溯源回看的轮数,默认 3,上限 30' },
     } },
     handler: async (input, ctx) => {
       const { runId, lookback } = (input ?? {}) as { runId?: string; lookback?: number }
@@ -84,7 +84,7 @@ export function makeTraceTools(
       '默认在自己最近 N 轮(lookback,默认 3)里搜;也可传 { runId } 限定单轮。返回 matches:{ runId, claim, sources }。',
     inputSchema: { type: 'object', properties: {
       runId:    { type: 'string' },
-      lookback: { type: 'number', description: '回看轮数,默认 3,上限 10' },
+      lookback: { type: 'number', description: '回看轮数,默认 3,上限 30' },
       query:    { type: 'string', description: '要溯源的结论/数字文本' },
     } },
     handler: async (input, ctx) => {

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -14,10 +14,20 @@ import { resolveClaimSources } from '../trace/diagnostics/buildLineageProjection
  * the agent. `runId` is the run being DIAGNOSED (distinct from the diagnoser's
  * own run).
  */
+/**
+ * `selfOnly` (default false): restrict to self-溯源 only — drop the `runId` axis
+ * from get_execution/get_lineage and omit get_run_io entirely. This is the GENERIC
+ * registration handed to every eventStore-enabled agent (#196). Reading an arbitrary
+ * `runId` is the diagnoser's privilege, granted via the full version through
+ * loadStandardAgents(); on a shared serve instance the full version would let one
+ * session read another's recorded I/O.
+ */
 export function makeTraceTools(
   eventStore: IEventStore,
   objectStore?: ITraceObjectStore,
+  opts?: { selfOnly?: boolean },
 ): ToolDefinition[] {
+  const selfOnly = opts?.selfOnly ?? false
   const get_run_io: ToolDefinition = {
     name: 'get_run_io',
     description: '取被诊断 run 的用户问题与最终答案。入参 { runId }。',
@@ -56,14 +66,18 @@ export function makeTraceTools(
 
   const get_execution: ToolDefinition = {
     name: 'get_execution',
-    description: '取执行投影:步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。' +
-      '诊断:传 { runId } 取该 run 全量投影(steps)。自溯源:不传 runId,取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。',
+    description: selfOnly
+      ? '自溯源执行投影:取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。'
+      : '取执行投影:步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。' +
+        '诊断:传 { runId } 取该 run 全量投影(steps)。自溯源:不传 runId,取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。',
     inputSchema: { type: 'object', properties: {
-      runId:    { type: 'string' },
+      ...(selfOnly ? {} : { runId: { type: 'string' } }),
       lookback: { type: 'number', description: '自溯源回看的轮数,默认 3,上限 30' },
     } },
     handler: async (input, ctx) => {
-      const { runId, lookback } = (input ?? {}) as { runId?: string; lookback?: number }
+      const raw = (input ?? {}) as { runId?: string; lookback?: number }
+      const runId = selfOnly ? undefined : raw.runId
+      const lookback = raw.lookback
       if (runId) {
         const events = await eventStore.readByRunId(runId)
         return buildExecutionProjection(events, { regionContent: await regionContentFor(events) })
@@ -80,15 +94,19 @@ export function makeTraceTools(
   }
   const get_lineage: ToolDefinition = {
     name: 'get_lineage',
-    description: '溯源:某条结论/数字引用了哪条源。传 { query } 按结论文本子串匹配(如对话里出现的数字),' +
-      '默认在自己最近 N 轮(lookback,默认 3)里搜;也可传 { runId } 限定单轮。返回 matches:{ runId, claim, sources }。',
+    description: selfOnly
+      ? '溯源:某条结论/数字引用了哪条源。传 { query } 按结论文本子串匹配,在自己最近 N 轮(lookback,默认 3)里搜。返回 matches:{ runId, claim, sources }。'
+      : '溯源:某条结论/数字引用了哪条源。传 { query } 按结论文本子串匹配(如对话里出现的数字),' +
+        '默认在自己最近 N 轮(lookback,默认 3)里搜;也可传 { runId } 限定单轮。返回 matches:{ runId, claim, sources }。',
     inputSchema: { type: 'object', properties: {
-      runId:    { type: 'string' },
+      ...(selfOnly ? {} : { runId: { type: 'string' } }),
       lookback: { type: 'number', description: '回看轮数,默认 3,上限 30' },
       query:    { type: 'string', description: '要溯源的结论/数字文本' },
     } },
     handler: async (input, ctx) => {
-      const { runId, lookback, query } = (input ?? {}) as { runId?: string; lookback?: number; query?: string }
+      const raw = (input ?? {}) as { runId?: string; lookback?: number; query?: string }
+      const runId = selfOnly ? undefined : raw.runId
+      const { lookback, query } = raw
       const window = runId
         ? [{ runId, events: await eventStore.readByRunId(runId) }]
         : await walkRunWindow(eventStore, (ctx as ToolContext | undefined)?.previousRunId,
@@ -102,5 +120,5 @@ export function makeTraceTools(
       return { matches }
     },
   }
-  return [get_run_io, get_execution, get_lineage]
+  return selfOnly ? [get_execution, get_lineage] : [get_run_io, get_execution, get_lineage]
 }


### PR DESCRIPTION
Milkie constructor 里 if eventStore 注册 makeTraceTools,与写端 lineageTools 对称。修复 serve --agent agent 缺读端工具、self-explain 失效(#189 盲区)。lookback 10→30。Closes #196. 来源 alfred#116.

## 安全修复(P1,review 反馈,commit 7a2b3d2)

review 指出 #196 的通用注册引入两处 P1:

1. **跨会话泄露** — 通用注册把带 runId 的全量 trace 工具发给所有 eventStore agent;`getForState(undefined)` 返回全部工具,故任何无 `tools:` 白名单的 FSM state 都能传任意 runId 读别的会话的问题/答案/执行链。共享 serve 实例构成跨会话数据泄露。
2. **数组污染** — 构造函数持有 `opts.tools` 引用并就地 push;复用同一数组建第二个(未配 eventStore 的)实例会带上前一个 store 绑定的句柄。

**方案:注册边界分离(self-only vs full)**

- `makeTraceTools(eventStore, objectStore, { selfOnly })`:`selfOnly` 时去掉 runId 轴、不返回 `get_run_io`,只留 self-溯源。构造函数(serve/通用)改传 `selfOnly:true`。
- 读任意 runId 仍是 diagnoser 特权,经 `loadStandardAgents()` 的 full 版本按 name 后写覆盖授予,默认行为与 diagnoser 契约不变。
- 未采用「按 contextId 校验归属」:diagnoser 诊断时跑在另一个 contextId(`diagnose:${runId}`),归属校验会拒掉它自己的正常诊断,需再开能力例外 = 逻辑网关,违背「结构大于逻辑」。
- 构造函数 `this.extraTools = [...(opts.tools ?? [])]` 拷贝数组,不再污染调用方。

**验证**:新增 `traceTools.selfOnly.test.ts` + 改写 `traceToolsServeRegistration.test.ts`(先 RED 后 GREEN);trace + standardAgentLayer 套件全绿;`tsc --noEmit` 通过;全量 996 用例 15 failed 全部为基线已存在,与本次改动无关。