### PR TITLE
feat(#200): lineage 句柄精确解引用 + 投递域 runId 门控 + 子串归位

### DIFF
--- a/src/__tests__/AgentRuntime.deliveredRunIds.test.ts
+++ b/src/__tests__/AgentRuntime.deliveredRunIds.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #200 C: AgentRuntime exposes ctx.deliveredRunIds — the sourceRunIds of the
+ * external projections delivered to this run — so the selfOnly trace tools can
+ * gate runId dereference on "was this delivered to me".
+ */
+import { AgentRuntime } from '../runtime/AgentRuntime'
+import { DefaultIOPort } from '../runtime/IOPort'
+import { MemoryStore } from '../store/MemoryStore'
+import { InMemoryRecorder } from '../trajectory/InMemoryRecorder'
+import type { AgentConfig } from '../types/agent'
+import type { ContextProjection } from '../types/common'
+import type { IModelGateway, ModelRequest, ModelResponse } from '../types/model'
+import type { ToolDefinition } from '../types/tool'
+
+function makeConfig(): AgentConfig {
+  return {
+    agentId:      'test-agent',
+    version:      '1.0.0',
+    systemPrompt: 'You are a test agent.',
+    fsm:          { states: [{ name: 'react', type: 'llm' }] },
+    model:        { provider: 'test', model: 'test-model', adapter: 'test' },
+  }
+}
+
+class SequentialGateway implements IModelGateway {
+  private index = 0
+  constructor(private readonly responses: ModelResponse[]) {}
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const r = this.responses[this.index++]
+    if (!r) throw new Error('No more mock responses')
+    return r
+  }
+  async *stream(_req: ModelRequest): AsyncIterable<never> { yield* [] }
+}
+
+const toolCall = (id: string, name: string): ModelResponse => ({
+  content: [{ type: 'tool_use', id, name, input: {} }], toolCalls: [{ id, name, input: {} }], finishReason: 'tool_use',
+})
+const text = (t: string): ModelResponse => ({ content: [{ type: 'text', text: t }], toolCalls: [], finishReason: 'end_turn' })
+
+function projection(sourceRunId: string): ContextProjection {
+  return { sourceRunId, displayText: 'a delivered report', deliveredAt: 1, attachedAt: 1 }
+}
+
+describe('#200 ToolContext.deliveredRunIds', () => {
+  it('a tool handler sees the sourceRunIds of the delivered projections', async () => {
+    let captured: string[] | undefined
+    const probe: ToolDefinition = {
+      name: 'probe', description: 'capture deliveredRunIds',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_i, ctx) => { captured = ctx.deliveredRunIds; return { ok: true } },
+    }
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'g',
+      input:      'hi',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([toolCall('t1', 'probe'), text('done')])),
+      extraTools: [probe],
+      externalProjections: [projection('job-run-1'), projection('job-run-2')],
+    })
+    await runtime.run('hi')
+    expect(captured).toEqual(['job-run-1', 'job-run-2'])
+  })
+
+  it('with no projections, deliveredRunIds is empty/undefined (no axis opened)', async () => {
+    let captured: string[] | undefined = ['sentinel']
+    const probe: ToolDefinition = {
+      name: 'probe', description: 'capture deliveredRunIds',
+      inputSchema: { type: 'object', properties: {} },
+      handler: async (_i, ctx) => { captured = ctx.deliveredRunIds; return { ok: true } },
+    }
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'g',
+      input:      'hi',
+      stateStore: new MemoryStore(),
+      recorder:   new InMemoryRecorder(),
+      ioPort:     new DefaultIOPort(new SequentialGateway([toolCall('t1', 'probe'), text('done')])),
+      extraTools: [probe],
+    })
+    await runtime.run('hi')
+    expect(captured ?? []).toEqual([])
+  })
+})

--- a/src/__tests__/buildLineageProjection.test.ts
+++ b/src/__tests__/buildLineageProjection.test.ts
@@ -1,4 +1,4 @@
-import { resolveClaimSources } from '../trace/diagnostics/buildLineageProjection'
+import { resolveClaimSources, derefObject } from '../trace/diagnostics/buildLineageProjection'
 import type { Event } from '../trace/types'
 
 function objCreated(objectId: string, type: string, meta?: Record<string, unknown>): Event {
@@ -27,5 +27,34 @@ describe('#189 resolveClaimSources', () => {
   })
   it('returns all claims when query omitted', () => {
     expect(resolveClaimSources(events)).toHaveLength(1)
+  })
+})
+
+describe('#200 A: derefObject — exact handle dereference (no text match)', () => {
+  const events: Event[] = [
+    objCreated('src1', 'shell:stdout', { source: 'cnbc', url: 'https://x' }),
+    objCreated('claim1', 'claim', { text: '某信号 — 原文地址' }),
+    citesRel('claim1', 'src1'),
+  ]
+
+  it('dereferences a claim by its objectId → its type/meta and the sources it cites', () => {
+    const r = derefObject(events, 'claim1')!
+    expect(r.objectId).toBe('claim1')
+    expect(r.type).toBe('claim')
+    expect(r.meta).toEqual({ text: '某信号 — 原文地址' })
+    expect(r.cites).toEqual([{ objectId: 'src1', type: 'shell:stdout', meta: { source: 'cnbc', url: 'https://x' } }])
+    expect(r.citedBy).toEqual([])
+  })
+
+  it('dereferences a source object by its objectId → the claims that cite it (reverse)', () => {
+    const r = derefObject(events, 'src1')!
+    expect(r.objectId).toBe('src1')
+    expect(r.type).toBe('shell:stdout')
+    expect(r.cites).toEqual([])
+    expect(r.citedBy).toEqual([{ objectId: 'claim1', type: 'claim', meta: { text: '某信号 — 原文地址' } }])
+  })
+
+  it('returns undefined for an unknown objectId (no fabrication)', () => {
+    expect(derefObject(events, 'nope')).toBeUndefined()
   })
 })

