### PR TITLE
fix(runtime): structure max iteration errors

### DIFF
--- a/docs/design/204-structured-runtime-errors.md
+++ b/docs/design/204-structured-runtime-errors.md
@@ -1,0 +1,29 @@
+# #204 结构化运行时终态错误
+
+最后更新：2026-07-12
+
+## 问题
+
+模型错误已有结构化 envelope，但 `MaxIterationsError` 只留下文本。调用方无法稳定地区分循环耗尽与模型或工具故障。
+
+## 设计
+
+扩展现有错误 envelope 的适用范围，不改变模型错误字段。`MaxIterationsError` 映射为：
+
+- `code`: `MAX_ITERATIONS_EXCEEDED`
+- `phase`: `agent_loop`
+- `retryable`: `false`
+- `message`: 保留当前可读文本
+
+该 envelope 同时进入 `AgentResult`、持久化 `agent.run.completed` 和 serve SSE 的 `error`、`agent.run.completed` 帧。
+
+## 测试计划
+
+- 单元测试：异常映射和 completion payload。
+- 集成测试：两轮上限的确定性循环返回结构化错误。
+- 功能测试：`/chat` 两个终态 SSE 帧包含同一 envelope。
+- 端到端测试：真实 sidecar 使用确定性循环模型耗尽次数，客户端和事件日志均取得相同错误字段。
+
+## 兼容性
+
+继续保留原错误文本；现有只读取字符串的消费者不受影响。

--- a/src/__tests__/AgentRuntime.test.ts
+++ b/src/__tests__/AgentRuntime.test.ts
@@ -813,6 +813,36 @@ describe('#148 run_command output is citable end-to-end', () => {
 
   // #175 切片 1.2a：RunLifecycle 成为 run 最终状态的权威（保行为）。
   describe('RunLifecycle authority (#175)', () => {
+    it('returns and persists a structured error when max iterations are exhausted', async () => {
+      const stateStore = new MemoryStore()
+      const eventStore = new MemoryEventStore()
+      const milkie = new Milkie({
+        stateStore,
+        eventStore,
+        gateway: new SequentialGateway([]),
+      })
+      milkie.registerAgent(makeConfig({
+        fsm: { states: [{ name: 'react', type: 'llm', max_iterations: 0 }] },
+      }))
+
+      const result = await milkie.invoke({
+        agentId: 'test-agent', goal: 'stop', input: 'stop', contextId: 'ctx-max-iterations',
+      })
+
+      expect(result).toMatchObject({
+        status: 'error',
+        error: {
+          code: 'MAX_ITERATIONS_EXCEEDED',
+          phase: 'agent_loop',
+          retryable: false,
+          message: 'State "react" exceeded max_iterations (0)',
+        },
+      })
+      const terminal = (await eventStore.readByRunId(result.agentRunId))
+        .find(event => event.type === 'agent.run.completed')
+      expect(terminal?.payload).toMatchObject({ status: 'error', error: result.error })
+    })
+
     it('exposes lifecycle "completed" after a successful run', async () => {
       const runtime = new AgentRuntime({
         config:     makeConfig(),

--- a/src/runtime/AgentRuntime.ts
+++ b/src/runtime/AgentRuntime.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto'
 import type { AgentConfig, FSMState } from '../types/agent.js'
 import type { AgentResult, ContextProjection } from '../types/common.js'
 import { MaxIterationsError } from '../types/common.js'
+import type { AgentErrorEnvelope } from '../types/model.js'
 import type { IStateStore, AgentCheckpoint, ChildAgentRecord } from '../types/store.js'
 import type { ITrajectoryRecorder, Span } from '../types/trajectory.js'
 import type { ToolDefinition, ToolContext, ToolResult, ToolResultStrategy } from '../types/tool.js'
@@ -985,7 +986,14 @@ export class AgentRuntime {
       }
       this.lifecycle.signal('error')
       this.recorder.endSpan(this.rootSpan, 'error')
-      const structuredError = modelErrorEnvelope(err)
+      const structuredError: AgentErrorEnvelope | undefined = err instanceof MaxIterationsError
+        ? {
+            code:      'MAX_ITERATIONS_EXCEEDED',
+            message:   err.message,
+            phase:     'agent_loop',
+            retryable: false,
+          }
+        : modelErrorEnvelope(err)
       return {
         agentRunId: this.agentRunId,
         contextId:  this.contextId,

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -1,4 +1,4 @@
-import type { ModelErrorEnvelope, ModelRequest, ModelResponse } from '../types/model.js'
+import type { AgentErrorEnvelope, ModelRequest, ModelResponse } from '../types/model.js'
 
 /**
  * Agent Trace event types.
@@ -124,7 +124,7 @@ export interface AgentRunStartedPayload {
 export interface AgentRunCompletedPayload {
   status:           'completed' | 'interrupted' | 'error'
   lastTextOutput?:  string
-  error?:           string | ModelErrorEnvelope
+  error?:           string | AgentErrorEnvelope
 }
 
 export interface AgentSpawnedPayload {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
-import type { ModelErrorEnvelope, ModelEvent } from './model.js'
+import type { AgentErrorEnvelope, ModelEvent } from './model.js'
 
 export type JSONValue = string | number | boolean | null | JSONValue[] | { [k: string]: JSONValue }
 export type JSONObject = Record<string, JSONValue>
@@ -62,7 +62,7 @@ export interface AgentResult {
   output:      string
   status:      'completed' | 'interrupted' | 'error'
   checkpointId?: string
-  error?:      ModelErrorEnvelope
+  error?:      AgentErrorEnvelope
 }
 
 export class InterruptSignal extends Error {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -22,6 +22,17 @@ export interface ModelErrorEnvelope {
   status?:    number
 }
 
+export interface RuntimeErrorEnvelope {
+  code:       'MAX_ITERATIONS_EXCEEDED'
+  message:    string
+  phase:      'agent_loop'
+  retryable:  false
+  provider?:  undefined
+  model?:     undefined
+}
+
+export type AgentErrorEnvelope = ModelErrorEnvelope | RuntimeErrorEnvelope
+
 export interface ToolSchema {
   name:        string
   description: string


### PR DESCRIPTION
Closes #204.

Design: [docs/design/204-structured-runtime-errors.md](https://github.com/xforce-io/milkie/blob/feat/204-structured-runtime-errors/docs/design/204-structured-runtime-errors.md)

## Changes
- map `MaxIterationsError` to a stable runtime error envelope
- persist the envelope in `agent.run.completed`
- expose it through `AgentResult` and existing serve SSE forwarding

## Tests
- `npm run build`
- `npm run test:unit` (59 passed)
- `npm run test:e2e:deterministic` (7 passed)