### PR TITLE
feat(skills): closed-world skill_request loads SKILL.md from manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "npm run test:unit && npm run test:e2e:deterministic",
-    "test:unit": "jest src/__tests__/AgentRuntime.test.ts src/__tests__/FSMEngine.test.ts src/__tests__/MemoryStore.test.ts src/__tests__/WorkingMemory.test.ts src/__tests__/SQLiteStore.abiMismatch.test.ts --runInBand",
+    "test:unit": "jest src/__tests__/AgentRuntime.test.ts src/__tests__/FSMEngine.test.ts src/__tests__/MemoryStore.test.ts src/__tests__/WorkingMemory.test.ts src/__tests__/SQLiteStore.abiMismatch.test.ts src/__tests__/skillListManifest.test.ts --runInBand",
     "test:all": "jest",
     "test:smoke": "jest src/__tests__/volcengine.smoke.test.ts --runInBand",
     "test:watch": "jest --watch",

--- a/src/__tests__/skillListManifest.test.ts
+++ b/src/__tests__/skillListManifest.test.ts
@@ -145,34 +145,90 @@ describe('skill_list 默认 handler 读 manifest (#139)', () => {
   })
 })
 
-describe('skill_request manifest-backed fallback (#153)', () => {
-  it('原生 AgentConfig 未声明但 manifest 有该 skill 时，不返回误导性的 unavailable', async () => {
-    const p = writeManifest('request-fallback.json', JSON.stringify({
+const unavailableCtx = {
+  requestSkill: (name: string) => ({ requested: name, status: 'unavailable' }),
+} as unknown as ToolContext
+
+/** Create a real skill dir with SKILL.md and return its absolute path. */
+function makeSkillDir(name: string, body: string): string {
+  const dir = path.join(tmpDir, 'skills', name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), body, 'utf-8')
+  return dir
+}
+
+describe('skill_request closed-world manifest load (#164)', () => {
+  // M1: hit + real SKILL.md → status ok, instructions + dir; no run_command/cat load guidance
+  it('M1: manifest hit returns instructions + dir (not cat/find guidance)', async () => {
+    const dir = makeSkillDir('web', '# Web\n\nFetch and analyze web pages.\n')
+    const p = writeManifest('request-hit.json', JSON.stringify({
       skills: [
-        { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+        { name: 'web', description: 'web skill', dir, version: '1.0.0' },
       ],
     }))
     process.env[ENV_KEY] = p
-    const unavailableCtx = {
-      requestSkill: (name: string) => ({ requested: name, status: 'unavailable' }),
-    } as unknown as ToolContext
 
-    const out = await skillRequest.handler({ name: 'twitter-watch' }, unavailableCtx) as Record<string, unknown>
+    const out = await skillRequest.handler({ name: 'web' }, unavailableCtx) as Record<string, unknown>
 
     expect(out).toMatchObject({
-      requested: 'twitter-watch',
-      status:    'manifest_backed',
-      skill:     { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+      requested: 'web',
+      status:    'ok',
+      dir,
+      instructionPath: path.join(dir, 'SKILL.md'),
+      truncated: false,
     })
-    expect(out.status).not.toBe('unavailable')
-    expect(out).toHaveProperty('instructionPath', '/abs/twitter-watch/SKILL.md')
-    expect(String(out.message)).toContain('SKILL.md')
+    expect(String(out.instructions)).toContain('Fetch and analyze web pages')
+    expect(out.skill).toMatchObject({ name: 'web', description: 'web skill', dir })
+    // Must not guide shell discovery as the primary load path
+    const msg = out.message != null ? String(out.message) : ''
+    expect(msg).not.toMatch(/run_command\/cat/i)
+    expect(msg).not.toMatch(/Read .+ with run_command/i)
+    expect(JSON.stringify(out)).not.toMatch(/Read .+ with run_command\/cat/i)
   })
 
-  it('原生 skill_request 成功时保持原生返回，不走 manifest fallback', async () => {
+  // M2: miss when registry configured → not_found; no disk search outside known paths
+  it('M2: unknown skill name returns not_found without disk scan', async () => {
+    const dir = makeSkillDir('web', '# Web\n\nbody\n')
+    const skillMd = path.join(dir, 'SKILL.md')
+    const p = writeManifest('request-miss.json', JSON.stringify({
+      skills: [{ name: 'web', description: 'web skill', dir }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const readSpy = jest.spyOn(fs, 'readFileSync')
+    try {
+      const out = await skillRequest.handler({ name: 'no-such-skill' }, unavailableCtx) as Record<string, unknown>
+
+      expect(out).toMatchObject({
+        requested: 'no-such-skill',
+        status:    'not_found',
+      })
+      expect(out).not.toHaveProperty('instructions')
+      expect(String(out.message ?? '')).not.toMatch(/find|run_command\/cat|search/i)
+      // Miss must not open any skill dir path (manifest JSON read is OK)
+      const skillPathsRead = readSpy.mock.calls
+        .map(c => String(c[0]))
+        .filter(f => f === skillMd || f.startsWith(dir + path.sep) || f === dir)
+      expect(skillPathsRead).toEqual([])
+    } finally {
+      readSpy.mockRestore()
+    }
+  })
+
+  // M3: registry not configured → unavailable (degrade)
+  it('M3: registry unconfigured stays unavailable without throw', async () => {
+    // ENV_KEY deleted in beforeEach
+    const out = await skillRequest.handler({ name: 'web' }, unavailableCtx) as Record<string, unknown>
+    expect(out).toMatchObject({ requested: 'web', status: 'unavailable' })
+  })
+
+  // M4: native pending_next_epoch wins; no disk read for manifest path
+  it('M4: native pending_next_epoch wins over manifest path', async () => {
+    const dir = makeSkillDir('twitter-watch', '# Twitter\n\nwatch\n')
+    const skillMd = path.join(dir, 'SKILL.md')
     const p = writeManifest('native-wins.json', JSON.stringify({
       skills: [
-        { name: 'twitter-watch', description: '盯推', dir: '/abs/twitter-watch', version: '1.2.0' },
+        { name: 'twitter-watch', description: '盯推', dir, version: '1.2.0' },
       ],
     }))
     process.env[ENV_KEY] = p
@@ -185,13 +241,153 @@ describe('skill_request manifest-backed fallback (#153)', () => {
       }),
     } as unknown as ToolContext
 
-    const out = await skillRequest.handler({ name: 'twitter-watch' }, nativeCtx)
+    const readSpy = jest.spyOn(fs, 'readFileSync')
+    try {
+      const out = await skillRequest.handler({ name: 'twitter-watch' }, nativeCtx)
 
-    expect(out).toEqual({
-      requested: 'twitter-watch',
-      status:    'pending_next_epoch',
-      version:   '9.9.9',
-      scope:     'turn',
+      expect(out).toEqual({
+        requested: 'twitter-watch',
+        status:    'pending_next_epoch',
+        version:   '9.9.9',
+        scope:     'turn',
+      })
+      // Native hit must not touch skill SKILL.md (or any skill dir file)
+      const skillPathsRead = readSpy.mock.calls
+        .map(c => String(c[0]))
+        .filter(f => f === skillMd || f.startsWith(dir + path.sep) || f === dir)
+      expect(skillPathsRead).toEqual([])
+    } finally {
+      readSpy.mockRestore()
+    }
+  })
+
+  // M5: truncation at 16k
+  it('M5: large SKILL.md is truncated to 16000 chars with truncated=true', async () => {
+    const body = 'X'.repeat(20_000)
+    const dir = makeSkillDir('big', body)
+    const p = writeManifest('request-trunc.json', JSON.stringify({
+      skills: [{ name: 'big', description: 'big skill', dir }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const out = await skillRequest.handler({ name: 'big' }, unavailableCtx) as Record<string, unknown>
+
+    expect(out.status).toBe('ok')
+    expect(out.truncated).toBe(true)
+    expect(String(out.instructions)).toHaveLength(16_000)
+    expect(out.dir).toBe(dir)
+    expect(out.instructionPath).toBe(path.join(dir, 'SKILL.md'))
+    // Truncation message may mention known absolute path; must not suggest search
+    if (out.message != null) {
+      expect(String(out.message)).not.toMatch(/find \$HOME|search the filesystem to discover/i)
+      expect(String(out.message)).toMatch(/instructionPath|truncated/i)
+    }
+  })
+
+  // M6: missing dir / missing SKILL.md
+  it('M6a: skill entry without dir returns missing_dir', async () => {
+    const p = writeManifest('no-dir.json', JSON.stringify({
+      skills: [{ name: 'ghost', description: 'no dir field' }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const out = await skillRequest.handler({ name: 'ghost' }, unavailableCtx) as Record<string, unknown>
+
+    expect(out).toMatchObject({
+      requested: 'ghost',
+      status:    'missing_dir',
     })
+    expect(out).not.toHaveProperty('instructions')
+    expect(String(out.message ?? '')).not.toMatch(/run_command\/cat|find \$HOME/i)
+  })
+
+  it('M6a2: empty dir string returns missing_dir without reading disk', async () => {
+    const p = writeManifest('empty-dir.json', JSON.stringify({
+      skills: [{ name: 'ghost', description: 'empty dir', dir: '   ' }],
+    }))
+    process.env[ENV_KEY] = p
+    const readSpy = jest.spyOn(fs, 'readFileSync')
+    try {
+      const out = await skillRequest.handler({ name: 'ghost' }, unavailableCtx) as Record<string, unknown>
+      expect(out).toMatchObject({ requested: 'ghost', status: 'missing_dir' })
+      // Only the manifest JSON path may be read
+      const nonManifestReads = readSpy.mock.calls
+        .map(c => String(c[0]))
+        .filter(f => f !== p)
+      expect(nonManifestReads).toEqual([])
+    } finally {
+      readSpy.mockRestore()
+    }
+  })
+
+  it('M6a3: relative dir returns invalid_dir without reading disk', async () => {
+    const p = writeManifest('rel-dir.json', JSON.stringify({
+      skills: [{ name: 'rel', description: 'relative', dir: 'skills/web' }],
+    }))
+    process.env[ENV_KEY] = p
+    const readSpy = jest.spyOn(fs, 'readFileSync')
+    try {
+      const out = await skillRequest.handler({ name: 'rel' }, unavailableCtx) as Record<string, unknown>
+      expect(out).toMatchObject({
+        requested: 'rel',
+        status:    'invalid_dir',
+        dir:       'skills/web',
+      })
+      expect(out).not.toHaveProperty('instructions')
+      const nonManifestReads = readSpy.mock.calls
+        .map(c => String(c[0]))
+        .filter(f => f !== p)
+      expect(nonManifestReads).toEqual([])
+    } finally {
+      readSpy.mockRestore()
+    }
+  })
+
+  it('M6b: dir present but SKILL.md missing returns read_error', async () => {
+    const dir = path.join(tmpDir, 'skills', 'broken-md')
+    fs.mkdirSync(dir, { recursive: true })
+    // deliberately no SKILL.md
+    const p = writeManifest('read-err.json', JSON.stringify({
+      skills: [{ name: 'broken-md', description: 'missing md', dir }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const out = await skillRequest.handler({ name: 'broken-md' }, unavailableCtx) as Record<string, unknown>
+
+    expect(out).toMatchObject({
+      requested: 'broken-md',
+      status:    'read_error',
+      dir,
+      instructionPath: path.join(dir, 'SKILL.md'),
+    })
+    expect(out).not.toHaveProperty('instructions')
+    expect(String(out.message ?? '')).not.toMatch(/run_command\/cat|find \$HOME/i)
+  })
+
+  // M7: no regression to "Read … with run_command/cat" as hit primary path
+  it('M7: hit path must not use status manifest_backed or cat load guidance', async () => {
+    const dir = makeSkillDir('ops', '# Ops\n\nops body\n')
+    const p = writeManifest('no-regress.json', JSON.stringify({
+      skills: [{ name: 'ops', description: 'ops', dir }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const out = await skillRequest.handler({ name: 'ops' }, unavailableCtx) as Record<string, unknown>
+
+    expect(out.status).toBe('ok')
+    expect(out.status).not.toBe('manifest_backed')
+    expect(JSON.stringify(out)).not.toContain('Read ')
+    expect(JSON.stringify(out)).not.toMatch(/run_command\/cat/)
+  })
+
+  it('normalizes trailing " skill" suffix on request name', async () => {
+    const dir = makeSkillDir('web', '# Web\n\nbody\n')
+    const p = writeManifest('norm.json', JSON.stringify({
+      skills: [{ name: 'web', description: 'web', dir }],
+    }))
+    process.env[ENV_KEY] = p
+
+    const out = await skillRequest.handler({ name: 'web skill' }, unavailableCtx) as Record<string, unknown>
+    expect(out).toMatchObject({ requested: 'web', status: 'ok' })
   })
 })

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -61,24 +61,84 @@ function normalizeSkillName(name: string): string {
   return name.trim().replace(/\s+skill$/i, '')
 }
 
+/** Max chars of SKILL.md body returned in tool_result (UTF-16 code units / JS string.length). */
+export const SKILL_INSTRUCTIONS_MAX_CHARS = 16_000
+
+/**
+ * Closed-world skill load via host manifest (#164).
+ *
+ * Hit: read only manifest.dir/SKILL.md and return instructions + dir.
+ * Miss: not_found without filesystem search.
+ * Registry unconfigured: undefined so the handler keeps native unavailable.
+ */
 function manifestBackedSkillRequest(name: string): Record<string, unknown> | undefined {
   const manifest = loadSkillManifest()
   if (!manifest.registryConfigured) return undefined
 
   const normalized = normalizeSkillName(name)
   const skill = manifest.skills.find(s => normalizeSkillName(s.name) === normalized)
-  if (!skill) return undefined
+  if (!skill) {
+    return {
+      requested: normalized,
+      status:    'not_found',
+      message:   `Skill "${normalized}" is not in the skill manifest.`,
+    }
+  }
 
-  const dir = typeof skill.dir === 'string' ? skill.dir : undefined
-  const instructionPath = dir ? path.join(dir, 'SKILL.md') : undefined
+  const dirRaw = typeof skill.dir === 'string' ? skill.dir : undefined
+  const dir = dirRaw?.trim() ? dirRaw : undefined
+  if (!dir) {
+    return {
+      requested: normalized,
+      status:    'missing_dir',
+      skill,
+      message:   `Skill "${normalized}" is in the skill manifest but has no dir field; cannot load SKILL.md.`,
+    }
+  }
+  // Authoritative dir must be absolute; never resolve relative paths against cwd.
+  if (!path.isAbsolute(dir)) {
+    return {
+      requested: normalized,
+      status:    'invalid_dir',
+      skill,
+      dir,
+      message:   `Skill "${normalized}" dir must be an absolute path; got ${JSON.stringify(dir)}. Do not search the filesystem for SKILL.md.`,
+    }
+  }
+
+  const instructionPath = path.join(dir, 'SKILL.md')
+  // Closed-world: read only this absolute path; never search other directories.
+  let text: string
+  try {
+    text = fs.readFileSync(instructionPath, 'utf-8')
+  } catch {
+    return {
+      requested: normalized,
+      status:    'read_error',
+      skill,
+      dir,
+      instructionPath,
+      message:   `Failed to read skill instructions at ${instructionPath}. Do not search the filesystem for SKILL.md.`,
+    }
+  }
+
+  const truncated = text.length > SKILL_INSTRUCTIONS_MAX_CHARS
+  const instructions = truncated ? text.slice(0, SKILL_INSTRUCTIONS_MAX_CHARS) : text
   return {
     requested: normalized,
-    status:    'manifest_backed',
+    status:    'ok',
     skill,
-    ...(instructionPath ? { instructionPath } : {}),
-    message: instructionPath
-      ? `Skill "${normalized}" is available via the manifest, but this agent was not configured with inline skillInstructions. Read ${instructionPath} with run_command/cat, then follow that SKILL.md.`
-      : `Skill "${normalized}" is available via the manifest, but this agent was not configured with inline skillInstructions and the manifest entry has no dir. Use skill_list details or host instructions to locate its SKILL.md.`,
+    dir,
+    instructionPath,
+    instructions,
+    truncated,
+    ...(truncated
+      ? {
+          message:
+            `Instructions truncated to ${SKILL_INSTRUCTIONS_MAX_CHARS} chars. ` +
+            `Continue reading only at instructionPath (known absolute path); do not search the filesystem.`,
+        }
+      : {}),
   }
 }
 
@@ -94,7 +154,11 @@ export const systemTools: ToolDefinition[] = [
 
   {
     name:        'skill_request',
-    description: "Request a skill to be loaded in the next context epoch. Choose scope=turn for one-shot usage (auto-released at turn end) or scope=session for cross-turn persistence. Default: turn.",
+    description:
+      'Load skill instructions by name from the host skill manifest (closed-world). ' +
+      'On success returns instructions text and authoritative dir. Prefer this over shell find/cat to discover SKILL.md. ' +
+      'Optional scope applies when the skill is also declared in AgentConfig.skillInstructions (next context epoch). ' +
+      "Choose scope=turn for one-shot usage (auto-released at turn end) or scope=session for cross-turn persistence. Default: turn.",
     inputSchema: {
       type:       'object',
       properties: {


### PR DESCRIPTION
## Summary

- `skill_request` is closed-world: hit reads only `manifest.dir/SKILL.md` and returns `instructions` + absolute `dir` (16k truncate).
- Miss / missing_dir / invalid_dir / read_error without searching the filesystem.
- Tool description steers agents away from `find`/`cat` discovery of SKILL.md.
- Unit coverage expanded in `skillListManifest.test.ts`.

## Context

Implements the milkie half of [alfred#164](https://github.com/xforce-io/alfred/issues/164) (Skill 闭世界加载). Pair with the alfred host/prompt PR.

## Test plan

- [x] Unit suite including `skillListManifest`
- [ ] Pair with alfred spawn E2E (sidecar skill_request hit/miss)