--- a/src/__tests__/traceTools.deliveredDeref.test.ts
+++ b/src/__tests__/traceTools.deliveredDeref.test.ts
@@ -1,0 +1,121 @@
+// src/__tests__/traceTools.deliveredDeref.test.ts
+// #200 C: selfOnly 的 runId 轴由"全砍"改为"投递域白名单解引用"。
+// 句柄 = 本会话被投递过的 sourceRunId(ctx.deliveredRunIds);消费侧可解引用
+// "投递给我的那条产出"的执行/血缘/IO,但任意未投递 runId 仍被拒(保留 #196 安全属性)。
+import { MemoryEventStore } from '../trace/MemoryEventStore'
+import { makeTraceTools } from '../tools/trace'
+import type { Event } from '../trace/types'
+
+function startedEvent(runId: string, input = 'REPORT QUESTION'): Event {
+  return { id: `${runId}-s`, runId, type: 'agent.run.started', actor: 'test', timestamp: 0,
+    payload: { agentId: 'a', goal: 'g', input, contextId: 'job' } } as Event
+}
+function llmReq(runId: string): Event {
+  return { id: `${runId}-llm`, runId, type: 'llm.requested', actor: 'test', timestamp: 1,
+    payload: { requestHash: 'h1', request: { system: 'SECRET PROMPT', messages: [], tools: [] } } } as Event
+}
+function objCreated(runId: string, objectId: string, type: string, meta?: Record<string, unknown>): Event {
+  return { id: `${objectId}-c`, runId, type: 'object.created', actor: 'test', timestamp: 2,
+    payload: { objectId, type, producerEventId: 'p', ...(meta ? { meta } : {}) } } as Event
+}
+function citesRel(runId: string, from: string, to: string): Event {
+  return { id: `${from}-${to}`, runId, type: 'relation.created', actor: 'test', timestamp: 3,
+    payload: { relationId: `${from}-${to}`, type: 'cites', fromObjectId: from, toObjectId: to, causedByEventId: 'x' } } as Event
+}
+function completed(runId: string): Event {
+  return { id: `${runId}-c`, runId, type: 'agent.run.completed', actor: 'test', timestamp: 4,
+    payload: { lastTextOutput: 'REPORT ANSWER' } } as Event
+}
+
+const delivered = (...runIds: string[]) => ({ deliveredRunIds: runIds } as never)
+
+describe('#200 C: selfOnly delivered-runId gated dereference', () => {
+  it('get_execution honours a DELIVERED runId — returns that run\'s full projection', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('job-run-1'), llmReq('job-run-1'), completed('job-run-1')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_execution')!
+    const res = await tool.handler({ runId: 'job-run-1' }, delivered('job-run-1')) as { steps?: unknown[] }
+    expect(res.steps).toBeDefined()                       // full projection, not self-window turns
+    expect(JSON.stringify(res)).toContain('SECRET PROMPT') // the delivered report run is reachable
+  })
+
+  it('get_execution IGNORES a non-delivered runId — falls back to self window (no leak)', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), llmReq('victim'), completed('victim')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_execution')!
+    // 'victim' was never delivered to this session.
+    const res = await tool.handler({ runId: 'victim' }, delivered('job-run-1')) as { turns?: unknown[]; steps?: unknown }
+    expect(res.turns).toEqual([])
+    expect(res.steps).toBeUndefined()
+    expect(JSON.stringify(res)).not.toContain('SECRET PROMPT')
+  })
+
+  it('get_lineage honours a DELIVERED runId — surfaces that run\'s claim→source graph', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('job-run-1'),
+      objCreated('job-run-1', 'src1', 'shell:stdout', { source: 'cnbc' }),
+      objCreated('job-run-1', 'claim1', 'claim', { text: '某信号' }),
+      citesRel('job-run-1', 'claim1', 'src1')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_lineage')!
+    const res = await tool.handler({ runId: 'job-run-1' }, delivered('job-run-1')) as
+      { matches: { runId: string; sources: { objectId: string }[] }[] }
+    expect(res.matches).toHaveLength(1)
+    expect(res.matches[0]!.runId).toBe('job-run-1')
+    expect(res.matches[0]!.sources[0]!.objectId).toBe('src1')
+  })
+
+  it('get_lineage IGNORES a non-delivered runId', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'),
+      objCreated('victim', 'claim1', 'claim', { text: '机密' }),
+      objCreated('victim', 'src1', 'passage'),
+      citesRel('victim', 'claim1', 'src1')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_lineage')!
+    const res = await tool.handler({ runId: 'victim' }, delivered('job-run-1')) as { matches: unknown[] }
+    expect(res.matches).toEqual([])
+  })
+
+  it('get_run_io is registered in selfOnly mode and returns a DELIVERED run\'s I/O', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('job-run-1'), completed('job-run-1')]) await store.append(e)
+    const tools = makeTraceTools(store, undefined, { selfOnly: true })
+    expect(tools.map(t => t.name)).toContain('get_run_io')
+    const tool = tools.find(t => t.name === 'get_run_io')!
+    const res = await tool.handler({ runId: 'job-run-1' }, delivered('job-run-1')) as
+      { question?: string; finalAnswer?: string; error?: string }
+    expect(res.question).toBe('REPORT QUESTION')
+    expect(res.finalAnswer).toBe('REPORT ANSWER')
+  })
+
+  it('get_run_io REFUSES a non-delivered runId (no cross-session I/O leak)', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), completed('victim')]) await store.append(e)
+    const tool = makeTraceTools(store, undefined, { selfOnly: true }).find(t => t.name === 'get_run_io')!
+    const res = await tool.handler({ runId: 'victim' }, delivered('job-run-1')) as
+      { question?: string; finalAnswer?: string; error?: string }
+    expect(res.error).toBeDefined()
+    expect(res.question).toBeUndefined()
+    expect(JSON.stringify(res)).not.toContain('REPORT ANSWER')
+  })
+
+  it('with NO deliveredRunIds in ctx, selfOnly still ignores/refuses every runId', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), llmReq('victim'), completed('victim')]) await store.append(e)
+    const tools = makeTraceTools(store, undefined, { selfOnly: true })
+    const exec = await tools.find(t => t.name === 'get_execution')!.handler({ runId: 'victim' }, {} as never) as { turns?: unknown[] }
+    expect(exec.turns).toEqual([])
+    const io = await tools.find(t => t.name === 'get_run_io')!.handler({ runId: 'victim' }, {} as never) as { error?: string }
+    expect(io.error).toBeDefined()
+  })
+})
+
+describe('#200 C: full (diagnoser) mode is unaffected — any runId still honoured', () => {
+  it('get_run_io reads an arbitrary runId without a delivered allowlist', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('target'), completed('target')]) await store.append(e)
+    const tool = makeTraceTools(store).find(t => t.name === 'get_run_io')!
+    const res = await tool.handler({ runId: 'target' }, {} as never) as { question: string; finalAnswer: string }
+    expect(res.question).toBe('REPORT QUESTION')
+    expect(res.finalAnswer).toBe('REPORT ANSWER')
+  })
+})

