### PR TITLE
feat: structured model errors and correlated service logs

### DIFF
--- a/docs/design/202-structured-model-errors.md
+++ b/docs/design/202-structured-model-errors.md
@@ -1,0 +1,51 @@
+# 结构化模型错误与关联服务日志（#202）
+
+> 最后更新：2026-07-10  
+> Issue: https://github.com/xforce-io/milkie/issues/202  
+> 分支：`feat/202-structured-model-errors`
+
+## 目标
+
+模型网关失败不能再退化为无法诊断的 `Connection error.`。错误需要从
+OpenAI-compatible adapter 经 runtime、event store 和 `serve` SSE 边界保留稳定、
+可机读且不泄露敏感信息的语义，并由服务日志通过 `runId`、`contextId` 关联。
+
+## 契约
+
+新增 `ModelGatewayError`，其安全序列化结果包含：
+
+- `code`：`MODEL_CONNECTION_ERROR`、`MODEL_TIMEOUT`、`MODEL_RATE_LIMITED`、
+  `MODEL_AUTH_ERROR`、`MODEL_BAD_RESPONSE` 或 `MODEL_UNKNOWN_ERROR`。
+- `message`：兼容现有消费者的安全文本。
+- `phase`：`request`、`stream_open`、`stream_read` 或 `response_parse`。
+- `provider`、`model`、可选 HTTP `status`。
+- `retryable`：由模型边界明确给出。
+
+原始异常只作为进程内 `cause` 保存。API key、认证头、请求头、prompt 和原始响应体
+不得进入事件或 SSE。
+
+SSE `error` 与终止 `agent.run.completed` 帧新增 `error` 对象，同时保留顶层
+`message`/字符串输出兼容旧客户端。
+
+## 实现边界
+
+1. `OpenAICompatibleAdapter.complete()` 和 `.stream()` 统一归一化 SDK/HTTP 异常。
+2. runtime 的失败事件保存同一安全 envelope。
+3. `serve.streamTurn` 记录一条带 `runId`、`contextId` 和 envelope 字段的 error 日志。
+4. Milkie 不实现业务重试、provider failover 或 circuit breaker。
+
+## 测试计划
+
+- **单元测试**：错误映射表、阶段分类、retryable、cause 和敏感信息脱敏。
+- **集成测试**：假网关错误穿过 AgentRuntime 后，JSONL 终止事件保留安全 envelope。
+- **功能测试**：真实 HTTP/SSE server 返回 `error` 与终止帧，并只写一条关联日志。
+- **端到端测试**：真实 `milkie serve` 子进程连接确定性失败的 OpenAI-compatible stub，
+  验证 SSE、JSONL、trace report，以及失败后 `/health` 仍可用。
+- **构建/清单验证**：TypeScript build、相关 lint、现有 deterministic suite。
+
+## 验收标准
+
+- Alfred 可根据 `error.retryable` 决策，不再依赖错误字符串。
+- 操作者可由任一失败 run 定位 provider、model、phase 和错误类型。
+- 旧 SSE 客户端仍可读取人类可读 message。
+- 失败路径不包含任何 secret 或 prompt 内容。

--- a/src/__tests__/LoggingGateway.test.ts
+++ b/src/__tests__/LoggingGateway.test.ts
@@ -1,6 +1,7 @@
 import { LoggingGateway } from '../logging/LoggingGateway'
 import { createServiceLogger } from '../logging/logger'
 import { createGateway } from '../gateway/GatewayFactory'
+import { ModelGatewayError } from '../gateway/ModelGatewayError'
 import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
 
 function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
