### PR TITLE
feat(tools): run_command default resultStrategy for LLM projection

### DIFF
--- a/docs/en/guide.md
+++ b/docs/en/guide.md
@@ -328,6 +328,19 @@ These are also auto-registered. No manual setup required.
 |------|-------------|
 | `skill_list` | Returns a list of available skills. (v1 stub — always returns an empty list; full registry support is planned.) |
 | `skill_request` | Requests a skill to be loaded in the next context epoch. Requires the skill to be declared in `AgentConfig.skills` and its instructions provided via `AgentConfig.skillInstructions`. The instructions appear in the LLM context from the next turn onward. |
+| `run_command` | Runs a shell command (`src/tools/exec.ts`). Auto-registered with the cognitive/system tools. |
+
+#### `run_command` output layers (LLM vs event-log vs host UI)
+
+Three separate caps apply; do not confuse them:
+
+| Layer | What it controls | Default |
+|-------|------------------|---------|
+| **Handler stream cap** | Per-stream stdout/stderr size stored on `tool.responded` / event-log | ~30k chars (head+tail) |
+| **`resultStrategy` (LLM projection)** | String shaped into the next LLM `tool_result` | `tail` @ **8000** chars (`RUN_COMMAND_LLM_MAX_CHARS`); emits `tool.shaped` when bytes change |
+| **Host UI preview** (e.g. alfred `max_tool_output_preview_chars`) | Timeline / chat UI only | Does **not** change the LLM view |
+
+Escape hatch: set `MILKIE_RUN_COMMAND_SHAPE_VERBATIM=1` to force LLM-facing `verbatim` (no shape). Prefer declaring `resultStrategy` on custom tools that return large payloads rather than relying on global truncation.
 
 To wire up a skill, declare it in the agent config:
 

--- a/docs/zh/guide.md
+++ b/docs/zh/guide.md
@@ -330,6 +330,19 @@ const milkie = new Milkie({ gateway: new MockGateway() })
 |------|------|
 | `skill_list` | 返回可用 Skill 列表。（v1 stub — 当前始终返回空列表，完整 Registry 支持计划在 v2 实现。） |
 | `skill_request` | 请求在下一个 context epoch 加载某个 Skill。需要在 `AgentConfig.skills` 中声明该 Skill，并通过 `AgentConfig.skillInstructions` 提供指令内容。指令从下一 turn 起生效。 |
+| `run_command` | 执行 shell 命令（`src/tools/exec.ts`），与 cognitive/system 工具一并自动注册。 |
+
+#### `run_command` 输出分层（LLM vs event-log vs 宿主 UI）
+
+三层上限互不替代：
+
+| 层 | 控制什么 | 默认 |
+|----|----------|------|
+| **Handler stream cap** | 写入 `tool.responded` / event-log 的 stdout/stderr 上界 | 约 30k 字符（头尾保留） |
+| **`resultStrategy`（LLM 投影）** | 进入下一轮 LLM `tool_result` 的字符串 | `tail` @ **8000** 字符（`RUN_COMMAND_LLM_MAX_CHARS`）；实际变短时发 `tool.shaped` |
+| **宿主 UI 预览**（如 alfred `max_tool_output_preview_chars`） | 仅 timeline / 会话 UI | **不**改变 LLM 视图 |
+
+逃生：环境变量 `MILKIE_RUN_COMMAND_SHAPE_VERBATIM=1` 强制 LLM 侧 `verbatim`。自定义大输出工具应自行声明 `resultStrategy`，不要依赖全局截断。
 
 在 Agent 配置中声明 Skill：
 

--- a/src/__tests__/AgentRuntime.toolResultStrategy.test.ts
+++ b/src/__tests__/AgentRuntime.toolResultStrategy.test.ts
@@ -152,4 +152,99 @@ describe('AgentRuntime — ToolResultStrategy applied end-to-end', () => {
     // Verbatim: full 5000 chars must arrive unchanged
     expect(tr.content.length).toBe(5000)
   })