--- a/src/__tests__/traceTools.lineage.test.ts
+++ b/src/__tests__/traceTools.lineage.test.ts
@@ -34,3 +34,36 @@ describe('#189 get_lineage', () => {
     expect(res.matches[0]!.sources[0]!.objectId).toBe('src1')
   })
 })
+
+describe('#200 A: get_lineage exact handle dereference', () => {
+  async function seed() {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('run1'),
+      objCreated('run1', 'src1', 'shell:stdout', { url: 'https://cnbc' }),
+      objCreated('run1', 'claim1', 'claim', { text: '某信号' }),
+      citesRel('run1', 'claim1', 'src1')]) await store.append(e)
+    await store.append(startedEvent('run2', 'run1'))
+    return store
+  }
+
+  it('deref by objectId returns the cites neighbourhood, no text match needed', async () => {
+    const store = await seed()
+    const tool = makeTraceTools(store).find(t => t.name === 'get_lineage')!
+    const res = await tool.handler({ objectId: 'src1' }, { previousRunId: 'run2' } as never) as
+      { refs: { runId: string; objectId: string; citedBy: { objectId: string }[] }[] }
+    expect(res.refs).toHaveLength(1)
+    expect(res.refs[0]!.runId).toBe('run1')
+    expect(res.refs[0]!.objectId).toBe('src1')
+    expect(res.refs[0]!.citedBy[0]!.objectId).toBe('claim1')
+  })
+
+  it('deref by claimId returns that claim\'s sources deterministically', async () => {
+    const store = await seed()
+    const tool = makeTraceTools(store).find(t => t.name === 'get_lineage')!
+    const res = await tool.handler({ claimId: 'claim1' }, { previousRunId: 'run2' } as never) as
+      { refs: { objectId: string; cites: { objectId: string }[] }[] }
+    expect(res.refs).toHaveLength(1)
+    expect(res.refs[0]!.objectId).toBe('claim1')
+    expect(res.refs[0]!.cites[0]!.objectId).toBe('src1')
+  })
+})

