### PR TITLE
【session】条件导入避免迟到快照回退历史

### DIFF
--- a/src/__tests__/portable-session.test.ts
+++ b/src/__tests__/portable-session.test.ts
@@ -128,6 +128,42 @@ describe('#84 portable session round-trip (single agent)', () => {
     const prompt = JSON.stringify((firstLlm.payload as { request: unknown }).request)
     expect(prompt).toContain('fact1')
   })
+
+  it('does not let a delayed conditional import replace a newer checkpoint', async () => {
+    const src = new Milkie({
+      stateStore: new MemoryStore(),
+      eventStore: new MemoryEventStore(),
+      gateway: endTurnGateway(),
+    })
+    src.registerAgent(recorderAgent)
+    const contextId = 'ctx-import-race'
+    await src.invoke({ agentId: 'recorder', goal: 'g', input: 'old', contextId })
+    const session = await src.exportSession(contextId)
+
+    class AdvanceBeforeCasStore extends MemoryStore {
+      override async compareAndSet(key: string, expected: unknown, value: unknown): Promise<boolean> {
+        await this.set(key, 'newer-run')
+        return super.compareAndSet(key, expected, value)
+      }
+    }
+
+    const stateStore = new AdvanceBeforeCasStore()
+    await stateStore.set(
+      `context:${contextId}:checkpoint-run:latest`,
+      session.manifest.latestRunId,
+    )
+    const dst = new Milkie({
+      stateStore,
+      eventStore: new MemoryEventStore(),
+      gateway: endTurnGateway(),
+    })
+    dst.registerAgent(recorderAgent)
+
+    await expect(
+      dst.importSession(session, { expectedLatestRunId: session.manifest.latestRunId }),
+    ).rejects.toThrow(/advanced after export/)
+    expect(await stateStore.get(`context:${contextId}:checkpoint-run:latest`)).toBe('newer-run')
+  })
 })
 
 // ---- multi-agent: a supervisor that spawns a worker sub-agent ----

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -683,4 +683,20 @@ describe('createServeServer', () => {
     const res = await request(port, 'POST', '/session/import', { session: bogus })
     expect(res.status).toBe(400)
   })
+
+  it('POST /session/import returns 409 when its expected checkpoint is stale', async () => {
+    const source = buildTextMilkie(['ok'])
+    const sourcePort = await listen(createServeServer(source))
+    await (await sse(sourcePort, 'POST', '/chat', { contextId: 'import-race', input: 'old' }).done)
+    const exported = (await request(sourcePort, 'POST', '/session/export', { contextId: 'import-race' })).json
+
+    const destination = buildTextMilkie(['new'])
+    const destinationPort = await listen(createServeServer(destination))
+    await (await sse(destinationPort, 'POST', '/chat', { contextId: 'import-race', input: 'new' }).done)
+    const res = await request(destinationPort, 'POST', '/session/import', {
+      session: exported,
+      expectedLatestRunId: (exported as { manifest: { latestRunId: string } }).manifest.latestRunId,
+    })
+    expect(res.status).toBe(409)
+  })
 })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,5 +1,5 @@
 import http, { type IncomingMessage, type ServerResponse, type Server } from 'http'
-import { Milkie } from '../runtime/Milkie.js'
+import { Milkie, SessionImportConflictError } from '../runtime/Milkie.js'
 import { BroadcastingEventStore } from '../trace/BroadcastingEventStore.js'
 import { MemoryStore } from '../store/MemoryStore.js'
 import { MemoryEventStore } from '../trace/MemoryEventStore.js'
