### PR TITLE
fix(runtime): reconcile abandoned runs

### DIFF
--- a/docs/design/205-orphan-run-reconciliation.md
+++ b/docs/design/205-orphan-run-reconciliation.md
@@ -1,0 +1,29 @@
+# #205 悬空运行终态协调
+
+最后更新：2026-07-12
+
+## 问题
+
+进程退出或执行被遗弃后，事件日志可能只有 `agent.run.started` 而没有 `agent.run.completed`，导致 trace 永久显示 in-flight。
+
+## 设计
+
+事件日志保持单一事实源。serve 启动时扫描 run 文件，对包含 started 且不存在 completion 的顶层 run 追加一个幂等终态：
+
+- `status`: `interrupted`
+- `error.code`: `RUN_ABANDONED`
+- `error.phase`: `recovery`
+- `error.retryable`: `true`
+
+只追加事件，不改写或删除历史；第二次启动不重复追加。客户端主动断开仍只取消订阅，不取消健康运行，只有服务重启后仍非终态的旧 run 才会被协调。
+
+## 测试计划
+
+- 单元测试：完整、悬空、畸形日志分类和幂等追加。
+- 集成测试：serve 使用包含悬空 run 的 data dir 初始化后写入终态。
+- 功能测试：有效 completed/interrupted run 不变，悬空 run 获得结构化终态。
+- 端到端测试：工具请求后杀死 sidecar，以同一 data dir 重启，旧 run 恰好新增一个终态且新请求成功。
+
+## 非目标
+
+不自动恢复或重试旧 run；上层调度器根据结构化结果决定后续动作。