--- a/src/__tests__/traceTools.selfOnly.test.ts
+++ b/src/__tests__/traceTools.selfOnly.test.ts
@@ -1,8 +1,11 @@
 // src/__tests__/traceTools.selfOnly.test.ts
-// #196 follow-up (P1 security): the GENERIC registration (serve/constructor) must
-// expose only a self-view. Reading an arbitrary runId is the diagnoser's privilege,
-// granted via loadStandardAgents(), not something every eventStore-enabled agent
-// should get — otherwise a shared serve instance leaks other sessions' I/O.
+// #196 follow-up (P1 security): the GENERIC registration (serve/constructor) must not
+// let an agent read an ARBITRARY runId — otherwise a shared serve instance leaks other
+// sessions' I/O. #200 C refines "self-view only" into "self-view + delivered-runId
+// dereference": a selfOnly agent may reach a runId that was *delivered to it* via a
+// projection (ctx.deliveredRunIds), but any other runId is still ignored/refused. These
+// tests pin the security boundary (non-delivered runId leaks nothing); the positive
+// delivered-runId path lives in traceTools.deliveredDeref.test.ts.
 import { MemoryEventStore } from '../trace/MemoryEventStore'
 import { makeTraceTools } from '../tools/trace'
 import type { Event } from '../trace/types'