@@ -26,7 +26,7 @@ import { getLogger, type ServiceLogger } from '../logging/logger.js'
  *   POST /resume { contextId, input? }        → text/event-stream
  *   POST /llm { system?, messages, stream? }  → JSON (or SSE when stream) (#124)
  *   POST /session/export { contextId }        → PortableSession JSON (#124)
- *   POST /session/import { session }          → { contextId } (#124)
+ *   POST /session/import { session, expectedLatestRunId? } → { contextId } (#124)
  *   POST /session/history { contextId }       → { messages: Message[] } full transcript (#128)
  *   POST /projection/attach { contextId, sourceRunId, displayText, ... } → { projection } (#146)
  *   POST /projection/list { contextId }       → { projections } (#146)
@@ -281,12 +281,24 @@ export function createServeServer(opts: ServeOptions): Server {
   }
 
   async function handleSessionImport(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const { session } = JSON.parse(await readBody(req)) as { session?: PortableSession }
+    const { session, expectedLatestRunId } = JSON.parse(await readBody(req)) as {
+      session?: PortableSession
+      expectedLatestRunId?: string
+    }
     if (!session) return sendJson(res, 400, { error: 'session is required' })
     try {
-      sendJson(res, 200, await milkie.importSession(session))
+      const result = await milkie.importSession(session, { expectedLatestRunId })
+      sendJson(res, 200, {
+        ...result,
+        // Lets callers fail closed against an older sidecar that silently
+        // ignores expectedLatestRunId.
+        conditionApplied: expectedLatestRunId !== undefined,
+      })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
+      if (err instanceof SessionImportConflictError) {
+        return sendJson(res, 409, { error: message })
+      }
       sendJson(res, /schemaVersion/.test(message) ? 400 : 500, { error: message })
     }
   }

--- a/src/runtime/Milkie.ts
+++ b/src/runtime/Milkie.ts
@@ -59,6 +59,16 @@ export interface ContextRunState {
   interruptSignaled: boolean
 }
 
+/** A conditional session import lost to a newer completed turn. */
+export class SessionImportConflictError extends Error {
+  constructor(contextId: string, expectedLatestRunId: string) {
+    super(
+      `Session ${contextId} advanced after export; expected latest run ${expectedLatestRunId}`,
+    )
+    this.name = 'SessionImportConflictError'
+  }
+}
+
 export interface MilkieOptions {
   /**
    * #99: required — no silent in-memory fallback. Choose the backend explicitly:
@@ -686,7 +696,10 @@ export class Milkie {
    * its persistent vars. Afterwards `invoke({ contextId })` continues the
    * conversation with the prior history. Returns the contextId now installed.
    */
-  async importSession(session: PortableSession): Promise<{ contextId: string }> {
+  async importSession(
+    session: PortableSession,
+    options: { expectedLatestRunId?: string } = {},
+  ): Promise<{ contextId: string }> {
     if (!this.eventStore) {
       throw new Error('Milkie has no eventStore; cannot import a portable session')
     }
@@ -696,13 +709,34 @@ export class Milkie {
         `this build imports v${PORTABLE_SESSION_SCHEMA_VERSION}`)
     }
     const { contextId, latestRunId } = session.manifest
+    const checkpointRunKey = `context:${contextId}:checkpoint-run:latest`
+
+    // Fast-fail before appending copied events. The compare-and-set below is
+    // still required: a chat turn can finish while this import is appending.
+    if (options.expectedLatestRunId !== undefined) {
+      const current = await this.stateStore.get(checkpointRunKey)
+      if (current !== options.expectedLatestRunId) {
+        throw new SessionImportConflictError(contextId, options.expectedLatestRunId)
+      }
+    }
 
     for (const event of session.events) {
       await this.eventStore.append(event)
     }
     // Routing pointer: invoke() reads this to project the resume checkpoint from
     // the event log (#73).
-    await this.stateStore.set(`context:${contextId}:checkpoint-run:latest`, latestRunId)
+    if (options.expectedLatestRunId !== undefined) {
+      const applied = await this.stateStore.compareAndSet(
+        checkpointRunKey,
+        options.expectedLatestRunId,
+        latestRunId,
+      )
+      if (!applied) {
+        throw new SessionImportConflictError(contextId, options.expectedLatestRunId)
+      }
+    } else {
+      await this.stateStore.set(checkpointRunKey, latestRunId)
+    }
 
     for (const [name, value] of Object.entries(session.variables)) {
       await this.setContextVar(contextId, name, value)

--- a/src/store/MemoryStore.ts
+++ b/src/store/MemoryStore.ts
@@ -25,6 +25,13 @@ export class MemoryStore implements IStateStore {
     return entry.value
   }
 
+  async compareAndSet(key: string, expected: unknown, value: unknown): Promise<boolean> {
+    const current = await this.get(key)
+    if (JSON.stringify(current) !== JSON.stringify(expected)) return false
+    await this.set(key, value)
+    return true
+  }
+
   async delete(key: string): Promise<void> {
     this.store.delete(key)
   }

--- a/src/store/RedisStore.ts
+++ b/src/store/RedisStore.ts
@@ -67,6 +67,18 @@ export class RedisStore implements IStateStore {
     return JSON.parse(raw) as unknown
   }
 
+  async compareAndSet(key: string, expected: unknown, value: unknown): Promise<boolean> {
+    if (!this.client) throw new Error('RedisStore is not initialized')
+    const result = await this.client.eval(
+      "if redis.call('GET', KEYS[1]) == ARGV[1] then redis.call('SET', KEYS[1], ARGV[2]); return 1 else return 0 end",
+      1,
+      key,
+      JSON.stringify(expected),
+      JSON.stringify(value),
+    )
+    return result === 1
+  }
+
   async delete(key: string): Promise<void> {
     if (!this.client) throw new Error('RedisStore is not initialized')
     await this.client.del(key)

--- a/src/store/SQLiteStore.ts
+++ b/src/store/SQLiteStore.ts
@@ -58,6 +58,14 @@ export class SQLiteStore implements IStateStore {
     return JSON.parse(row.value) as unknown
   }
 
+  async compareAndSet(key: string, expected: unknown, value: unknown): Promise<boolean> {
+    const stmt = this.db.prepare(
+      'UPDATE kv SET value = ?, expires = NULL WHERE key = ? AND value = ?'
+    )
+    const result = stmt.run(JSON.stringify(value), key, JSON.stringify(expected))
+    return result.changes === 1
+  }
+
   async delete(key: string): Promise<void> {
     this.db.prepare('DELETE FROM kv WHERE key = ?').run(key)
   }

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -3,6 +3,13 @@ import type { Message } from './common.js'
 export interface IStateStore {
   set(key: string, value: unknown, ttl?: number): Promise<void>
   get(key: string): Promise<unknown>
+  /**
+   * Atomically replace a key only when it still holds ``expected``.
+   *
+   * Used by session import to ensure a delayed snapshot cannot replace a
+   * checkpoint that a newer turn has already published.
+   */
+  compareAndSet(key: string, expected: unknown, value: unknown): Promise<boolean>
   delete(key: string): Promise<void>
   exists(key: string): Promise<boolean>
   /**


### PR DESCRIPTION
## 背景

Alfred 的会话压缩在导入请求超时后，迟到的旧快照仍可能完成导入并覆盖较新的 chat checkpoint。

## 变更

- 为状态存储新增原子 compare-and-set。
- `POST /session/import` 支持 `expectedLatestRunId`；不匹配时返回 `409 Conflict`。
- 响应提供 `conditionApplied`，让调用方在旧 sidecar 静默忽略条件字段时安全失败。
- 增加迟到导入不会覆盖新 checkpoint 的库层和 HTTP 回归测试。

## 验证

- `npm run build`
- `npx jest src/__tests__/portable-session.test.ts --runInBand`
- `npx jest src/__tests__/serve.test.ts -t 'expected checkpoint is stale' --runInBand`

## 关联

- Alfred: xforce-io/alfred#175
- Issue: xforce-io/alfred#166