+
+  test('built-in run_command default strategy shapes oversized stdout into LLM tool_result (alfred#160)', async () => {
+    // Drive the *shipped* run_command definition (not a test double) so registration
+    // and resultStrategy on execTools are what AgentRuntime applies.
+    const { execTools, RUN_COMMAND_LLM_MAX_CHARS, runCommand } = await import('../tools/exec')
+    const runCmdDef = execTools.find(t => t.name === 'run_command')!
+    expect(runCmdDef.resultStrategy).toBeDefined()
+    const shape = runCmdDef.resultStrategy!.shape
+    expect(typeof shape === 'object' && shape.kind === 'tail').toBe(true)
+
+    // Oversized payload: larger than LLM maxChars but under stream cap (~30k)
+    const bigLen = RUN_COMMAND_LLM_MAX_CHARS + 5_000
+    expect(bigLen).toBeLessThan(30_000)
+
+    // Gateway: first call asks for run_command with a command that prints bigLen A's
+    const requestsSeen: ModelRequest[] = []
+    const gateway: IModelGateway = {
+      async complete(req: ModelRequest): Promise<ModelResponse> {
+        requestsSeen.push(req)
+        if (requestsSeen.length === 1) {
+          const cmd = `${process.execPath} -e "process.stdout.write('A'.repeat(${bigLen}))"`
+          return {
+            content:      [{ type: 'tool_use', id: 'tc-rc', name: 'run_command', input: { command: cmd } }],
+            toolCalls:    [{ id: 'tc-rc', name: 'run_command', input: { command: cmd } }],
+            finishReason: 'tool_use',
+          }
+        }
+        return {
+          content:      [{ type: 'text', text: 'done' }],
+          toolCalls:    [],
+          finishReason: 'end_turn',
+        }
+      },
+      async *stream(_req: ModelRequest): AsyncIterable<never> {
+        yield* []
+      },
+    }
+
+    const recorder = new InMemoryRecorder()
+    const runtime = new AgentRuntime({
+      config:     makeConfig(),
+      goal:       'test',
+      input:      'go',
+      stateStore: new MemoryStore(),
+      recorder,
+      ioPort:     new DefaultIOPort(gateway),
+      // Register the real built-in tool only (avoid double-register of system tools if any)
+      extraTools: [runCmdDef],
+    })
+
+    // Sanity: real handler produces raw stdout at least bigLen
+    const rawOut = await runCommand({
+      command: `${process.execPath} -e "process.stdout.write('A'.repeat(${bigLen}))"`,
+    })
+    expect(rawOut.stdout.length).toBe(bigLen)
+    expect(rawOut.truncated).toBe(false)
+
+    const result = await runtime.run('go')
+    expect(result.status).toBe('completed')
+    expect(requestsSeen.length).toBe(2)
+
+    const messagesIter2 = requestsSeen[1]!.messages
+    const toolResultMsg = messagesIter2.find(
+      m => m.role === 'tool' && m.content.some(c => c.type === 'tool_result'),
+    )
+    expect(toolResultMsg).toBeDefined()
+    const tr = toolResultMsg!.content.find(c => c.type === 'tool_result') as {
+      type: 'tool_result'
+      content: string
+    }
+    expect(tr).toBeDefined()
+
+    // LLM-facing content must be shaped ≤ maxChars (+ small marker overhead for tail prefix)
+    expect(tr.content.length).toBeLessThanOrEqual(RUN_COMMAND_LLM_MAX_CHARS + 80)
+    expect(tr.content.length).toBeLessThan(bigLen)
+    expect(tr.content).toMatch(/chars dropped/i)
+    // tail keeps the end of the payload
+    expect(tr.content.endsWith('AAAAA') || tr.content.includes('AAAAA')).toBe(true)
+
+    // tool.shaped observation when bytes actually changed
+    const shapedEvents = recorder.getSpans()
+      .flatMap(s => s.events)
+      .filter(e => e.name === 'tool.shaped')
+    expect(shapedEvents.length).toBeGreaterThanOrEqual(1)
+    const attrs = shapedEvents[0]!.attributes as {
+      rawBytes: number
+      storedBytes: number
+      shapeKind: string
+      toolName: string
+    }
+    expect(attrs.toolName).toBe('run_command')
+    expect(attrs.shapeKind).toBe('tail')
+    expect(attrs.rawBytes).toBeGreaterThan(attrs.storedBytes)
+    expect(attrs.storedBytes).toBeLessThanOrEqual(RUN_COMMAND_LLM_MAX_CHARS + 80)
+  })
 })

