### PR TITLE
【stories】对齐最小学习闭环（Outcome / Fork 叙事）

### DIFF
--- a/docs/stories/INDEX.md
+++ b/docs/stories/INDEX.md
@@ -4,7 +4,9 @@ Projected view over every story in this directory. Conventions live in
 `README.md`. A regenerator script may overwrite the tables below; the
 **Notes** section is hand-maintained.
 
-Last updated: 2026-05-24 (re-calibrated readiness view against ARCHITECTURE.md Implementation Status; Phase 3 — IOPort / Event log / Cache / structural Replay — has landed; the five "verify-in-code" TODOs are confirmed implemented; ARCHITECTURE.md now records Yield point + interrupt signal and Supervisor tree as Implemented today; 6 stories now `active` after 2026-05-24 e2e run)
+Last updated: 2026-07-23 (#214 minimal learning loop: s-016 task-outcome draft;
+s-006 title/narrative → current-task repair; pointer Out/related on
+s-002/003/005/009/010)
 
 ## By id
 
@@ -15,7 +17,7 @@ Last updated: 2026-05-24 (re-calibrated readiness view against ARCHITECTURE.md I
 | [s-003](./s-003-explain-a-decision-with-context.md) | Explain an agent decision with its full context | active | agent-trace | `tests/e2e/s-003-explain-a-decision-with-context.e2e.test.ts` |
 | [s-004](./s-004-lineage-from-artifact-to-source.md) | Trace lineage from an artifact back to its source | draft | agent-trace | `tests/e2e/s-004-lineage-from-artifact-to-source.e2e.test.ts` |
 | [s-005](./s-005-deterministic-replay.md) | Deterministically replay a recorded agent run | active | agent-trace · agent-runtime | `tests/e2e/s-005-deterministic-replay.e2e.test.ts` |
-| [s-006](./s-006-fork-at-event-for-what-if.md) | Fork a run at an event to explore a counterfactual | draft | agent-trace · agent-runtime | `tests/e2e/s-006-fork-at-event-for-what-if.e2e.test.ts` |
+| [s-006](./s-006-fork-at-event-for-what-if.md) | Fork a failed run at an event to repair the current task | draft | agent-trace · agent-runtime | `tests/e2e/s-006-fork-at-event-for-what-if.e2e.test.ts` |
 | [s-007](./s-007-inter-agent-parallel-code-review.md) | Inter-agent parallel via named sub-agent tools | active | agent-runtime · agent-trace | `tests/e2e/s-007-inter-agent-parallel-code-review.e2e.test.ts` |
 | [s-008](./s-008-long-task-interrupt-and-resume.md) | Interrupt a long-running agent and resume from checkpoint | active | agent-runtime · agent-trace | `tests/e2e/s-008-long-task-interrupt-and-resume.e2e.test.ts` |
 | [s-009](./s-009-multi-turn-with-tool-error-recovery.md) | Multi-turn conversation with tool error recovery | active | agent-runtime · agent-trace | `tests/e2e/s-009-multi-turn-with-tool-error-recovery.e2e.test.ts` |
@@ -25,6 +27,7 @@ Last updated: 2026-05-24 (re-calibrated readiness view against ARCHITECTURE.md I
 | [s-013](./s-013-variant-search-with-bounded-cost.md) | Variant search with bounded amortized cost | draft | agent-trace · evolution | `tests/e2e/s-013-variant-search-with-bounded-cost.e2e.test.ts` |
 | [s-014](./s-014-reverse-reference-lineage-query.md) | Reverse-reference lineage query | draft | agent-trace | `tests/e2e/s-014-reverse-reference-lineage-query.e2e.test.ts` |
 | [s-015](./s-015-subagent-reads-parent-trace-runtime.md) | Sub-agent reads parent's in-flight trace at runtime | draft | agent-runtime · agent-trace | `tests/e2e/s-015-subagent-reads-parent-trace-runtime.e2e.test.ts` |
+| [s-016](./s-016-record-and-query-task-outcome.md) | Record and query task outcome after a run | draft | agent-trace | `tests/e2e/s-016-record-and-query-task-outcome.e2e.test.ts` |
 
 ## By implementation readiness
 
@@ -52,11 +55,12 @@ These work today in degraded / basic form; full story validation requires
 target capabilities to land.
 
 - **s-005** Deterministic replay — IOPort ✓, Event log ✓, Cache ✓, structural Replay ✓ (Phase 3); byte-identical replay still needs Non-determinism log (Phase 4)
-- **s-006** Fork at event — IOPort ✓, Event log ✓, Response cache ✓; still needs Fork primitive (Phase 5)
+- **s-006** Fork at event (current-task repair) — IOPort ✓, Event log ✓, Response cache ✓; still needs Fork primitive (Phase 5)
 - **s-008** Interrupt + resume — FSM Core ✓, State stores ✓, Yield point + interrupt signal ✓ confirmed in `FSMEngine.ts:11,61-62` and `Milkie.ts:297-300` (test file exists)
-- **s-010** Skill load + A/B — FSM Core ✓, working context ✓, Skill epoch loading ✓ confirmed in `ContextLayer.ts:19,40-46` (test file exists); Evolution components are target only
+- **s-010** Skill load + A/B — FSM Core ✓, working context ✓, Skill epoch loading ✓ confirmed in `ContextLayer.ts:19,40-46` (test file exists); Evolution components are target only; experiment metrics should prefer task outcome (s-016) when available
 - **s-012** Batch replay + classify — Replay ✓, Cache ✓; still needs Structural diff, Suite definition + batch replay (Phase 5)
 - **s-013** Variant search bounded cost — Cache ✓; still needs Fork primitive, Structural diff (Phase 5)
+- **s-016** Task outcome record/query — Event log basic ✓; still needs Task outcome record API/storage (target)
 
 ### Blocked (all or most requires are target only)
 
@@ -71,7 +75,7 @@ as design specification.
 
 ### draft
 
-- s-004, s-006, s-010, s-012, s-013, s-014, s-015 (7 stories)
+- s-004, s-006, s-010, s-012, s-013, s-014, s-015, **s-016** (8 stories)
 
 ### active
 
@@ -85,6 +89,7 @@ as design specification.
 - **s-011** Multi-state FSM intent routing + slot filling
 
 s-010 stays `draft` until its Evolution requires are split (current test only validates skill-epoch loading, not Experiment Registry).
+s-016 stays `draft` until Outcome storage/API + e2e land (tracking #215 stage 2).
 
 ### deprecated
 
@@ -103,7 +108,7 @@ appear here.
 
 ### agent-trace
 
-- s-001 through s-015 (every story)
+- s-001 through s-016 (every story)
 
 ### evolution
 
@@ -128,20 +133,13 @@ appear here.
 | variant-search | s-013 |
 | lineage-reverse-reference | s-014 |
 | runtime-trace-consumption | s-015 |
+| task-outcome | s-016 |
 
 ## Notes
 
-- 15 stories total; 7 `draft`, 8 `active` (s-001 / s-002 / s-003 / s-005 / s-007 / s-008 / s-009 / s-011). Readiness varies — see the "By implementation readiness" view above. E2E run 2026-05-24: 9/9 existing test suites green; s-002 / s-003 added as hermetic stub-gateway tests against TrajectoryStore + Agent Trace event log; s-009 switched from Redis-gated to MemoryStore-by-default; s-010 still `draft` until Evolution requires are split.
+- 16 stories total; 8 `draft`, 8 `active` (s-001 / s-002 / s-003 / s-005 / s-007 / s-008 / s-009 / s-011). Readiness varies — see the "By implementation readiness" view above.
+- **#214 (2026-07-23)** aligned stories with ARCH minimal learning loop: new **s-016** (task outcome); **s-006** primary narrative = current-task repair (slug unchanged); pointer Out/related on s-002, s-003, s-005, s-009, s-010. Active acceptance checklists were not rewritten.
 - s-012 / s-013 / s-014 / s-015 are **agent-first scenarios** added to mirror ARCHITECTURE.md invariants 12-13 (Agent Trace is agent-first; CLI is the agent-facing protocol facade). They sit alongside the existing single-run / single-consumer stories (s-002–s-006) and cover batch / runtime / reverse-graph patterns.
-- **Tests exist for 7 stories** (s-001, s-005, s-007, s-008, s-009, s-010, s-011). Of these only s-005 is `active`; the rest are still `draft`. When those tests are green in CI, flip them to `active` per the README lifecycle.
-- Next wave of E2E test writing: **s-002 / s-003** are the lowest-hanging Partial stories (Trajectory observability already supports basic timeline / span query); they exercise observable + diagnosable capabilities against today's TrajectoryStore.
-- Several migrated stories (s-009, s-010, s-011) carry **internal sub-scenarios** that may be split per the README's granularity rule after discussion. Flagged inside each story.
-- Migration source: `docs/superpowers/specs/2026-05-16-agent-e2e-scenarios.md` (Cases 2–6 ported as s-007 to s-011).
 - The "Test" path column reserves filenames per the convention; matching E2E test files may not yet exist while stories are in `draft`.
-- **Verify-in-code TODOs resolved (2026-05-24)** — all five marked architectural checkpoints confirmed implemented in source:
-  - Sub-agent as named tool — `src/runtime/AgentRuntime.ts:116-198` (AgentFactory.spawn)
-  - Error handling FSM transition — `src/fsm/FSMEngine.ts:11,64-66` (global `error` → `error_handling`)
-  - Action state with `ctx.emit` — `src/types/agent.ts`, `src/fsm/FSMEngine.ts:44-49`, `src/runtime/AgentRuntime.ts:223`
-  - Yield point + interrupt signal — `src/fsm/FSMEngine.ts:11,61-62`, `src/runtime/Milkie.ts:297-300`
-  - Skill epoch loading — `src/context/ContextLayer.ts:19,40-46`
+- Parent tracking for Outcome → Fork implementation: GitHub #215.
 - When code lands closing a target capability, update `ARCHITECTURE.md`'s Implementation Status first, then this index's readiness view will need to be regenerated.

--- a/docs/stories/s-002-inspect-a-completed-run.md
+++ b/docs/stories/s-002-inspect-a-completed-run.md
@@ -15,6 +15,7 @@ tests:
   - tests/e2e/s-002-inspect-a-completed-run.e2e.test.ts
 related:
   - ARCHITECTURE.md#agent-trace
+  - docs/stories/s-016-record-and-query-task-outcome.md
 ---
 
 ## 场景叙事
@@ -64,3 +65,4 @@ inspect (无 LLM 调用)
 - **确定性回放** → 见 [s-005](./s-005-deterministic-replay.md)
 - **跨多个 run 的批量查询 / suite replay** → 见 [s-012](./s-012-batch-replay-suite-and-classify-divergences.md)
 - **in-flight 查询语义**（运行中的 run） → 见 [s-015](./s-015-subagent-reads-parent-trace-runtime.md)
+- **Task outcome 的后置写入与查询**（execution status ≠ 任务成败）→ 见 [s-016](./s-016-record-and-query-task-outcome.md)；inspect 只保证「发生了什么」，不判定任务是否做对

--- a/docs/stories/s-003-explain-a-decision-with-context.md
+++ b/docs/stories/s-003-explain-a-decision-with-context.md
@@ -15,6 +15,7 @@ tests:
   - tests/e2e/s-003-explain-a-decision-with-context.e2e.test.ts
 related:
   - ARCHITECTURE.md#agent-trace
+  - docs/stories/s-016-record-and-query-task-outcome.md
 ---
 
 ## 场景叙事
@@ -70,3 +71,5 @@ explain a decision (无 LLM 调用)
 - **从 source 反推到所有引用它的 run（lineage reverse）** → 见 [s-014](./s-014-reverse-reference-lineage-query.md)
 - **重放该决策点** → 见 [s-005](./s-005-deterministic-replay.md)
 - **替换该决策后看 outcome 变化（fork）** → 见 [s-006](./s-006-fork-at-event-for-what-if.md)
+- **Task outcome（任务成败判定记录）** → 见 [s-016](./s-016-record-and-query-task-outcome.md)
+- **结构化 Attribution 判决**（category / suggestedAction 等）→ 延后；本 story 的 explain 只提供**证据材料**，不是 Attribution 记录

--- a/docs/stories/s-005-deterministic-replay.md
+++ b/docs/stories/s-005-deterministic-replay.md
@@ -19,6 +19,7 @@ tests:
   - tests/e2e/s-005-deterministic-replay.e2e.test.ts
 related:
   - ARCHITECTURE.md#agent-trace
+  - docs/stories/s-006-fork-at-event-for-what-if.md
 ---
 
 > Phase 3 provides structural replay; byte-identical pending Phase 4 non-determinism log.
@@ -31,4 +32,10 @@ related:
 
 典型用法：本地复现一个生产故障；examples / demo 在无 API key 环境下能 ship；regression test 把昨日的 run 当今日的 baseline。
 
-> 待补：interaction flow / 验收准则 / 不在此 story 范围
+> 待补：interaction flow / 完整验收准则（既有 e2e 为权威实现锚点）。
+
+## 不在此 story 范围
+
+- **Fork / debug rerun**（从某事件分支并修改决策以修复**当前任务**）→ 见 [s-006](./s-006-fork-at-event-for-what-if.md)。**Replay ≠ Fork**：replay 忠实重放已录 log，不声称修好错误决策
+- **工具瞬时 Retry** → 见 [s-009](./s-009-multi-turn-with-tool-error-recovery.md)
+- **Task outcome 写入** → 见 [s-016](./s-016-record-and-query-task-outcome.md)

--- a/docs/stories/s-006-fork-at-event-for-what-if.md
+++ b/docs/stories/s-006-fork-at-event-for-what-if.md
@@ -1,6 +1,6 @@
 ---
 id: s-006
-title: Fork a run at an event to explore a counterfactual
+title: Fork a failed run at an event to repair the current task
 status: draft
 kind: scenario
 subsystems:
@@ -18,12 +18,78 @@ tests:
   - tests/e2e/s-006-fork-at-event-for-what-if.e2e.test.ts
 related:
   - ARCHITECTURE.md#agent-trace
+  - ARCHITECTURE.md#retry-fork-and-reconfigure-action-vocabulary
+  - docs/stories/s-005-deterministic-replay.md
+  - docs/stories/s-009-multi-turn-with-tool-error-recovery.md
+  - docs/stories/s-016-record-and-query-task-outcome.md
 ---
 
 ## 场景叙事
 
-用户对一个 200 步的 run 提问"如果我在第 150 步换一个 prompt / 换一个工具 / 改一个配置，结果会怎样"。系统在第 150 个事件处分叉：**前 149 步从 cache 服务，不重付 LLM 钱**，从第 150 步起以新配置继续跑。父分支不受影响，可与子分支结构化 diff。
+一次长 run 已经结束（或已判定任务失败）：执行路径里某一步决策错了——例如第 N 个事件处选了错误工具、用了错误 prompt 片段、或 FSM 走了错误分支。操作者要**修好当前这次任务**，而不是「再盲跑一遍」或「只忠实重放日志」。
 
-这是 Evolution 的 Outcome Collector 评估变体的核心机制，也是 Human reviewer 做 "what if I had…" 实验的廉价方式。
+系统在指定 **event** 处分叉（fork）：
 
-> 待补：interaction flow / 验收准则 / 不在此 story 范围
+- **分叉点之前**的共享前缀从 response cache / 已录事件服务，不重付 LLM 成本；
+- **分叉点及之后**按修正（换工具选择、局部配置、或其它 fork 参数）继续执行，产生**新的 branch run**；
+- **父 run 不变**；父子可后续做结构化 diff（完整 diff 见 s-012）。
+
+主动机是 **当前任务修复（debug rerun）**。  
+「what if 换一个配置会怎样」的反事实实验是同一机制的次要用法，也可服务后续变体评估，但本 story 验收以**修复路径**为准。
+
+与相邻能力的边界（ARCHITECTURE 动作词汇）：
+
+| 能力 | 本 story？ | 说明 |
+|------|------------|------|
+| **Retry** | 否 | 同一配置下瞬时失败重试 → [s-009](./s-009-multi-turn-with-tool-error-recovery.md) |
+| **Replay** | 否 | 忠实重放已录 log，证明可复现，不声称修好错误决策 → [s-005](./s-005-deterministic-replay.md) |
+| **Fork** | 是 | 从事件点分支并改决策/参数，救当前任务 |
+| **Reconfigure** | 否 | 换 agent/skill 版本面向**未来**任务 → [s-010](./s-010-skill-versioned-load-and-ab-experiment.md) |
+
+可选：fork 前可有 task outcome / 薄 Attribution 记录；**均非 fork 的前置条件**。
+
+## 关键交互流
+
+```
+准备
+  ├─ 已有 parentRunId（一次已录 run；事件数 ≥ N，N 为分叉点）
+  ├─ （可选）task outcome = failure — 见 s-016；非必须
+  └─ 选定 fork 点 eventId（或序号），及 fork 修正（例：替换该步工具输入 / 配置补丁）
+
+fork
+  ├─ milkie.fork({ runId: parentRunId, atEventId, patch? })
+  │    → { branchRunId, parentRunId, forkEventId }
+  ├─ 前缀：branch 不重新实调 LLM 覆盖已 cache 的共享段
+  └─ 后缀：从 fork 点起按 patch 继续，写出 branch 自己的 event log
+
+观察
+  ├─ parent run 的事件序列与 fork 前一致（未改写）
+  ├─ branchRunId ≠ parentRunId
+  ├─ branch 从 fork 点起与 parent 可观测分歧（至少一处 LLM/tool/FSM 差异或最终 output 差异）
+  └─ （可选）对 branch 写 task outcome；不自动 promote 配置
+```
+
+> API 形状以实现 design 为准；本 story 约束的是**按事件分叉、父不变、前缀便宜、后缀可改**。
+
+## 验收准则
+
+- [ ] 给定已完成的 `parentRunId` 与合法 `atEventId`（或等价位置），fork 返回新的 `branchRunId`
+- [ ] `branchRunId !== parentRunId`
+- [ ] fork 之后再次读取 parent 的 event log，与 fork 前一致（父分支不受影响）
+- [ ] branch 的 event log 在 fork 点之前与 parent 结构对齐（共享前缀；具体等价定义：相同 requestHash 序列或实现规定的 prefix 契约）
+- [ ] 共享前缀段**不产生新的真实 LLM 调用**（cache / 录制回放服务；stub 下 callCount 不增加前缀长度）
+- [ ] 从 fork 点起，branch 应用了声明的修正（可观测：不同 tool 输入、不同配置字段、或不同后续事件）
+- [ ] branch 能跑到终止状态（`completed` / `error` / `interrupted` 之一），并产生可查询的 trace
+- [ ] （语义）同一 parent 上 Retry 路径（s-009）与本 fork API 不是同一入口；文档/测试不把「无 patch 整 run 重跑」称作 fork
+- [ ] Attribution / task outcome **不是**调用 fork 的必填参数
+
+## 不在此 story 范围
+
+- **确定性 Replay（忠实重放，零修复语义）** → [s-005](./s-005-deterministic-replay.md)。Replay ≠ debug rerun ≠ Fork
+- **工具 retryable / error_handling 瞬时 Retry** → [s-009](./s-009-multi-turn-with-tool-error-recovery.md)
+- **Task outcome 的写入与查询** → [s-016](./s-016-record-and-query-task-outcome.md)（fork 可消费 outcome，但不实现 outcome）
+- **批量 suite replay 与 divergence 分类** → [s-012](./s-012-batch-replay-suite-and-classify-divergences.md)
+- **有界成本的多变体搜索** → [s-013](./s-013-variant-search-with-bounded-cost.md)
+- **把 fork 结果自动 promote 为生产配置（Reconfigure / Evolution Gate）** → 非本 story
+- **强制先写 Attribution 才能 fork** → 非目标；Attribution 可选
+- **Lineage 正反向查询** → s-004 / s-014

--- a/docs/stories/s-009-multi-turn-with-tool-error-recovery.md
+++ b/docs/stories/s-009-multi-turn-with-tool-error-recovery.md
@@ -19,7 +19,10 @@ tests:
   - tests/e2e/s-009-multi-turn-with-tool-error-recovery.e2e.test.ts
 related:
   - ARCHITECTURE.md#agent-runtime
+  - ARCHITECTURE.md#retry-fork-and-reconfigure-action-vocabulary
   - docs/superpowers/specs/2026-05-16-agent-e2e-scenarios.md
+  - docs/stories/s-006-fork-at-event-for-what-if.md
+  - docs/stories/s-016-record-and-query-task-outcome.md
 ---
 
 ## 场景叙事
@@ -85,3 +88,5 @@ milkie.invoke({
 - **中断与恢复**（Interrupt / Resume）→ s-008
 - **不可重试错误的终止行为**（非 retryable） → 未来的 error story
 - **多 contextId 之间的隔离** → 未来的 context-isolation story
+- **Fork / 当前任务决策修复** → 见 [s-006](./s-006-fork-at-event-for-what-if.md)。本 story 是 **Retry**（`retryable` 工具 + `error_handling`），不是 Fork
+- **Task outcome（业务/任务成败）** → 见 [s-016](./s-016-record-and-query-task-outcome.md)；工具重试成功只影响 execution 路径，不自动等于 task success

--- a/docs/stories/s-010-skill-versioned-load-and-ab-experiment.md
+++ b/docs/stories/s-010-skill-versioned-load-and-ab-experiment.md
@@ -19,7 +19,9 @@ tests:
   - tests/e2e/s-010-skill-versioned-load-and-ab-experiment.e2e.test.ts
 related:
   - ARCHITECTURE.md#evolution
+  - ARCHITECTURE.md#retry-fork-and-reconfigure-action-vocabulary
   - docs/superpowers/specs/2026-05-16-agent-e2e-scenarios.md
+  - docs/stories/s-016-record-and-query-task-outcome.md
 ---
 
 ## 场景叙事
@@ -91,3 +93,4 @@ v1.1.0 输出含 "来源 / source / 引用" 关键词，v1.0.0 不含
 - **Skill 卸载（unload）/ 版本回退** → 未来
 - **Skill 之间的依赖解析** → 未来
 - **prefix cache 命中的细粒度行为**（cache_control 标记的内部实现）→ 不属于用户场景
+- **Task outcome 存储本身** → 见 [s-016](./s-016-record-and-query-task-outcome.md)。本 story 的 A/B / Experiment 对比在指标上应**优先使用 task outcome（及 scores）**，而不是把 execution `status: completed` 当作任务成功；本 issue 不拆分 epoch vs A/B，也不实现 Outcome API

--- a/docs/stories/s-016-record-and-query-task-outcome.md
+++ b/docs/stories/s-016-record-and-query-task-outcome.md
@@ -1,0 +1,80 @@
+---
+id: s-016
+title: Record and query task outcome after a run
+status: draft
+kind: scenario
+subsystems:
+  - agent-trace
+capability: task-outcome
+requires:
+  - Agent Trace event log (basic)
+  - Task outcome record (target)
+owner: "@xupeng"
+created: 2026-07-23
+tests:
+  - tests/e2e/s-016-record-and-query-task-outcome.e2e.test.ts
+related:
+  - ARCHITECTURE.md#outcome-task-outcome
+  - ARCHITECTURE.md#cross-cutting-decisions-invariants
+  - docs/stories/s-002-inspect-a-completed-run.md
+  - docs/stories/s-003-explain-a-decision-with-context.md
+  - docs/stories/s-006-fork-at-event-for-what-if.md
+---
+
+## 场景叙事
+
+一次 agent run 已正常跑完：runtime **execution status** 为 `completed`，调用方也拿到了最终 output。但业务或评测事后发现**任务并没有做对**（例如推荐了错误供应商、答案未通过规则校验）。
+
+操作者（人或 eval 脚本）对这次 run **后置**写入一条 **task outcome**（如 `failure`），可选附带 score。之后任意时刻仅凭 `runId` 能查回该 outcome，且 **不覆盖、不改写** 原有的 execution status。
+
+本 story 固化 `ARCHITECTURE.md` 不变量 14：**Execution status ≠ Task outcome**。  
+`completed` 只表示运行时结束；任务成败是挂在 run 上的独立判定记录。
+
+不在此做自动「猜业务是否成功」、不写 Attribution 引擎、不触发 Evolution promote。
+
+## 关键交互流
+
+```
+record path
+  ├─ milkie.invoke({ agentId, goal, input }) → result
+  │    · result.status === 'completed'
+  │    · result.agentRunId (or runId) 可用
+  ├─ （可选）inspect timeline — 见 s-002；此时尚无 outcome 或 outcome 仍为 unknown/absent
+  └─ recordTaskOutcome({
+       runId: result.agentRunId,
+       value: 'failure',           // success | failure | partial | unknown
+       source: 'eval' | 'human' | 'rule' | 'business',
+       note?: '...',
+       scores?: [{ name, value }],
+     })
+
+query path（无额外 LLM）
+  ├─ getTaskOutcome(runId) → { value: 'failure', source, at, ... }
+  ├─ 同一 run 的 execution status 仍为 'completed'（invoke 结果 / run 记录）
+  └─ 未写过 outcome 的 run：查询返回 absent 或 value: 'unknown'（实现二选一，契约稳定即可）
+```
+
+> 具体 SDK/CLI 动词名以实现 design 为准；本 story 约束的是**可写、可查、与 status 分离**的用户可见能力。
+
+## 验收准则
+
+- [ ] 存在一次 `invoke` 返回 `status: 'completed'` 且带可用 `runId` / `agentRunId`
+- [ ] 对该 `runId` **后置**写入 task outcome，`value: 'failure'`（或等价枚举），`source` 非空
+- [ ] 按同一 `runId` 查询，读回的 outcome `value` 与写入一致
+- [ ] 写入 outcome **之后**，该 run 的 execution status 仍为 `completed`（未被改成 error/failed 等）
+- [ ] 允许 `status: 'completed'` 与 outcome `failure` **同时成立**（核心：跑完 ≠ 做对）
+- [ ] （可选）写入时附带至少一条 score；查询时可读到，且不改变 outcome `value` 语义
+- [ ] 从未写入 outcome 的另一 `runId`：查询为 absent 或 `unknown`，且不抛成「run 不存在」（与非法 runId 错误可区分）
+- [ ] 记录 / 查询路径不要求再次调用真实 LLM（hermetic 测试可用 stub gateway）
+
+## 不在此 story 范围
+
+- **Timeline 浏览 / 过滤** → 见 [s-002](./s-002-inspect-a-completed-run.md)
+- **单点决策证据材料（explain）** → 见 [s-003](./s-003-explain-a-decision-with-context.md)；explain 是证据，不是 task outcome
+- **结构化失败归因（Attribution 引擎或必填归因）** → 延后；Attribution 为可选外部写入，非本 story
+- **Fork 修复当前任务** → 见 [s-006](./s-006-fork-at-event-for-what-if.md)
+- **确定性 Replay** → 见 [s-005](./s-005-deterministic-replay.md)
+- **Retry 瞬时工具失败** → 见 [s-009](./s-009-multi-turn-with-tool-error-recovery.md)
+- **自动从 output 猜测业务成功 / 失败** → 非目标
+- **Evolution 流量切分、显著性、promote/rollback** → 非本 story；Collector 日后可消费 outcome，本 story 只保证 outcome 可挂 run
+- **Learnable Delta / 控制面 / 内嵌反思 LLM** → ARCH Non-goals


### PR DESCRIPTION
## Summary

- **S1**: New draft [s-016](docs/stories/s-016-record-and-query-task-outcome.md) — record/query task outcome after a run; `completed` may coexist with outcome `failure`.
- **S2**: [s-006](docs/stories/s-006-fork-at-event-for-what-if.md) primary narrative = current-task repair via fork; slug unchanged; flow / acceptance / Out distinguish Retry (s-009) and Replay (s-005).
- **S3**: Pointer Out/related on s-002, s-003, s-005, s-009, s-010; [INDEX](docs/stories/INDEX.md) lists s-016 (`task-outcome`). Active acceptance checklist items untouched.

## Test plan

- [x] s-016 draft with narrative, flow, acceptance, Out (no Attribution engine / Evolution promote)
- [x] s-006 filename/slug stable; sections complete; no empty 待补 for main sections
- [x] Diff on active stories is Out/related only for acceptance lines
- [x] INDEX contains s-016 and task-outcome
- [x] Diff limited to `docs/stories/**`

## Issue

- Closes #214
- Tracking: #215