@@ -28,16 +31,24 @@ function completed(runId: string): Event {
 }
 
 describe('makeTraceTools selfOnly mode (generic/serve registration)', () => {
-  it('omits get_run_io entirely (it has no self meaning)', () => {
-    const names = makeTraceTools(new MemoryEventStore(), undefined, { selfOnly: true }).map(t => t.name)
-    expect(names).not.toContain('get_run_io')
-    expect(names).toEqual(expect.arrayContaining(['get_execution', 'get_lineage']))
+  it('registers get_run_io but gates it — a non-delivered runId is refused (#200 C)', async () => {
+    const store = new MemoryEventStore()
+    for (const e of [startedEvent('victim'), completed('victim')]) await store.append(e)
+    const tools = makeTraceTools(store, undefined, { selfOnly: true })
+    expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(['get_run_io', 'get_execution', 'get_lineage']))
+    // No deliveredRunIds in ctx → the victim's runId is not dereferenceable.
+    const res = await tools.find(t => t.name === 'get_run_io')!.handler({ runId: 'victim' }, {} as never) as
+      { error?: string; question?: string }
+    expect(res.error).toBeDefined()
+    expect(JSON.stringify(res)).not.toContain('VICTIM ANSWER')
   })
 
-  it('get_execution drops runId from its inputSchema', () => {
+  it('get_execution exposes runId but ignores one that was not delivered (#200 C)', () => {
     const tool = makeTraceTools(new MemoryEventStore(), undefined, { selfOnly: true })
       .find(t => t.name === 'get_execution')!
-    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeUndefined()
+    // runId is now in the schema (delivered runs are reachable) ...
+    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeDefined()
+    // ... but the security behaviour is asserted below: a non-delivered runId yields the self window.
   })
 
   it('get_execution ignores a foreign runId — returns self window, never the target run', async () => {

--- a/src/__tests__/traceToolsServeRegistration.test.ts
+++ b/src/__tests__/traceToolsServeRegistration.test.ts
@@ -3,10 +3,12 @@
 // present — not only via the opt-in loadStandardAgents path. This covers the serve
 // --agent path, which #189's tests never exercised.
 //
-// #196 follow-up (P1): the generic registration must be SELF-ONLY — get_execution /
-// get_lineage without a runId axis, and NO get_run_io. Reading an arbitrary runId is
-// the diagnoser's privilege (loadStandardAgents). On a shared serve instance the full
-// version would let any session read another's I/O.
+// #196 follow-up (P1): the generic registration must not let an agent read an ARBITRARY
+// runId — on a shared serve instance that would leak another session's I/O. #200 C
+// refines this: the runId axis is present but GATED to ctx.deliveredRunIds (runs
+// delivered to this session via a projection); a non-delivered runId is ignored
+// (get_execution/get_lineage) or refused (get_run_io). Reading any runId remains the
+// diagnoser's privilege via loadStandardAgents().
 import { Milkie } from '../runtime/Milkie'
 import { MemoryStore } from '../store/MemoryStore'
 import { MemoryEventStore } from '../trace/MemoryEventStore'
@@ -22,16 +24,23 @@ describe('#196 read-trace tools registered whenever an eventStore is present', (
     expect(toolNames(milkie)).toEqual(expect.arrayContaining(['get_execution', 'get_lineage']))
   })
 
-  it('the generic registration does NOT expose get_run_io (diagnoser-only privilege)', () => {
+  it('the generic registration exposes get_run_io but gated to delivered runIds (#200 C)', async () => {
     const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
-    expect(toolNames(milkie)).not.toContain('get_run_io')
+    expect(toolNames(milkie)).toContain('get_run_io')
+    // Without a delivered runId in ctx, get_run_io refuses — no cross-session read.
+    const tool = (milkie as unknown as { extraTools: ToolDefinition[] }).extraTools
+      .find(t => t.name === 'get_run_io')!
+    const res = await tool.handler({ runId: 'someone-elses-run' }, {} as never) as { error?: string }
+    expect(res.error).toBeDefined()
   })
 
-  it('the generic get_execution has no runId axis (cannot read a foreign run)', () => {
+  it('the generic get_execution exposes runId but gates it to delivered runs (#200 C)', () => {
     const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: new MemoryEventStore() })
     const tool = (milkie as unknown as { extraTools: ToolDefinition[] }).extraTools
       .find(t => t.name === 'get_execution')!
-    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeUndefined()
+    // runId axis is present (delivered runs are reachable); the gating is behavioural,
+    // covered by traceTools.deliveredDeref.test.ts (non-delivered runId → self window).
+    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.runId).toBeDefined()
   })
 
   it('a Milkie built without an eventStore registers no read-trace tools', () => {

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -333,6 +333,11 @@ export class AgentRuntime {
       requestSkill:  (name: string, scope?: 'turn' | 'session') => this.requestSkill(name, scope),
       currentTurn:   this.currentTurnRaw,
       previousRunId: this.previousRunId,
+      // #200 C: the runIds delivered to this turn via projections — the allowlist
+      // the selfOnly trace tools gate runId dereference on.
+      ...(this.externalProjections?.length
+        ? { deliveredRunIds: [...new Set(this.externalProjections.map(p => p.sourceRunId))] }
+        : {}),
     }
     // #37/#38: only wire lineage when a sink is present (LLM-state tool calls go
     // through ioPort.invokeTool, which drains the buffer). objectId/relationId are

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -120,11 +120,13 @@ export class Milkie {
     // these were only wired via loadStandardAgents(), which the serve --agent path
     // never calls, leaving serve agents unable to self-explain.
     //
-    // selfOnly: this generic registration is SELF-溯源 only (no runId axis, no
-    // get_run_io). Reading an arbitrary runId is the diagnoser's privilege, granted by
-    // the full version via loadStandardAgents(); the full version, registered later by
-    // name, upgrades these in that opt-in path. Without selfOnly, a shared serve
-    // instance would let one session read another's recorded I/O (#196 P1).
+    // selfOnly: this generic registration withholds the diagnoser privilege of reading
+    // an ARBITRARY runId — without it a shared serve instance would let one session read
+    // another's recorded I/O (#196 P1). It is NOT a blanket ban on the runId axis: a
+    // selfOnly agent may dereference a runId DELIVERED to it via a projection
+    // (ctx.deliveredRunIds, #200 C), so a consumer can reach the execution/lineage/I/O of
+    // "the report delivered to me". The full version, registered later by name via
+    // loadStandardAgents(), upgrades these to honour any runId.
     if (this.eventStore) {
       this.extraTools.push(...makeTraceTools(this.eventStore, this.traceObjectStore ?? undefined, { selfOnly: true }))
     }

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -6,7 +6,7 @@ import { regionReuseCounts } from '../trace/RegionContextView.js'
 import { buildExecutionProjection } from '../trace/diagnostics/buildExecutionProjection.js'
 import type { ExecutionStep, ToolStep } from '../trace/diagnostics/buildExecutionProjection.js'
 import { walkRunWindow } from '../trace/diagnostics/walkRunWindow.js'
-import { resolveClaimSources } from '../trace/diagnostics/buildLineageProjection.js'
+import { resolveClaimSources, derefObject } from '../trace/diagnostics/buildLineageProjection.js'
 
 /**
  * Read-Trace tools for the diagnoser agent: deterministic projections over a
@@ -15,12 +15,14 @@ import { resolveClaimSources } from '../trace/diagnostics/buildLineageProjection
  * own run).
  */
 /**
- * `selfOnly` (default false): restrict to self-溯源 only — drop the `runId` axis
- * from get_execution/get_lineage and omit get_run_io entirely. This is the GENERIC
- * registration handed to every eventStore-enabled agent (#196). Reading an arbitrary
- * `runId` is the diagnoser's privilege, granted via the full version through
- * loadStandardAgents(); on a shared serve instance the full version would let one
- * session read another's recorded I/O.
+ * `selfOnly` (default false): the GENERIC registration handed to every
+ * eventStore-enabled agent (#196). It withholds the diagnoser privilege of reading
+ * an *arbitrary* runId — on a shared serve instance that would leak another session's
+ * recorded I/O. It does NOT, however, blanket-drop the runId axis: a selfOnly agent
+ * may dereference a runId that was *delivered to it* via a projection (#200 C). The
+ * allowlist is `ctx.deliveredRunIds`; a runId outside it is ignored (get_execution /
+ * get_lineage fall back to the self window) or refused (get_run_io). The full version,
+ * granted via loadStandardAgents(), honours any runId.
  */
 export function makeTraceTools(
   eventStore: IEventStore,
@@ -28,12 +30,28 @@ export function makeTraceTools(
   opts?: { selfOnly?: boolean },
 ): ToolDefinition[] {
   const selfOnly = opts?.selfOnly ?? false
+
+  /**
+   * #200 C: resolve the runId a selfOnly handler may act on. Full mode → any runId.
+   * selfOnly → the runId only if it was delivered to this run (capability-by-handle);
+   * otherwise undefined, so the caller treats it as "no runId" (self window).
+   */
+  function gatedRunId(rawRunId: string | undefined, ctx: ToolContext | undefined): string | undefined {
+    if (!selfOnly) return rawRunId
+    if (!rawRunId) return undefined
+    return ctx?.deliveredRunIds?.includes(rawRunId) ? rawRunId : undefined
+  }
+
   const get_run_io: ToolDefinition = {
     name: 'get_run_io',
-    description: '取被诊断 run 的用户问题与最终答案。入参 { runId }。',
+    description: selfOnly
+      ? '取投递给你的某条产出 run 的用户问题与最终答案。入参 { runId },runId 必须是上下文里 producedBy.runId(投递给你的那条 run);未投递的 runId 会被拒绝。'
+      : '取被诊断 run 的用户问题与最终答案。入参 { runId }。',
     inputSchema: { type: 'object', properties: { runId: { type: 'string' } }, required: ['runId'] },
-    handler: async (input) => {
-      const { runId } = input as { runId: string }
+    handler: async (input, ctx) => {
+      const rawRunId = (input as { runId: string }).runId
+      const runId = gatedRunId(rawRunId, ctx as ToolContext | undefined)
+      if (!runId) return { error: `runId '${rawRunId}' 未在投递上下文中,拒绝解引用;只能解引用上下文里 producedBy.runId 的那条 run。` }
       const events = await eventStore.readByRunId(runId)
       let question = '', finalAnswer = ''
       for (const e of events) {
@@ -67,16 +85,17 @@ export function makeTraceTools(
   const get_execution: ToolDefinition = {
     name: 'get_execution',
     description: selfOnly
-      ? '自溯源执行投影:取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。'
+      ? '执行投影。不传 runId:取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。' +
+        '传 { runId }:仅当它是投递给你的 producedBy.runId 时,取该 run 全量投影(steps);未投递的 runId 被忽略,退回自溯源窗口。'
       : '取执行投影:步骤序列(LLM/工具调用、工具 query、命中证据、region 组成)。' +
         '诊断:传 { runId } 取该 run 全量投影(steps)。自溯源:不传 runId,取自己最近 N 轮(默认 3)的工具步骤摘要(turns;不含 prompt 正文),可加 { lookback }。',
     inputSchema: { type: 'object', properties: {
-      ...(selfOnly ? {} : { runId: { type: 'string' } }),
+      runId: { type: 'string', ...(selfOnly ? { description: '投递给你的 producedBy.runId;未投递的 runId 被忽略' } : {}) },
       lookback: { type: 'number', description: '自溯源回看的轮数,默认 3,上限 30' },
     } },
     handler: async (input, ctx) => {
       const raw = (input ?? {}) as { runId?: string; lookback?: number }
-      const runId = selfOnly ? undefined : raw.runId
+      const runId = gatedRunId(raw.runId, ctx as ToolContext | undefined)
       const lookback = raw.lookback
       if (runId) {
         const events = await eventStore.readByRunId(runId)
@@ -94,23 +113,37 @@ export function makeTraceTools(
   }
   const get_lineage: ToolDefinition = {
     name: 'get_lineage',
-    description: selfOnly
-      ? '溯源:某条结论/数字引用了哪条源。传 { query } 按结论文本子串匹配,在自己最近 N 轮(lookback,默认 3)里搜。返回 matches:{ runId, claim, sources }。'
-      : '溯源:某条结论/数字引用了哪条源。传 { query } 按结论文本子串匹配(如对话里出现的数字),' +
-        '默认在自己最近 N 轮(lookback,默认 3)里搜;也可传 { runId } 限定单轮。返回 matches:{ runId, claim, sources }。',
+    description: '溯源某条结论/数字引用了哪条源。两种入口:' +
+      '①精确解引用(推荐):传 { claimId } 或源 { objectId }(工具/上下文给你的真实 id),确定性返回其 cites 邻域(cites/citedBy),返回 refs,无文本匹配。' +
+      '②弱检索:传 { query } 按结论文本子串匹配(如对话里出现的数字),返回 matches。' +
+      (selfOnly
+        ? '范围默认自己最近 N 轮(lookback,默认 3);也可传投递给你的 { runId }(未投递的 runId 被忽略)。'
+        : '范围默认自己最近 N 轮(lookback,默认 3);也可传 { runId } 限定单轮。'),
     inputSchema: { type: 'object', properties: {
-      ...(selfOnly ? {} : { runId: { type: 'string' } }),
+      runId:    { type: 'string', ...(selfOnly ? { description: '投递给你的 producedBy.runId;未投递的 runId 被忽略' } : {}) },
       lookback: { type: 'number', description: '回看轮数,默认 3,上限 30' },
-      query:    { type: 'string', description: '要溯源的结论/数字文本' },
+      claimId:  { type: 'string', description: '精确解引用:claim 的 objectId,返回其引用的源(cites)' },
+      objectId: { type: 'string', description: '精确解引用:源 object 的 objectId,返回引用它的结论(citedBy)' },
+      query:    { type: 'string', description: '弱检索:要溯源的结论/数字文本(子串匹配,非精确入口)' },
     } },
     handler: async (input, ctx) => {
-      const raw = (input ?? {}) as { runId?: string; lookback?: number; query?: string }
-      const runId = selfOnly ? undefined : raw.runId
+      const raw = (input ?? {}) as { runId?: string; lookback?: number; query?: string; claimId?: string; objectId?: string }
+      const runId = gatedRunId(raw.runId, ctx as ToolContext | undefined)
       const { lookback, query } = raw
       const window = runId
         ? [{ runId, events: await eventStore.readByRunId(runId) }]
         : await walkRunWindow(eventStore, (ctx as ToolContext | undefined)?.previousRunId,
             Math.max(1, Math.min(LOOKBACK_MAX, lookback ?? LOOKBACK_DEFAULT)))
+      // #200 A: exact handle dereference takes precedence over the weak substring query.
+      const handle = raw.claimId ?? raw.objectId
+      if (handle) {
+        const refs = []
+        for (const { runId: rid, events } of window) {
+          const ref = derefObject(events, handle)
+          if (ref) refs.push({ runId: rid, ...ref })
+        }
+        return { refs }
+      }
       const matches = []
       for (const { runId: rid, events } of window) {
         for (const m of resolveClaimSources(events, query)) {
@@ -120,5 +153,7 @@ export function makeTraceTools(
       return { matches }
     },
   }
-  return selfOnly ? [get_execution, get_lineage] : [get_run_io, get_execution, get_lineage]
+  // #200 C: get_run_io is registered in BOTH modes; in selfOnly it is gated to
+  // delivered runIds (refusing any other), so it carries no cross-session leak.
+  return [get_run_io, get_execution, get_lineage]
 }

--- a/src/trace/diagnostics/buildLineageProjection.ts
+++ b/src/trace/diagnostics/buildLineageProjection.ts
@@ -5,12 +5,62 @@ export interface ClaimLineage {
   sources: { objectId: string; type: string; meta?: Record<string, unknown> }[]
 }
 
+/** #200 A: a content-addressable handle dereferenced to its cite neighbourhood. */
+export interface HandleRef {
+  objectId: string
+  type:     string
+  meta?:    Record<string, unknown>
+  /** sources this object cites (outgoing `cites`; populated for a claim). */
+  cites:    { objectId: string; type: string; meta?: Record<string, unknown> }[]
+  /** claims that cite this object (incoming `cites`; populated for a source). */
+  citedBy:  { objectId: string; type: string; meta?: Record<string, unknown> }[]
+}
+
+/**
+ * #200 A: exact, deterministic handle dereference — NO text match. Given an
+ * `objectId` (a `claimId` is just a claim object's id), return that object plus its
+ * cite neighbourhood: the sources it `cites` (outgoing) and the claims that cite it
+ * (`citedBy`, incoming). This is the clean lineage primitive — unlike
+ * resolveClaimSources's substring `query` (a weak window-local retrieval), it needs
+ * no recall of the verbatim claim text. Returns undefined for an unknown objectId
+ * (no fabrication). Pure (no IO); walks the explicit cite graph, NOT event.causedBy.
+ */
+export function derefObject(events: Event[], objectId: string): HandleRef | undefined {
+  const objects = new Map<string, ObjectCreatedPayload>()
+  const cites: RelationCreatedPayload[] = []
+  for (const e of events) {
+    if (e.type === 'object.created') {
+      const p = e.payload as ObjectCreatedPayload
+      objects.set(p.objectId, p)
+    } else if (e.type === 'relation.created') {
+      const p = e.payload as RelationCreatedPayload
+      if (p.type === 'cites') cites.push(p)
+    }
+  }
+  const self = objects.get(objectId)
+  if (!self) return undefined
+  const view = (id: string) => {
+    const o = objects.get(id)
+    return o ? { objectId: o.objectId, type: o.type, ...(o.meta ? { meta: o.meta } : {}) } : undefined
+  }
+  const isView = <T>(v: T | undefined): v is T => !!v
+  return {
+    objectId: self.objectId,
+    type:     self.type,
+    ...(self.meta ? { meta: self.meta } : {}),
+    cites:    cites.filter(c => c.fromObjectId === objectId).map(c => view(c.toObjectId)).filter(isView),
+    citedBy:  cites.filter(c => c.toObjectId === objectId).map(c => view(c.fromObjectId)).filter(isView),
+  }
+}
+
 /**
  * #189 ③Lineage read: fold a run's object.created / relation.created into
  * claim→source attributions. Pure (no IO). A claim is an object of type 'claim'
  * whose meta.text holds the conclusion (minted by the `cite` tool); a 'cites'
- * relation points claim→source. `query` filters claims by text substring; omit
- * to return all. Walks the explicit cite graph, NOT event.causedBy.
+ * relation points claim→source. `query` is a WEAK window-local retrieval — a
+ * case-sensitive substring over claim.meta.text (omit = all). It is NOT the precise
+ * lineage entry: for that use derefObject (#200 B keeps these roles distinct).
+ * Walks the explicit cite graph, NOT event.causedBy.
  */
 export function resolveClaimSources(events: Event[], query?: string): ClaimLineage[] {
   const objects = new Map<string, ObjectCreatedPayload>()

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -15,6 +15,13 @@ export interface ToolContext {
    * resolve "my last turn(s)" without the agent passing a runId. Unset on a
    * session's first turn. */
   previousRunId?: string
+  /** #200 C: sourceRunIds of the external projections delivered to this run (#146).
+   * The capability-by-handle for selfOnly trace tools: a consumer may dereference
+   * the execution / lineage / I/O of a run that was *delivered to it*, but not an
+   * arbitrary runId — that would leak another session's run on a shared serve
+   * instance (the #196 invariant this stays within). Empty/undefined on a turn
+   * with no delivered projections. */
+  deliveredRunIds?: string[]
   /**
    * #37: declare a content-addressable object (a passage read, a claim produced).
    * Returns a stable `objectId` handle (content-addressed → identical across


### PR DESCRIPTION
## 摘要

解决 #200 暴露的两件结构问题(A/B/C;D 标 stretch 留后续)。一次 alfred 溯源失败的根因不是单 bug:① lineage 检索只有"窗口内弱子串"一条路,缺"按句柄精确解引用";② selfOnly 消费端 `runId` 轴被 #196 一刀切砍掉,够不着投递给自己的那条产出 run。

实现过程中校正了 issue 评论里 C 的句柄机制:消费侧真正持有的是 **`sourceRunId`**(渲染为 `producedBy.runId`),`ContextProjection` 无 objectId。白名单**直接取自 `AgentRuntime.externalProjections`**(即 `listContextProjections(contextId)` 的已解析形),经 `ctx.deliveredRunIds` 下发,无需透传 contextId 二次查库——比评论里设想的更直接。

## 改动

**A — `get_lineage` 增按句柄精确解引用**
- 新增 `derefObject(events, objectId)`:确定性返回对象的 cites 邻域(`cites` 出边 / `citedBy` 入边),**无文本匹配**;未知 id 返回 `undefined`(不臆造)。
- `get_lineage` 增 `{ claimId }` / `{ objectId }` 入参,返回 `refs`,优先于弱检索。

**B — 子串 `query` 归位**
- `query` 在描述与 `resolveClaimSources` 注释里明确标注为"窗口内弱检索(子串,非精确入口)";精确入口结构性独立为 A 的 `refs` 路径,不演进 fuzzy/semantic。

**C — selfOnly 的 `runId` 轴:全砍 → 投递域白名单解引用**
- `ToolContext.deliveredRunIds` ← `externalProjections.map(p => p.sourceRunId)`(去重)。
- `get_run_io` 在 selfOnly 下**重新注册但门控**:非投递 runId 拒绝(无跨会话 I/O 泄露)。
- `get_execution` / `get_lineage` selfOnly 下重新暴露 runId 轴,**仅放行已投递 runId**;未投递的仍忽略,退回自溯源窗口。
- **保留 #196 安全不变量**:不可读任意 run,只能读"投递给我的那条"。

A 与 C 可组合:消费者用 `producedBy.runId` 走 `get_execution(runId)` 看到报告 run 的 `shell:stdout` object,拿到其 objectId 再 `get_lineage({ objectId })` 精确回看。

## 测试

- 新增 `traceTools.deliveredDeref.test.ts`(C 门控:投递放行 / 非投递拒绝 / full 模式不变)、`AgentRuntime.deliveredRunIds.test.ts`(运行时接线)。
- `buildLineageProjection.test.ts` / `traceTools.lineage.test.ts` 增句柄解引用用例。
- 随 C 更新 `traceTools.selfOnly` / `traceToolsServeRegistration` 的旧 #196 不变量(`get_run_io` 由"缺席"改为"门控")。
- 全量单元测试绿;`tsc --noEmit` 干净。4 个 e2e 套件失败为**主干既有**(stash 验证失败集完全一致),与本改动无关。

## 非目标

- 不做 L3 原子血缘(逐条 object / `derives_from`)——属 alfred 另议。
- D(框架级 auto-cite)标 stretch,留后续。

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