--- a/src/__tests__/execTools.test.ts
+++ b/src/__tests__/execTools.test.ts
@@ -1,7 +1,13 @@
 import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { execTools, runCommand, type RunCommandOutput } from '../tools/exec'
+import {
+  execTools,
+  getRunCommandResultStrategy,
+  runCommand,
+  RUN_COMMAND_LLM_MAX_CHARS,
+  type RunCommandOutput,
+} from '../tools/exec'
 import { sha256Hex } from '../trace/hash'
 import type { ToolContext } from '../types/tool'
 
@@ -12,6 +18,20 @@ describe('built-in run_command tool (#134)', () => {
   it('registers run_command', () => {
     expect(runCmd).toBeTruthy()
     expect(runCmd.name).toBe('run_command')
+  })
+
+  it('declares non-verbatim resultStrategy for LLM projection (alfred#160)', () => {
+    // Shipped tool definition must opt into shape — default verbatim leaves 19k stdout in context.
+    expect(runCmd.resultStrategy).toBeDefined()
+    const strategy = getRunCommandResultStrategy()
+    expect(strategy.shape).not.toBe('verbatim')
+    if (typeof strategy.shape === 'object') {
+      expect(strategy.shape.kind).toBe('tail')
+      expect(strategy.shape.maxChars).toBe(RUN_COMMAND_LLM_MAX_CHARS)
+      expect(strategy.shape.maxChars).toBeLessThan(20_000)
+    }
+    // Tool registration carries the same strategy object shape
+    expect(runCmd.resultStrategy?.shape).toEqual(strategy.shape)
   })
 
   it('runs a command and captures stdout + exitCode 0', async () => {

--- a/src/__tests__/execTools.test.ts
+++ b/src/__tests__/execTools.test.ts
@@ -34,6 +34,35 @@ describe('built-in run_command tool (#134)', () => {
     expect(runCmd.resultStrategy?.shape).toEqual(strategy.shape)
   })
 
+  describe('getRunCommandResultStrategy escape hatch', () => {
+    const envKey = 'MILKIE_RUN_COMMAND_SHAPE_VERBATIM'
+    const previous = process.env[envKey]
+
+    afterEach(() => {
+      if (previous === undefined) delete process.env[envKey]
+      else process.env[envKey] = previous
+    })
+
+    it('returns tail@RUN_COMMAND_LLM_MAX_CHARS when escape is unset', () => {
+      delete process.env[envKey]
+      expect(getRunCommandResultStrategy()).toEqual({
+        shape: { kind: 'tail', maxChars: RUN_COMMAND_LLM_MAX_CHARS },
+      })
+    })
+
+    it('returns verbatim when MILKIE_RUN_COMMAND_SHAPE_VERBATIM=1', () => {
+      process.env[envKey] = '1'
+      expect(getRunCommandResultStrategy()).toEqual({ shape: 'verbatim' })
+    })
+
+    it('ignores non-1 values (still default tail)', () => {
+      process.env[envKey] = 'true'
+      expect(getRunCommandResultStrategy()).toEqual({
+        shape: { kind: 'tail', maxChars: RUN_COMMAND_LLM_MAX_CHARS },
+      })
+    })
+  })
+
   it('runs a command and captures stdout + exitCode 0', async () => {
     const out = await runCommand({ command: 'echo hello-milkie' })
     expect(out.stdout).toContain('hello-milkie')

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import type { ToolDefinition } from '../types/tool.js'
+import type { ToolDefinition, ToolResultStrategy } from '../types/tool.js'
 import { citeable } from './lineage.js'
 
 // Built-in shell/exec tool (#134). Lets an agent run subprocess commands —
@@ -10,6 +10,10 @@ import { citeable } from './lineage.js'
 // re-runs — see ReplayingIOPort / ExplodingInnerPort). So the subprocess forks
 // only at record time; replay reproduces the captured stdout/exit without side
 // effects. No "non-replayable" contract is needed (mirrors create_plan).
+//
+// LLM projection (alfred#160): declare resultStrategy so AgentRuntime shapes
+// tool_result for the model. Stream cap below still bounds event-log raw;
+// UI preview (alfred max_tool_output_preview_chars) is unrelated.
 
 const DEFAULT_TIMEOUT_MS = 120_000
 
@@ -18,6 +22,20 @@ const DEFAULT_TIMEOUT_MS = 120_000
 // BOTH the LLM context AND the persisted event log / CacheIndex. Head+tail is
 // kept so the agent sees how the command started and ended.
 const MAX_STREAM_CHARS = 30_000
+
+/** Default max chars of serialized run_command output sent to the LLM (alfred#160). */
+export const RUN_COMMAND_LLM_MAX_CHARS = 8_000
+
+/**
+ * LLM-facing strategy for run_command.
+ * Escape: MILKIE_RUN_COMMAND_SHAPE_VERBATIM=1 → verbatim (no shape).
+ */
+export function getRunCommandResultStrategy(): ToolResultStrategy {
+  if (process.env.MILKIE_RUN_COMMAND_SHAPE_VERBATIM === '1') {
+    return { shape: 'verbatim' }
+  }
+  return { shape: { kind: 'tail', maxChars: RUN_COMMAND_LLM_MAX_CHARS } }
+}
 
 export interface RunCommandInput {
   command:    string
@@ -84,7 +102,8 @@ export const execTools: ToolDefinition[] = [
     description:
       'Execute a shell command in a subprocess and return { objectId?, stdout, stderr, exitCode, timedOut, truncated }. ' +
       'Use this to run skill scripts (e.g. `python skills/<name>/scripts/x.py`), CLIs (`inv`, `codex-cli`), ' +
-      'and other tools. Output over 30000 chars per stream is truncated (head+tail kept). ' +
+      'and other tools. Output over 30000 chars per stream is truncated (head+tail kept) in the raw/event-log path. ' +
+      `LLM context may further apply a tail projection (default ${RUN_COMMAND_LLM_MAX_CHARS} chars; see resultStrategy). ` +
       'When stdout is non-empty the result carries an `objectId` for that output — to source a claim from this ' +
       'fetched data (a file you cat-ed, an API/DB you queried, a page you scraped), pass that objectId to the ' +
       'cite tool. Never write provenance like "(source:...)" in prose; cite the objectId instead.',
@@ -97,6 +116,8 @@ export const execTools: ToolDefinition[] = [
       },
       required:   ['command'],
     },
+    // alfred#160: non-verbatim LLM projection; raw remains on tool.responded / stream cap.
+    resultStrategy: getRunCommandResultStrategy(),
     handler: async (input, ctx) => {
       const cmd = input as RunCommandInput
       const out = await runCommand(cmd)


### PR DESCRIPTION
## Summary

- Built-in `run_command` declares `resultStrategy: { shape: { kind: 'tail', maxChars: 8000 } }` so oversized outputs are shaped for the **LLM** via existing AgentRuntime `applyShape` / `tool.shaped`.
- Handler **stream cap (~30k)** still bounds event-log / `tool.responded` raw (unchanged).
- Escape: `MILKIE_RUN_COMMAND_SHAPE_VERBATIM=1`.
- Docs (en/zh guide): three-layer table — stream cap vs LLM shape vs host UI preview.

## Design

- alfred#160 design comment: https://github.com/xforce-io/alfred/issues/160#issuecomment-5015983149

## Test plan

- [x] `npx jest src/__tests__/execTools.test.ts src/__tests__/AgentRuntime.toolResultStrategy.test.ts src/__tests__/toolResultStrategy.test.ts --runInBand`
- [x] Runtime test drives **shipped** `execTools` run_command with stdout > 8k → LLM tool_result ≤ maxChars + dropped marker; `tool.shaped` with rawBytes > storedBytes
- [x] `npm run test:unit`

Refs: alfred#160