--- a/src/__tests__/serve-persistence.test.ts
+++ b/src/__tests__/serve-persistence.test.ts
@@ -84,9 +84,44 @@ describe('#130 buildServeStores — backend selection', () => {
 
     const re = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
     const events = await re.eventStore.readByRunId('run-1')
-    expect(events).toHaveLength(1)
-    expect(events[0]!.runId).toBe('run-1')
+    expect(events[0]).toMatchObject({ runId: 'run-1', type: 'agent.run.started' })
+    expect(events[1]).toMatchObject({ runId: 'run-1', type: 'agent.run.completed', payload: { status: 'interrupted' } })
     closeIfPossible(re.stateStore)
+  })
+
+  it('reconciles an abandoned persisted run exactly once on restart', async () => {
+    const runsDir = path.join(tmpDir, 'runs')
+    fs.mkdirSync(runsDir, { recursive: true })
+    const started: Event = {
+      id: 'started', runId: 'run-abandoned', type: 'agent.run.started', actor: 'runtime', timestamp: 1,
+      payload: { agentId: 'recorder', goal: 'g', input: 'hi', contextId: 'C' },
+    }
+    fs.writeFileSync(path.join(runsDir, 'run-abandoned.jsonl'), `${JSON.stringify(started)}\n`)
+    const completed: Event = {
+      id: 'completed', runId: 'run-complete', type: 'agent.run.completed', actor: 'runtime', timestamp: 2,
+      payload: { status: 'completed', lastTextOutput: 'ok' },
+    }
+    fs.writeFileSync(
+      path.join(runsDir, 'run-complete.jsonl'),
+      `${JSON.stringify({ ...started, runId: 'run-complete' })}\n${JSON.stringify(completed)}\n`,
+    )
+
+    const first = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const firstEvents = await first.eventStore.readByRunId('run-abandoned')
+    expect(firstEvents.filter(event => event.type === 'agent.run.completed')).toHaveLength(1)
+    expect(firstEvents.at(-1)?.payload).toMatchObject({
+      status: 'interrupted',
+      error: {
+        code: 'RUN_ABANDONED', phase: 'recovery', retryable: true,
+      },
+    })
+    expect(await first.eventStore.readByRunId('run-complete')).toHaveLength(2)
+    closeIfPossible(first.stateStore)
+
+    const second = await buildServeStores({ stateStore: 'sqlite', dataDir: tmpDir })
+    const secondEvents = await second.eventStore.readByRunId('run-abandoned')
+    expect(secondEvents.filter(event => event.type === 'agent.run.completed')).toHaveLength(1)
+    closeIfPossible(second.stateStore)
   })
 
   it('state-store=sqlite without data-dir is rejected', async () => {

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -391,6 +391,7 @@ export async function buildServeStores(opts: { stateStore?: 'memory' | 'sqlite';
     const stateStore = new SQLiteStore({ path: path.join(opts.dataDir, 'state.sqlite') })
     await stateStore.init()
     const eventStore = new JsonlEventStore(path.join(opts.dataDir, 'runs'))
+    await eventStore.reconcileAbandonedRuns()
     return { stateStore, eventStore }
   }
   // Fail fast: an unknown backend (typo, or unsupported like redis) must NOT

--- a/src/trace/JsonlEventStore.ts
+++ b/src/trace/JsonlEventStore.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import path from 'path'
+import { randomUUID } from 'crypto'
 import type { IEventStore } from './EventStore.js'
 import type { Event } from './types.js'
 
@@ -48,5 +49,47 @@ export class JsonlEventStore implements IEventStore {
     return count !== undefined
       ? all.slice(fromIndex, fromIndex + count)
       : all.slice(fromIndex)
+  }
+
+  async reconcileAbandonedRuns(): Promise<number> {
+    await this.ensureDir()
+    const files = await fs.readdir(this.baseDir)
+    let reconciled = 0
+
+    for (const file of files.filter(name => name.endsWith('.jsonl'))) {
+      const runId = file.slice(0, -'.jsonl'.length)
+      let events: Event[]
+      try {
+        events = await this.readByRunId(runId)
+      } catch {
+        continue
+      }
+      const started = events.find(event => event.type === 'agent.run.started')
+      const completed = events.some(event => event.type === 'agent.run.completed')
+      const parentId = started && typeof started.payload === 'object' && started.payload !== null
+        ? (started.payload as { parentId?: unknown }).parentId
+        : undefined
+      if (!started || completed || parentId) continue
+
+      await this.append({
+        id:        randomUUID(),
+        runId,
+        type:      'agent.run.completed',
+        actor:     'runtime',
+        timestamp: Date.now(),
+        payload: {
+          status: 'interrupted',
+          error: {
+            code:      'RUN_ABANDONED',
+            message:   'Run was abandoned before the service restarted.',
+            phase:     'recovery',
+            retryable: true,
+          },
+        },
+      })
+      reconciled++
+    }
+
+    return reconciled
   }
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -22,7 +22,7 @@ export interface ModelErrorEnvelope {
   status?:    number
 }
 
-export interface RuntimeErrorEnvelope {
+export interface MaxIterationsErrorEnvelope {
   code:       'MAX_ITERATIONS_EXCEEDED'
   message:    string
   phase:      'agent_loop'
@@ -31,6 +31,16 @@ export interface RuntimeErrorEnvelope {
   model?:     undefined
 }
 
+export interface AbandonedRunErrorEnvelope {
+  code:       'RUN_ABANDONED'
+  message:    string
+  phase:      'recovery'
+  retryable:  true
+  provider?:  undefined
+  model?:     undefined
+}
+
+export type RuntimeErrorEnvelope = MaxIterationsErrorEnvelope | AbandonedRunErrorEnvelope
 export type AgentErrorEnvelope = ModelErrorEnvelope | RuntimeErrorEnvelope
 
 export interface ToolSchema {


### PR DESCRIPTION
Closes #205.

Depends on #206 for the generalized runtime error envelope.

Design: [docs/design/205-orphan-run-reconciliation.md](https://github.com/xforce-io/milkie/blob/feat/205-orphan-run-reconciliation/docs/design/205-orphan-run-reconciliation.md)

## Changes
- scan persisted run logs during serve startup
- append one structured interrupted terminal to abandoned top-level runs
- preserve valid terminal runs and make repeated startup idempotent

## Tests
- `npm run build`
- `npm run test:unit` (59 passed)
- `npx jest src/__tests__/serve-persistence.test.ts --runInBand` (10 passed)
- `npm run test:e2e:deterministic` (7 passed)