@@ -60,6 +61,29 @@ describe('LoggingGateway.complete', () => {
     expect(line.level).toBe('error')
     expect(line.msg).toBe('llm call failed')
     expect((line.err as { message: string }).message).toBe('rate limited')
+  })
+
+  it('logs and rethrows a structured model error without mutating its envelope', async () => {
+    const sink = memorySink()
+    const log = createServiceLogger({ level: 'info', format: 'json', destination: sink.stream })
+    const error = new ModelGatewayError({
+      code: 'MODEL_BAD_RESPONSE',
+      message: 'Model provider rejected the request or returned an invalid response.',
+      phase: 'stream_open',
+      provider: 'openai',
+      model: 'test-model',
+      retryable: true,
+      status: 503,
+    })
+    const gateway: IModelGateway = {
+      async complete(): Promise<ModelResponse> { throw error },
+      async *stream(): AsyncIterable<ModelEvent> { throw error },
+    }
+
+    await expect(new LoggingGateway(gateway, log).complete(REQ)).rejects.toBe(error)
+    const line = sink.lines()[0]!
+    expect(line.msg).toBe('llm call failed')
+    expect((line.err as { message: string }).message).toBe(error.message)
   })
 
   it('does not log prompt or completion content (脱敏)', async () => {

--- a/src/__tests__/ModelGatewayError.test.ts
+++ b/src/__tests__/ModelGatewayError.test.ts
@@ -1,0 +1,82 @@
+import {
+  ModelGatewayError,
+  normalizeModelGatewayError,
+} from '../gateway/ModelGatewayError'
+
+describe('normalizeModelGatewayError', () => {
+  test.each([
+    ['APIConnectionError', undefined, 'MODEL_CONNECTION_ERROR', true],
+    ['APITimeoutError', undefined, 'MODEL_TIMEOUT', true],
+    ['APIError', 429, 'MODEL_RATE_LIMITED', true],
+    ['APIError', 401, 'MODEL_AUTH_ERROR', false],
+    ['APIError', 403, 'MODEL_AUTH_ERROR', false],
+    ['APIError', 400, 'MODEL_BAD_RESPONSE', false],
+    ['APIError', 503, 'MODEL_BAD_RESPONSE', true],
+  ])('%s status=%s maps to %s', (name, status, code, retryable) => {
+    const cause = Object.assign(new Error('provider detail'), { name, status })
+    const error = normalizeModelGatewayError(cause, {
+      provider: 'volcengine', model: 'glm-5.2', phase: 'stream_open',
+    })
+
+    expect(error).toBeInstanceOf(ModelGatewayError)
+    expect(error.toJSON()).toMatchObject({
+      code, retryable, provider: 'volcengine', model: 'glm-5.2', phase: 'stream_open',
+    })
+    expect(error.cause).toBe(cause)
+  })
+
+  test('classifies a nested transport errno without serializing the cause', () => {
+    const cause = Object.assign(new Error('request failed'), {
+      cause: Object.assign(new Error('socket'), { code: 'ECONNRESET' }),
+    })
+    const error = normalizeModelGatewayError(cause, {
+      provider: 'volcengine', model: 'glm-5.2', phase: 'stream_read',
+    })
+
+    expect(error.toJSON()).toEqual({
+      code: 'MODEL_CONNECTION_ERROR',
+      message: 'Model provider connection failed.',
+      phase: 'stream_read',
+      provider: 'volcengine',
+      model: 'glm-5.2',
+      retryable: true,
+    })
+    expect(JSON.stringify(error)).not.toContain('ECONNRESET')
+  })
+
+  test('recognizes SDK subclasses even when the public error name is generic', () => {
+    class APIConnectionError extends Error {}
+    const cause = new APIConnectionError('connection detail')
+    cause.name = 'Error'
+    const error = normalizeModelGatewayError(cause, {
+      provider: 'p', model: 'm', phase: 'stream_open',
+    })
+    expect(error.toJSON()).toMatchObject({ code: 'MODEL_CONNECTION_ERROR', retryable: true })
+  })
+
+  test('redacts credentials, URLs, prompt text, and raw provider bodies', () => {
+    const cause = Object.assign(
+      new Error('sk-secret failed at https://provider.example/v1 prompt=private'),
+      { status: 500, headers: { authorization: 'Bearer secret' }, body: 'private response' },
+    )
+    const error = normalizeModelGatewayError(cause, {
+      provider: 'volcengine', model: 'glm-5.2', phase: 'request',
+    })
+
+    const serialized = JSON.stringify(error)
+    expect(serialized).not.toContain('sk-secret')
+    expect(serialized).not.toContain('provider.example')
+    expect(serialized).not.toContain('private')
+    expect(serialized).not.toContain('authorization')
+  })
+
+  test('normalization is idempotent', () => {
+    const original = new ModelGatewayError({
+      code: 'MODEL_TIMEOUT', message: 'Model provider request timed out.',
+      phase: 'request', provider: 'p', model: 'm', retryable: true,
+    })
+    expect(normalizeModelGatewayError(original, {
+      provider: 'other', model: 'other', phase: 'response_parse',
+    })).toBe(original)
+  })
+})

--- a/src/__tests__/OpenAICompatibleAdapter.stream.test.ts
+++ b/src/__tests__/OpenAICompatibleAdapter.stream.test.ts
@@ -326,3 +326,28 @@ describe('OpenAICompatibleAdapter.stream — token-level streaming', () => {
     ])
   })
 })
+
+describe('OpenAICompatibleAdapter.stream — structured failures (#202)', () => {
+  test('distinguishes stream-open from stream-read failures', async () => {
+    const openAdapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test', provider: 'volcengine' })
+    ;(openAdapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+      .client.chat.completions.create = async () => {
+        throw Object.assign(new Error('open failed'), { name: 'APITimeoutError' })
+      }
+    const open = collect(openAdapter)
+    await expect(open).rejects.toMatchObject({
+      envelope: { code: 'MODEL_TIMEOUT', phase: 'stream_open', retryable: true },
+    })
+
+    const readAdapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test', provider: 'volcengine' })
+    ;(readAdapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+      .client.chat.completions.create = async () => (async function* () {
+        yield contentChunk('partial')
+        throw Object.assign(new Error('read failed'), { name: 'APIConnectionError' })
+      })()
+    const read = collect(readAdapter)
+    await expect(read).rejects.toMatchObject({
+      envelope: { code: 'MODEL_CONNECTION_ERROR', phase: 'stream_read', retryable: true },
+    })
+  })
+})

--- a/src/__tests__/OpenAICompatibleAdapter.test.ts
+++ b/src/__tests__/OpenAICompatibleAdapter.test.ts
@@ -104,3 +104,34 @@ describe('OpenAICompatibleAdapter — temperature passthrough (#126)', () => {
     expect((calls[0] as { temperature?: number }).temperature).toBe(0.7)
   })
 })
+
+describe('OpenAICompatibleAdapter — structured failures (#202)', () => {
+  const req: ModelRequest = {
+    model: 'glm-5.2', messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+  }
+
+  test('normalizes request failures with provider/model metadata', async () => {
+    const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test', provider: 'volcengine' })
+    const cause = Object.assign(new Error('secret endpoint'), { name: 'APIConnectionError' })
+    ;(adapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+      .client.chat.completions.create = async () => { throw cause }
+
+    await expect(adapter.complete(req)).rejects.toMatchObject({
+      envelope: {
+        code: 'MODEL_CONNECTION_ERROR', message: 'Model provider connection failed.',
+        phase: 'request', provider: 'volcengine', model: 'glm-5.2', retryable: true,
+      },
+      cause,
+    })
+  })
+
+  test('classifies response parsing failures as bad responses', async () => {
+    const adapter = new OpenAICompatibleAdapter({ apiKey: 'sk-test', provider: 'volcengine' })
+    ;(adapter as unknown as { client: { chat: { completions: { create: unknown } } } })
+      .client.chat.completions.create = async () => ({ choices: [] })
+
+    await expect(adapter.complete(req)).rejects.toMatchObject({
+      envelope: { code: 'MODEL_BAD_RESPONSE', phase: 'response_parse', retryable: false },
+    })
+  })
+})

--- a/src/__tests__/render-viewer.test.ts
+++ b/src/__tests__/render-viewer.test.ts
@@ -74,6 +74,24 @@ describe('renderViewer', () => {
     expect(html).toContain('<strong>重点</strong>')
   })
 
+  it('renders structured model error metadata on a failed output', () => {
+    const events: Event[] = [
+      e({ id: 'start', runId: 'r1', type: 'agent.run.started', timestamp: 1, payload: { agentId: 'x', goal: 'g', input: 'i', contextId: 'c' } }),
+      e({ id: 'done', runId: 'r1', type: 'agent.run.completed', timestamp: 2, payload: {
+        status: 'error', lastTextOutput: 'Model provider connection failed.',
+        error: {
+          code: 'MODEL_CONNECTION_ERROR', message: 'Model provider connection failed.',
+          phase: 'stream_open', provider: 'volcengine', model: 'glm-5.2', retryable: true,
+        },
+      } }),
+    ]
+    const html = renderViewer(events)
+    expect(html).toContain('MODEL_CONNECTION_ERROR')
+    expect(html).toContain('stream_open')
+    expect(html).toContain('volcengine / glm-5.2')
+    expect(html).toContain('retryable')
+  })
+
   it('trims a panel causal chain to spine decisions only', () => {
     const html = renderViewer(scenario())
     const exps = JSON.parse(html.match(/id="explanations-data">(.*?)<\/script>/s)![1]!)

--- a/src/__tests__/serve.logging.test.ts
+++ b/src/__tests__/serve.logging.test.ts
@@ -8,6 +8,7 @@ import { BroadcastingEventStore } from '../trace/BroadcastingEventStore'
 import { createServiceLogger } from '../logging/logger'
 import type { AgentConfig } from '../types/agent'
 import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
+import { ModelGatewayError } from '../gateway/ModelGatewayError'
 
 function memorySink(): { lines: () => Record<string, unknown>[]; stream: { write: (s: string) => void } } {
   const raw: string[] = []
@@ -35,6 +36,30 @@ function buildMilkie(): { milkie: Milkie; agentId: string; broadcaster: Broadcas
   const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
   milkie.registerAgent(agent)
   return { milkie, agentId: 'echo', broadcaster }
+}
+
+function buildFailingMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore } {
+  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
+  const failure = new ModelGatewayError({
+    code: 'MODEL_CONNECTION_ERROR',
+    message: 'Model provider connection failed.',
+    phase: 'stream_open',
+    provider: 'volcengine',
+    model: 'glm-5.2',
+    retryable: true,
+  })
+  const gateway: IModelGateway = {
+    async complete(): Promise<ModelResponse> { throw failure },
+    async *stream(): AsyncIterable<never> { throw failure },
+  }
+  const agent: AgentConfig = {
+    agentId: 'failing', version: '1.0.0', systemPrompt: 'fail',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model: { provider: 'volcengine', model: 'glm-5.2', adapter: 'openai-compatible' },
+  }
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
+  milkie.registerAgent(agent)
+  return { milkie, agentId: 'failing', broadcaster }
 }
 
 function listen(server: http.Server): Promise<number> {
@@ -127,5 +152,32 @@ describe('serve HTTP service log', () => {
     expect(res.text).toContain('agent.run.completed')
     const line = await waitFor(() => sink.lines().find(l => l.msg === 'http request' && l.path === '/chat'))
     expect(line.status).toBe(200)
+  })
+
+  it('logs one correlated structured error and exposes the envelope over SSE', async () => {
+    const sink = memorySink()
+    const { milkie, agentId, broadcaster } = buildFailingMilkie()
+    server = createServeServer({
+      milkie, agentId, broadcaster,
+      logger: createServiceLogger({ level: 'info', format: 'json', destination: sink.stream }),
+    })
+    const port = await listen(server)
+    const res = await post(port, '/chat', { contextId: 'ctx-failure', input: 'hi' })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('event: error')
+    expect(res.text).toContain('MODEL_CONNECTION_ERROR')
+    expect(res.text).toContain('agent.run.completed')
+
+    const failures = await waitFor(() => {
+      const lines = sink.lines().filter(l => l.msg === 'agent run failed')
+      return lines.length > 0 ? lines : undefined
+    })
+    expect(failures).toHaveLength(1)
+    expect(failures[0]).toMatchObject({
+      mod: 'server', contextId: 'ctx-failure', errorCode: 'MODEL_CONNECTION_ERROR',
+      retryable: true, provider: 'volcengine', model: 'glm-5.2', phase: 'stream_open',
+      runId: expect.any(String),
+    })
   })
 })

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -10,6 +10,7 @@ import { BroadcastingEventStore } from '../trace/BroadcastingEventStore'
 import type { AgentConfig } from '../types/agent'
 import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent } from '../types/model'
 import type { ToolDefinition } from '../types/tool'
+import { ModelGatewayError } from '../gateway/ModelGatewayError'
 
 // ─────────────────────────── test harnesses ───────────────────────────
 
@@ -134,6 +135,26 @@ function buildErrorMilkie(): { milkie: Milkie; agentId: string; broadcaster: Bro
   const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
   milkie.registerAgent(agent)
   return { milkie, agentId: 'boomer', broadcaster }
+}
+
+function buildStructuredErrorMilkie(): { milkie: Milkie; agentId: string; broadcaster: BroadcastingEventStore } {
+  const broadcaster = new BroadcastingEventStore(new MemoryEventStore())
+  const failure = new ModelGatewayError({
+    code: 'MODEL_TIMEOUT', message: 'Model provider request timed out.', phase: 'stream_read',
+    provider: 'volcengine', model: 'glm-5.2', retryable: true,
+  })
+  const gateway: IModelGateway = {
+    async complete(): Promise<ModelResponse> { throw failure },
+    async *stream(): AsyncIterable<never> { throw failure },
+  }
+  const agent: AgentConfig = {
+    agentId: 'structured-boomer', version: '1.0.0', systemPrompt: 'boom',
+    fsm: { states: [{ name: 'react', type: 'llm' }] },
+    model: { provider: 'volcengine', model: 'glm-5.2', adapter: 'openai-compatible' },
+  }
+  const milkie = new Milkie({ stateStore: new MemoryStore(), eventStore: broadcaster, gateway })
+  milkie.registerAgent(agent)
+  return { milkie, agentId: 'structured-boomer', broadcaster }
 }
 
 // ─────────────────────────── http helpers ───────────────────────────
@@ -273,6 +294,24 @@ describe('createServeServer', () => {
     const terminal = events.find(e => e.event === 'agent.run.completed')
     expect(terminal).toBeDefined()
     expect((terminal!.data as { status: string }).status).toBe('error')
+  })
+
+  it('POST /chat carries a structured model error in both error and terminal frames', async () => {
+    const { milkie, agentId, broadcaster } = buildStructuredErrorMilkie()
+    const port = await listen(createServeServer({ milkie, agentId, broadcaster }))
+    const { done } = sse(port, 'POST', '/chat', { contextId: 'structured-error', input: 'go' })
+    const events = await done
+
+    expect(events.find(e => e.event === 'error')?.data).toMatchObject({
+      message: 'Model provider request timed out.',
+      error: { code: 'MODEL_TIMEOUT', retryable: true, phase: 'stream_read' },
+    })
+    expect(events.find(e => e.event === 'agent.run.completed')?.data).toMatchObject({
+      status: 'error',
+      message: 'Model provider request timed out.',
+      error: { code: 'MODEL_TIMEOUT', retryable: true, provider: 'volcengine', model: 'glm-5.2' },
+      runId: expect.any(String),
+    })
   })
 
   // ─────────────────────── #140 terminal frame carries runId ───────────────────────

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -116,9 +116,31 @@ export function createServeServer(opts: ServeOptions): Server {
       const result = await run(e => {
         if (e.type === 'message_delta') writeSSE(res, 'message_delta', e.data)
       })
-      writeSSE(res, 'agent.run.completed', { status: result.status, output: result.output, runId: result.agentRunId })
+      if (result.status === 'error') {
+        const message = result.error?.message ?? result.output
+        log.error({
+          runId: result.agentRunId,
+          contextId,
+          errorCode: result.error?.code,
+          retryable: result.error?.retryable,
+          provider: result.error?.provider,
+          model: result.error?.model,
+          phase: result.error?.phase,
+        }, 'agent run failed')
+        writeSSE(res, 'error', {
+          message,
+          ...(result.error ? { error: result.error } : {}),
+        })
+        writeSSE(res, 'agent.run.completed', {
+          status: 'error', output: result.output, message,
+          error: result.error ?? message, runId: result.agentRunId,
+        })
+      } else {
+        writeSSE(res, 'agent.run.completed', { status: result.status, output: result.output, runId: result.agentRunId })
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
+      log.error({ contextId, runId: capturedRunId, err }, 'agent run failed')
       writeSSE(res, 'error', { message })
       writeSSE(res, 'agent.run.completed', { status: 'error', output: '', error: message, runId: capturedRunId })
     } finally {

--- a/src/gateway/GatewayFactory.ts
+++ b/src/gateway/GatewayFactory.ts
@@ -21,6 +21,7 @@ export function createGateway(model: ModelConfig, logger?: ServiceLogger): IMode
     adapter === 'volcengine'
   ) {
     return new LoggingGateway(new OpenAICompatibleAdapter({
+      provider: model.provider,
       baseUrl: model.baseUrl ?? process.env['VOLCENGINE_API_BASE'],
       apiKey:
         process.env['VOLCENGINE_TOKEN'] ??

--- a/src/gateway/ModelGatewayError.ts
+++ b/src/gateway/ModelGatewayError.ts
@@ -1,0 +1,114 @@
+import type {
+  ModelErrorCode,
+  ModelErrorEnvelope,
+  ModelErrorPhase,
+} from '../types/model.js'
+
+export interface ModelErrorContext {
+  provider: string
+  model:    string
+  phase:    ModelErrorPhase
+}
+
+const SAFE_MESSAGES: Record<ModelErrorCode, string> = {
+  MODEL_CONNECTION_ERROR: 'Model provider connection failed.',
+  MODEL_TIMEOUT:          'Model provider request timed out.',
+  MODEL_RATE_LIMITED:     'Model provider rate limit exceeded.',
+  MODEL_AUTH_ERROR:       'Model provider authentication failed.',
+  MODEL_BAD_RESPONSE:     'Model provider rejected the request or returned an invalid response.',
+  MODEL_UNKNOWN_ERROR:    'Model provider request failed.',
+}
+
+function statusOf(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const status = (error as { status?: unknown }).status
+  return typeof status === 'number' ? status : undefined
+}
+
+function namesOf(error: unknown): string {
+  const names: string[] = []
+  let current = error
+  for (let depth = 0; depth < 4 && current && typeof current === 'object'; depth++) {
+    const name = (current as { name?: unknown }).name
+    if (typeof name === 'string') names.push(name)
+    const ctorName = (current as { constructor?: { name?: unknown } }).constructor?.name
+    if (typeof ctorName === 'string') names.push(ctorName)
+    current = (current as { cause?: unknown }).cause
+  }
+  return names.join(' ').toLowerCase()
+}
+
+function transportCodeOf(error: unknown): string {
+  let current = error
+  for (let depth = 0; depth < 4 && current && typeof current === 'object'; depth++) {
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'string') return code.toUpperCase()
+    current = (current as { cause?: unknown }).cause
+  }
+  return ''
+}
+
+function classify(error: unknown): { code: ModelErrorCode; retryable: boolean; status?: number } {
+  const status = statusOf(error)
+  const names = namesOf(error)
+  const transportCode = transportCodeOf(error)
+
+  if (
+    names.includes('timeout') ||
+    ['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT'].includes(transportCode)
+  ) {
+    return { code: 'MODEL_TIMEOUT', retryable: true, ...(status !== undefined ? { status } : {}) }
+  }
+  if (
+    names.includes('connection') ||
+    ['ECONNRESET', 'ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'EPIPE', 'UND_ERR_SOCKET'].includes(transportCode)
+  ) {
+    return { code: 'MODEL_CONNECTION_ERROR', retryable: true, ...(status !== undefined ? { status } : {}) }
+  }
+  if (status === 429) return { code: 'MODEL_RATE_LIMITED', retryable: true, status }
+  if (status === 401 || status === 403) return { code: 'MODEL_AUTH_ERROR', retryable: false, status }
+  if (status !== undefined) {
+    return { code: 'MODEL_BAD_RESPONSE', retryable: status === 408 || status >= 500, status }
+  }
+  return { code: 'MODEL_UNKNOWN_ERROR', retryable: false }
+}
+
+export class ModelGatewayError extends Error {
+  readonly envelope: ModelErrorEnvelope
+  override readonly cause?: unknown
+
+  constructor(envelope: ModelErrorEnvelope, cause?: unknown) {
+    super(envelope.message)
+    this.name = 'ModelGatewayError'
+    this.envelope = Object.freeze({ ...envelope })
+    this.cause = cause
+  }
+
+  toJSON(): ModelErrorEnvelope {
+    return { ...this.envelope }
+  }
+}
+
+export function normalizeModelGatewayError(
+  error: unknown,
+  context: ModelErrorContext,
+): ModelGatewayError {
+  if (error instanceof ModelGatewayError) return error
+  const initial = classify(error)
+  const classified = initial.code === 'MODEL_UNKNOWN_ERROR' && context.phase === 'response_parse'
+    ? { code: 'MODEL_BAD_RESPONSE' as const, retryable: false }
+    : initial
+  return new ModelGatewayError({
+    code: classified.code,
+    message: SAFE_MESSAGES[classified.code],
+    phase: context.phase,
+    provider: context.provider,
+    model: context.model,
+    retryable: classified.retryable,
+    ...(classified.status !== undefined ? { status: classified.status } : {}),
+  }, error)
+}
+
+export function modelErrorEnvelope(error: unknown): ModelErrorEnvelope | undefined {
+  return error instanceof ModelGatewayError ? error.toJSON() : undefined
+}

--- a/src/gateway/ModelGatewayError.ts
+++ b/src/gateway/ModelGatewayError.ts
@@ -80,7 +80,7 @@ export class ModelGatewayError extends Error {
   constructor(envelope: ModelErrorEnvelope, cause?: unknown) {
     super(envelope.message)
     this.name = 'ModelGatewayError'
-    this.envelope = Object.freeze({ ...envelope })
+    this.envelope = { ...envelope }
     this.cause = cause
   }
 

--- a/src/gateway/OpenAICompatibleAdapter.ts
+++ b/src/gateway/OpenAICompatibleAdapter.ts
@@ -2,16 +2,20 @@ import OpenAI from 'openai'
 import type { IModelGateway, ModelRequest, ModelResponse, ModelEvent, ModelUsage } from '../types/model.js'
 import type { MessageContent } from '../types/common.js'
 import type { ToolCall } from '../types/tool.js'
+import { normalizeModelGatewayError } from './ModelGatewayError.js'
 
 export interface OpenAICompatibleAdapterOptions {
   apiKey?:  string
   baseUrl?: string
+  provider?: string
 }
 
 export class OpenAICompatibleAdapter implements IModelGateway {
   private readonly client: OpenAI
+  private readonly provider: string
 
   constructor(options: OpenAICompatibleAdapterOptions = {}) {
+    this.provider = options.provider ?? 'openai-compatible'
     this.client = new OpenAI({
       apiKey:  options.apiKey  ?? process.env['VOLCENGINE_TOKEN'] ?? process.env['OPENAI_API_KEY'] ?? '',
       baseURL: options.baseUrl ?? process.env['VOLCENGINE_API_BASE'],
@@ -19,46 +23,67 @@ export class OpenAICompatibleAdapter implements IModelGateway {
   }
 
   async complete(request: ModelRequest): Promise<ModelResponse> {
-    const raw = await this.client.chat.completions.create({
-      model:    request.model,
-      messages: this.convertMessages(request),
-      tools:    request.tools?.map(t => ({
-        type:     'function' as const,
-        function: {
-          name:        t.name,
-          description: t.description,
-          parameters:  t.inputSchema,
-        },
-      })),
-      tool_choice: request.tools?.length ? 'auto' : undefined,
-      temperature: request.temperature,
-    })
+    let raw: OpenAI.ChatCompletion
+    try {
+      raw = await this.client.chat.completions.create({
+        model:    request.model,
+        messages: this.convertMessages(request),
+        tools:    request.tools?.map(t => ({
+          type:     'function' as const,
+          function: {
+            name:        t.name,
+            description: t.description,
+            parameters:  t.inputSchema,
+          },
+        })),
+        tool_choice: request.tools?.length ? 'auto' : undefined,
+        temperature: request.temperature,
+      })
+    } catch (error) {
+      throw normalizeModelGatewayError(error, {
+        provider: this.provider, model: request.model, phase: 'request',
+      })
+    }
 
-    return this.parseResponse(raw)
+    try {
+      return this.parseResponse(raw)
+    } catch (error) {
+      throw normalizeModelGatewayError(error, {
+        provider: this.provider, model: request.model, phase: 'response_parse',
+      })
+    }
   }
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
-    const stream = await this.client.chat.completions.create({
-      model:    request.model,
-      messages: this.convertMessages(request),
-      tools:    request.tools?.map(t => ({
-        type:     'function' as const,
-        function: {
-          name:        t.name,
-          description: t.description,
-          parameters:  t.inputSchema,
-        },
-      })),
-      tool_choice:    request.tools?.length ? 'auto' : undefined,
-      temperature:    request.temperature,
-      stream:         true,
-      stream_options: { include_usage: true },
-    })
+    let stream: AsyncIterable<OpenAI.ChatCompletionChunk>
+    try {
+      stream = await this.client.chat.completions.create({
+        model:    request.model,
+        messages: this.convertMessages(request),
+        tools:    request.tools?.map(t => ({
+          type:     'function' as const,
+          function: {
+            name:        t.name,
+            description: t.description,
+            parameters:  t.inputSchema,
+          },
+        })),
+        tool_choice:    request.tools?.length ? 'auto' : undefined,
+        temperature:    request.temperature,
+        stream:         true,
+        stream_options: { include_usage: true },
+      })
+    } catch (error) {
+      throw normalizeModelGatewayError(error, {
+        provider: this.provider, model: request.model, phase: 'stream_open',
+      })
+    }
 
     // Accumulate tool_call fragments keyed by their stream `index`.
     const toolCalls = new Map<number, { id: string; argsBuf: string }>()
 
-    for await (const chunk of stream) {
+    try {
+      for await (const chunk of stream) {
       const choice = chunk.choices[0]
       const delta  = choice?.delta
 
@@ -113,6 +138,11 @@ export class OpenAICompatibleAdapter implements IModelGateway {
           },
         }
       }
+      }
+    } catch (error) {
+      throw normalizeModelGatewayError(error, {
+        provider: this.provider, model: request.model, phase: 'stream_read',
+      })
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export { TrajectoryStore } from './trajectory/TrajectoryStore.js'
 // Model Gateway
 export { AnthropicAdapter }         from './gateway/AnthropicAdapter.js'
 export { OpenAICompatibleAdapter }  from './gateway/OpenAICompatibleAdapter.js'
+export { ModelGatewayError, normalizeModelGatewayError } from './gateway/ModelGatewayError.js'
 export { createGateway }            from './gateway/GatewayFactory.js'
 
 // #84: portable session export/import
@@ -74,6 +75,9 @@ export type {
   ModelRequest,
   ModelResponse,
   ModelEvent,
+  ModelErrorCode,
+  ModelErrorEnvelope,
+  ModelErrorPhase,
   ToolSchema,
 } from './types/model.js'
 

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -45,6 +45,7 @@ import type { CausalCursor } from '../trace/CausalCursor.js'
 import { checkpointFromEvents } from '../trace/diagnostics/checkpointFromEvents.js'
 import type { Region } from '../context/Region.js'
 import type { SkillLifecyclePayload, AgentRunStartedPayload, AgentRunCompletedPayload, LineageBuffer, ObjectType } from '../trace/types.js'
+import { modelErrorEnvelope } from '../gateway/ModelGatewayError.js'
 
 export type MakeChildPort = (
   childRunId:  string,
@@ -280,7 +281,11 @@ export class AgentRuntime {
             eventStore:    this.eventStore,
             makeChildPort: this.makeChildPort,
           })
-          await finish?.({ status: result.status, lastTextOutput: result.output })
+          await finish?.({
+            status: result.status,
+            lastTextOutput: result.output,
+            ...(result.error ? { error: result.error } : {}),
+          })
 
           // #73: read the child's resume state from its event log (source of truth).
           const childCheckpoint = result.status === 'interrupted' && this.eventStore
@@ -980,11 +985,13 @@ export class AgentRuntime {
       }
       this.lifecycle.signal('error')
       this.recorder.endSpan(this.rootSpan, 'error')
+      const structuredError = modelErrorEnvelope(err)
       return {
         agentRunId: this.agentRunId,
         contextId:  this.contextId,
         output:     err instanceof Error ? err.message : String(err),
         status:     'error',
+        ...(structuredError ? { error: structuredError } : {}),
       }
     } finally {
       await this.tryFlushTraceWrites()

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -410,7 +410,11 @@ export class Milkie {
     const invokeStartedAt = Date.now()
     try {
       const result = await runtime.run(request.input)
-      await rec?.detach({ status: result.status, lastTextOutput: result.output })
+      await rec?.detach({
+        status: result.status,
+        lastTextOutput: result.output,
+        ...(result.error ? { error: result.error } : {}),
+      })
       invokeLog.info({ agentId: config.agentId, durationMs: Date.now() - invokeStartedAt, status: result.status }, 'invoke completed')
       return result
     } catch (err) {

--- a/src/trace/render/viewer.ts
+++ b/src/trace/render/viewer.ts
@@ -5,6 +5,7 @@ import { contextRefsAt, type RegionContentRef } from '../RegionContextView.js'
 import { renderTimelineSections } from './html.js'
 import { renderMarkdown } from './markdown.js'
 import { VIEWER_STYLES, VIEWER_SCRIPT } from './viewer-template.js'
+import type { ModelErrorEnvelope } from '../../types/model.js'
 
 function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
@@ -51,10 +52,16 @@ function panelRecord(events: Event[], node: DecisionNode, eventById: Map<string,
   }
   // output
   const evt = eventById.get(node.eventId)
-  const out = (evt?.payload as { lastTextOutput?: string; status?: string } | undefined)
+  const out = (evt?.payload as { lastTextOutput?: string; status?: string; error?: string | ModelErrorEnvelope } | undefined)
+  const structuredError = out?.error && typeof out.error === 'object' ? out.error : undefined
+  const errorMeta = structuredError
+    ? `<div class="error-meta"><strong>${esc(structuredError.code)}</strong> · ${esc(structuredError.phase)}`
+      + ` · ${esc(structuredError.provider)} / ${esc(structuredError.model)}`
+      + ` · ${structuredError.retryable ? 'retryable' : 'terminal'}</div>`
+    : ''
   const drill = node.causeDecisionId ? '由上游决策产生(点 ← 谁导致的 下钻)' : '（无上游决策记录）'
   return { ...base, chain: [], title: '为什么是这个结果?',
-    bodyHtml: `<div>${renderMarkdown(out?.lastTextOutput ?? out?.status ?? '')}</div>`
+    bodyHtml: `<div>${renderMarkdown(out?.lastTextOutput ?? out?.status ?? '')}</div>${errorMeta}`
       + `<div style="color:#888;font-size:11px;margin-top:8px">${drill}</div>` }
 }
 

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -1,4 +1,4 @@
-import type { ModelRequest, ModelResponse } from '../types/model.js'
+import type { ModelErrorEnvelope, ModelRequest, ModelResponse } from '../types/model.js'
 
 /**
  * Agent Trace event types.
@@ -124,7 +124,7 @@ export interface AgentRunStartedPayload {
 export interface AgentRunCompletedPayload {
   status:           'completed' | 'interrupted' | 'error'
   lastTextOutput?:  string
-  error?:           string
+  error?:           string | ModelErrorEnvelope
 }
 
 export interface AgentSpawnedPayload {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
-import type { ModelEvent } from './model.js'
+import type { ModelErrorEnvelope, ModelEvent } from './model.js'
 
 export type JSONValue = string | number | boolean | null | JSONValue[] | { [k: string]: JSONValue }
 export type JSONObject = Record<string, JSONValue>
@@ -62,6 +62,7 @@ export interface AgentResult {
   output:      string
   status:      'completed' | 'interrupted' | 'error'
   checkpointId?: string
+  error?:      ModelErrorEnvelope
 }
 
 export class InterruptSignal extends Error {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,6 +2,26 @@ import type { Message, MessageContent } from './common.js'
 import type { ToolCall } from './tool.js'
 import type { JSONSchema } from './common.js'
 
+export type ModelErrorCode =
+  | 'MODEL_CONNECTION_ERROR'
+  | 'MODEL_TIMEOUT'
+  | 'MODEL_RATE_LIMITED'
+  | 'MODEL_AUTH_ERROR'
+  | 'MODEL_BAD_RESPONSE'
+  | 'MODEL_UNKNOWN_ERROR'
+
+export type ModelErrorPhase = 'request' | 'stream_open' | 'stream_read' | 'response_parse'
+
+export interface ModelErrorEnvelope {
+  code:       ModelErrorCode
+  message:    string
+  phase:      ModelErrorPhase
+  provider:   string
+  model:      string
+  retryable:  boolean
+  status?:    number
+}
+
 export interface ToolSchema {
   name:        string
   description: string

--- a/tests/e2e/model-error-sidecar.e2e.test.ts
+++ b/tests/e2e/model-error-sidecar.e2e.test.ts
@@ -1,0 +1,157 @@
+import { spawn, spawnSync, type ChildProcess } from 'child_process'
+import fs from 'fs'
+import http from 'http'
+import os from 'os'
+import path from 'path'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const CLI = path.join('dist', 'cli', 'index.js')
+
+interface SSEEvent { event: string; data: unknown }
+
+function parseSse(text: string): SSEEvent[] {
+  return text.split('\n\n').flatMap(raw => {
+    let event = 'message'
+    const data: string[] = []
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('event:')) event = line.slice(6).trim()
+      if (line.startsWith('data:')) data.push(line.slice(5).trim())
+    }
+    return data.length > 0 ? [{ event, data: JSON.parse(data.join('\n')) as unknown }] : []
+  })
+}
+
+function startServe(agentFile: string, dataDir: string): Promise<{ child: ChildProcess; port: number; output: () => string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [
+      CLI, 'serve', '--agent', agentFile, '--port', '0',
+      '--state-store', 'sqlite', '--data-dir', dataDir,
+    ], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, VOLCENGINE_TOKEN: 'test-token', LOG_FORMAT: 'json' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let output = ''
+    const timer = setTimeout(() => {
+      cleanup()
+      proc.kill('SIGKILL')
+      reject(new Error(`serve did not become ready:\n${output}`))
+    }, 30000)
+    const onExit = (code: number | null) => {
+      cleanup()
+      reject(new Error(`serve exited before ready (${code}):\n${output}`))
+    }
+    const onData = (chunk: Buffer) => {
+      output += chunk.toString()
+      const match = output.match(/MILKIE_SERVE_READY (\d+)/)
+      if (match) {
+        cleanup()
+        resolve({ child: proc, port: Number(match[1]), output: () => output })
+      }
+    }
+    const collect = (chunk: Buffer) => { output += chunk.toString() }
+    function cleanup(): void {
+      clearTimeout(timer)
+      proc.stdout?.off('data', onData)
+      proc.off('exit', onExit)
+    }
+    proc.stdout?.on('data', onData)
+    proc.stderr?.on('data', collect)
+    proc.on('exit', onExit)
+  })
+}
+
+function stop(proc: ChildProcess): Promise<void> {
+  return new Promise(resolve => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return resolve()
+    proc.once('exit', () => resolve())
+    proc.kill('SIGTERM')
+    setTimeout(() => proc.kill('SIGKILL'), 4000).unref()
+  })
+}
+
+describe('#202 structured model errors — real serve subprocess', () => {
+  let provider: http.Server
+  let providerPort: number
+  let child: ChildProcess | undefined
+  let tempDir: string
+
+  beforeAll(async () => {
+    provider = http.createServer((req) => {
+      req.resume()
+      req.socket.destroy()
+    })
+    providerPort = await new Promise<number>(resolve => {
+      provider.listen(0, '127.0.0.1', () => {
+        resolve((provider.address() as { port: number }).port)
+      })
+    })
+  })
+
+  afterAll(async () => {
+    if (child) await stop(child)
+    await new Promise<void>(resolve => provider.close(() => resolve()))
+    if (tempDir && process.env['KEEP_E2E_ARTIFACTS'] !== '1') {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('persists and renders a retryable connection envelope while serve remains healthy', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milkie-model-error-'))
+    const agentFile = path.join(tempDir, 'agent.md')
+    fs.writeFileSync(agentFile, `---
+agentId: failing-agent
+version: 1.0.0
+fsm:
+  states:
+    - name: react
+      type: llm
+model:
+  provider: local-stub
+  model: failing-model
+  adapter: openai-compatible
+  baseUrl: http://127.0.0.1:${providerPort}
+---
+fail deterministically
+`)
+
+    const started = await startServe(agentFile, tempDir)
+    child = started.child
+    const base = `http://127.0.0.1:${started.port}`
+    const chat = await fetch(base + '/chat', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ contextId: 'model-error-e2e', input: 'go' }),
+    })
+    const events = parseSse(await chat.text())
+    const error = events.find(event => event.event === 'error')
+    const terminal = events.find(event => event.event === 'agent.run.completed')
+
+    expect(error?.data).toMatchObject({
+      error: {
+        code: 'MODEL_CONNECTION_ERROR', phase: 'stream_open', provider: 'local-stub',
+        model: 'failing-model', retryable: true,
+      },
+    })
+    expect(terminal?.data).toMatchObject({ status: 'error', runId: expect.any(String) })
+    const runId = (terminal!.data as { runId: string }).runId
+
+    const health = await fetch(base + '/health')
+    expect(await health.json()).toEqual({ ok: true })
+
+    const traceFile = path.join(tempDir, 'runs', `${runId}.jsonl`)
+    const trace = fs.readFileSync(traceFile, 'utf8')
+    expect(trace).toContain('MODEL_CONNECTION_ERROR')
+    expect(trace).not.toContain('test-token')
+
+    const report = spawnSync(process.execPath, [CLI, 'trace', 'report', '--data-dir', tempDir, runId], {
+      cwd: REPO_ROOT, encoding: 'utf8', timeout: 30000,
+    })
+    if (process.env['KEEP_E2E_ARTIFACTS'] === '1') process.stderr.write(`E2E artifacts: ${tempDir}\n`)
+    expect(report.status).toBe(0)
+    expect(report.stdout).toContain(runId)
+    expect(report.stdout).toContain('badge error')
+
+    await stop(started.child)
+    child = undefined
+  }, 45000)
+})


### PR DESCRIPTION
Closes #202.

Design: [docs/design/202-structured-model-errors.md](https://github.com/xforce-io/milkie/blob/feat/202-structured-model-errors/docs/design/202-structured-model-errors.md)

## What changed

- Normalize OpenAI-compatible SDK failures into a safe typed envelope.
- Preserve the envelope in `AgentResult`, JSONL terminal events and SSE frames.
- Emit correlated `runId`/`contextId` service logs.
- Render structured error metadata in trace viewer output.

## Verification

- `npm run build`
- 89 targeted unit/functional/e2e tests
- `npm test` (58 unit + 7 deterministic e2e)
- Real `milkie serve` subprocess against a socket-closing local model stub; verified SSE, JSONL, trace report and post-failure health.

Lint note: the repository's `npm run lint` entry currently invokes ESLint but ESLint is not declared locally and the fetched ESLint 9 requires an absent `eslint.config.*`; no lint claim is made.
